### PR TITLE
[#38] Make format pluggable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion := "2.13.7"
+ThisBuild / scalaVersion := "2.13.14"
 ThisBuild / version := "0.3.0-SNAPSHOT"
 ThisBuild / organization := "org.calinburloiu.music"
 

--- a/core/src/main/scala/org/calinburloiu/music/microtonalist/core/TuningRef.scala
+++ b/core/src/main/scala/org/calinburloiu/music/microtonalist/core/TuningRef.scala
@@ -75,3 +75,5 @@ case class ConcertPitchTuningRef(concertPitchToBaseInterval: Interval,
 
   override val baseTuningPitch: TuningPitch = TuningPitch(basePitchClass, baseDeviation)
 }
+
+// TODO Add support for Scala-app-style implementation; also look at Ableton Live 12 (https://www.ableton.com/en/live-manual/12/using-tuning-systems/#the-tuning-section)

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormat.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormat.scala
@@ -108,5 +108,3 @@ private object ComponentJsonFormat {
     //@formatter:on
   }
 }
-
-

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormat.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormat.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Calin-Andrei Burloiu
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.calinburloiu.music.microtonalist.format
+
+import play.api.libs.json.{Format, JsError, JsObject, JsPath, JsResult, JsString, JsValue, Json, JsonValidationError,
+  OWrites, Writes, __}
+import play.api.libs.functional.syntax._
+
+/**
+ * Instances of this class are used for parsing a _family_ of JSON component objects by using Play JSON Format.
+ *
+ * A _JSON component_ is an object with a particular _type_ that is part of a _family_. The family is used in a
+ * certain context (e.g. tuning mapper, tuning reduces, scale etc.). For each family there can be one or more types.
+ * The type is identified in the JSON object by the `type` property (which might be implicit for a default type).
+ * Each type may have its own specific properties.
+ *
+ * One should create separate instances of this class for each family and configure it with a sequence of specs, each
+ * for each type. Each type may have default values, in `defaultSettings`, for certain properties to allow users to
+ * omit them. Property values per family/type can also be set globally by the user per composition file in the
+ * settings section and the class has a getter for setter for settings the root of the settings JSON after the JSON
+ * file was parsed.
+ */
+class ComponentJsonFormat[F](val familyName: String,
+                             specs: Seq[ComponentJsonFormat.TypeSpec[_ <: F]],
+                             defaultTypeName: Option[String] = None) extends Format[F] {
+
+  import ComponentJsonFormat._
+
+  private var _rootGlobalSettings: JsObject = Json.obj()
+
+  private val componentSpecsByType: Map[String, TypeSpec[_ <: F]] = specs
+    .map { spec => spec.typeName -> spec }.toMap
+  private val componentSpecsByClass: Map[Class[_ <: F], TypeSpec[_ <: F]] = specs
+    .map { spec => spec.javaClass -> spec }.toMap
+
+  def rootGlobalSettings_=(newValue: JsObject): Unit = {
+    _rootGlobalSettings = newValue
+  }
+
+  override def reads(componentJson: JsValue): JsResult[F] = {
+    val (typeNameOpt, localSettings) = componentJson match {
+      case typeName: JsString => (Some(typeName.value), Json.obj())
+      case componentObj: JsObject =>
+        val typeNameOpt = (componentObj \ PropertyNameType).asOpt[String].orElse(defaultTypeName)
+        (typeNameOpt, componentObj - PropertyNameType)
+    }
+
+    typeNameOpt match {
+      case Some(typeName) =>
+        componentSpecsByType.get(typeName) match {
+          case Some(spec) =>
+            val mergedSettings = spec.defaultSettings ++ globalSettingsOf(typeName) ++ localSettings
+            spec.format.reads(mergedSettings)
+          case None => JsError(Seq(JsPath -> Seq(UnrecognizedTypeError)))
+        }
+      case None => JsError(Seq(JsPath -> Seq(MissingTypeError)))
+    }
+  }
+
+  private def globalSettingsOf(typeName: String): JsObject = (_rootGlobalSettings \ familyName \ typeName)
+    // Non-object entries are ignored, i.e. replaced with an empty object
+    .validate[JsObject].getOrElse(Json.obj())
+
+  override def writes(component: F): JsValue = componentSpecsByClass.get(component.getClass) match {
+    case Some(spec) => writesWithTypeFor(spec.format.asInstanceOf[Format[F]], spec.typeName).writes(component)
+    case None => throw new Error(s"Unregistered scale list sub-component class ${component.getClass.getName}")
+  }
+}
+
+private object ComponentJsonFormat {
+  private val PropertyNameType = "type"
+
+  private val MissingTypeError: JsonValidationError = JsonValidationError("error.component.type.missing")
+  private val UnrecognizedTypeError: JsonValidationError = JsonValidationError("error.component.type.unrecognized")
+
+  private[format] case class TypeSpec[T](typeName: String,
+                                         javaClass: Class[T],
+                                         format: Format[T],
+                                         defaultSettings: JsObject)
+
+  private def writesWithTypeFor[A](writes: Writes[A], typeName: String): OWrites[A] = {
+    //@formatter:off
+    (
+      (__ \ PropertyNameType).write[String] and
+      __.write[A](writes)
+    ) ({ component: A => (typeName, component) })
+    //@formatter:on
+  }
+}
+
+

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormat.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormat.scala
@@ -28,13 +28,12 @@ import play.api.libs.functional.syntax._
  * A _JSON component_ is an object with a particular _type_ that is part of a _family_. The family is used in a
  * certain context (e.g. tuning mapper, tuning reduces, scale etc.). For each family there can be one or more types.
  * The type is identified in the JSON object by the `type` property (which might be implicit for a default type).
- * Each type may have its own specific properties.
+ * Each type may have its own specific properties called _settings_.
  *
  * One should create separate instances of this class for each family and configure it with a sequence of specs, each
- * for each type. Each type may have default values, in `defaultSettings`, for certain properties to allow users to
- * omit them. Property values per family/type can also be set globally by the user per composition file in the
- * settings section and the class has a getter for setter for settings the root of the settings JSON after the JSON
- * file was parsed.
+ * for each type. Each type may have default values, in `defaultSettings`, for certain settings to allow users to
+ * omit them. Settings values per family/type can also be set globally by the user per composition file in the
+ * settings section and the class has a setter for setting the root of the settings JSON after the JSON file was parsed.
  */
 class ComponentJsonFormat[F](val familyName: String,
                              specs: Seq[ComponentJsonFormat.TypeSpec[_ <: F]],

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentPlayJsonFormat.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/ComponentPlayJsonFormat.scala
@@ -27,6 +27,7 @@ import play.api.libs.json._
  *
  * @tparam A base Scala class or trait
  */
+@deprecated
 trait ComponentPlayJsonFormat[A] extends Format[A] {
 
   import ComponentPlayJsonFormat._
@@ -95,6 +96,7 @@ trait ComponentPlayJsonFormat[A] extends Format[A] {
   }
 }
 
+@deprecated
 object ComponentPlayJsonFormat {
 
   /** Field that identifies the class that extends type parameter `A` in companion class. */

--- a/format/src/test/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormatTest.scala
+++ b/format/src/test/scala/org/calinburloiu/music/microtonalist/format/ComponentJsonFormatTest.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2024 Calin-Andrei Burloiu
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.calinburloiu.music.microtonalist.format
+
+import org.scalatest.{BeforeAndAfterEach, Inside}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsError, JsNull, JsSuccess, JsValue, Json, JsonValidationError}
+
+class ComponentJsonFormatTest extends AnyFlatSpec with Matchers with Inside {
+  private sealed trait Animals
+
+  private case class Domestic(cat: String, dog: String) extends Animals
+
+  private case class Forest(fox: String, rabbit: String, squirrel: String, wolf: String) extends Animals
+
+  private case class Jungle(lion: String, snake: String) extends Animals
+
+  private val FamilyNameAnimals = "animals"
+  private val TypeNameDomestic = "domestic"
+  private val TypeNameForest = "forest"
+  private val TypeNameJungle = "jungle"
+
+  private val format: ComponentJsonFormat[Animals] = createFormat(Some(TypeNameDomestic))
+  format.rootGlobalSettings = Json.obj(
+    "animals" -> Json.obj(
+      "domestic" -> Json.obj(
+        "dog" -> "Scooby"
+      ),
+      "forest" -> Json.obj(
+        "fox" -> "Jumpy",
+        "rabbit" -> "Gump",
+        "wolf" -> "Daos"
+      )
+    )
+  )
+
+  private def createFormat(defaultTypeName: Option[String]): ComponentJsonFormat[Animals] = new ComponentJsonFormat(
+    FamilyNameAnimals,
+    Seq(
+      ComponentJsonFormat.TypeSpec[Domestic](TypeNameDomestic, classOf[Domestic], Json.format[Domestic]),
+      ComponentJsonFormat.TypeSpec[Forest](TypeNameForest, classOf[Forest], Json.format[Forest], Json.obj(
+        "rabbit" -> "Bugs Bunny",
+        "squirrel" -> "Nutz",
+        "wolf" -> "White Fang"
+      )),
+      ComponentJsonFormat.TypeSpec[Jungle](TypeNameJungle, classOf[Jungle], Json.format[Jungle], Json.obj(
+        "lion" -> "King",
+        "snake" -> "Monty"
+      ))
+    ),
+    defaultTypeName
+  )
+
+  private def assertReads(json: JsValue, result: Animals): Unit =
+    format.reads(json) should matchPattern { case JsSuccess(`result`, _) => }
+
+  private def assertReadsFailure(json: JsValue,
+                                 error: JsonValidationError,
+                                 customFormat: ComponentJsonFormat[Animals] = format): Unit =
+    customFormat.reads(json) should matchPattern { case JsError(Seq((_, Seq(`error`)))) => }
+
+  "reads" should "parse a component with type property and all properties given" in {
+    val json = Json.obj(
+      "type" -> TypeNameForest,
+      "fox" -> "Lady",
+      "rabbit" -> "Snowy",
+      "squirrel" -> "Cheeks",
+      "wolf" -> "Jack"
+    )
+    assertReads(json, Forest("Lady", "Snowy", "Cheeks", "Jack"))
+  }
+
+  it should "parse a component without a type property and use the default type provided" in {
+    val json = Json.obj("cat" -> "Mitzi", "dog" -> "Pamela")
+    assertReads(json, Domestic("Mitzi", "Pamela"))
+  }
+
+  it should "fail to parse a component without a type property when the format does not provide a default type" in {
+    val format2 = createFormat(defaultTypeName = None)
+    val json = Json.obj("cat" -> "Mitzi", "dog" -> "Pamela")
+    assertReadsFailure(json, ComponentJsonFormat.MissingTypeError, format2)
+  }
+
+  it should "parse a component expressed as a type string when all settings have defaults" in {
+    assertReads(Json.toJson(TypeNameJungle), Jungle("King", "Monty"))
+  }
+
+  it should "fail to parse a component expressed as a type string when not all settings have defaults" in {
+    format.reads(Json.toJson(TypeNameDomestic)).isError shouldBe true
+  }
+
+  it should "fail to parse components with unknown type" in {
+    assertReadsFailure(Json.toJson("foo"), ComponentJsonFormat.UnrecognizedTypeError)
+    assertReadsFailure(Json.obj("type" -> "bar", "x" -> 3), ComponentJsonFormat.UnrecognizedTypeError)
+  }
+
+  it should "parse components whose missing settings are taken from defaults or global settings" in {
+    val domesticJson = Json.obj(
+      "type" -> TypeNameDomestic,
+      "cat" -> "Tom"
+    )
+    // dog is taken from global settings
+    assertReads(domesticJson, Domestic("Tom", "Scooby"))
+
+    val forestJson = Json.obj(
+      "type" -> TypeNameForest,
+      "fox" -> "Sebastian",
+      "rabbit" -> "Norris",
+      "squirrel" -> "Mark"
+    )
+    // wolf is taken from global settings
+    assertReads(forestJson, Forest("Sebastian", "Norris", "Mark", "Daos"))
+
+    val jungleJson = Json.obj(
+      "type" -> TypeNameJungle,
+      "lion" -> "Chris"
+    )
+    // snake is taken from defaults
+    assertReads(jungleJson, Jungle("Chris", "Monty"))
+  }
+
+  it should "fail to parse a component that is not a type name string or valid object" in {
+    assertReadsFailure(Json.toJson(3), ComponentJsonFormat.InvalidError)
+    assertReadsFailure(JsNull, ComponentJsonFormat.InvalidError)
+    assertReadsFailure(Json.arr(1, 2), ComponentJsonFormat.InvalidError)
+  }
+
+  "writes" should "serialize as JSON a Scala component" in {
+    val domestic = Domestic("Tom", "Scooby")
+    format.writes(domestic) shouldEqual Json.obj(
+      "type" -> TypeNameDomestic,
+      "cat" -> "Tom",
+      "dog" -> "Scooby"
+    )
+  }
+}


### PR DESCRIPTION
Replace `org.calinburloiu.music.microtonalist.format.ComponentPlayJsonFormat` with a better version of it: `org.calinburloiu.music.microtonalist.format.ComponentJsonFormat`.

Part of #38.