### PR TITLE
 [#76] Unexpected tuning mapper conflict in just intonation Cireșar scale 

### DIFF
--- a/app/src/test/scala/org/calinburloiu/music/microtonalist/config/CoreConfigTest.scala
+++ b/app/src/test/scala/org/calinburloiu/music/microtonalist/config/CoreConfigTest.scala
@@ -23,7 +23,7 @@ class CoreConfigTest extends SubConfigTest[CoreConfig, CoreConfigManager] {
   override lazy val subConfigManager: CoreConfigManager = mainConfigManager.coreConfigManager
 
   override lazy val expectedSubConfigRead: CoreConfig = CoreConfig(
-    libraryUri = new URI("file:///Users/johnny/Music/microtonalist/lib/scales/"),
+    libraryUri = new URI("file:///Users/johnny/Music/microtonalist/lib/scales"),
     metaConfig = MetaConfig(
       saveIntervalMillis = 2000,
       saveOnExit = false

--- a/core/src/main/scala/org/calinburloiu/music/microtonalist/core/Composition.scala
+++ b/core/src/main/scala/org/calinburloiu/music/microtonalist/core/Composition.scala
@@ -49,7 +49,7 @@ case class TuningSpec(transposition: Interval,
                       tuningMapper: TuningMapper) {
 
   def tuningFor(ref: TuningRef): PartialTuning = {
-    tuningMapper.mapScale(scale, transposition, ref)
+    tuningMapper.mapScale(scale, ref, transposition)
   }
 }
 

--- a/core/src/main/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapper.scala
+++ b/core/src/main/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapper.scala
@@ -29,7 +29,7 @@ case class ManualTuningMapper(keyboardMapping: KeyboardMapping) extends TuningMa
 
   import ManualTuningMapper._
 
-  override def mapScale(scale: Scale[Interval], transposition: Interval, ref: TuningRef): PartialTuning = {
+  override def mapScale(scale: Scale[Interval], ref: TuningRef, transposition: Interval): PartialTuning = {
     val processedScale = scale.transpose(transposition)
     val partialTuningValues = keyboardMapping.values.map { pair =>
       val maybeScalePitchIndex = pair._2

--- a/core/src/main/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapper.scala
+++ b/core/src/main/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapper.scala
@@ -30,6 +30,8 @@ case class ManualTuningMapper(keyboardMapping: KeyboardMapping) extends TuningMa
   import ManualTuningMapper._
 
   override def mapScale(scale: Scale[Interval], ref: TuningRef, transposition: Interval): PartialTuning = {
+    require(keyboardMapping.indexesInScale.flatten.max < scale.size)
+
     val processedScale = scale.transpose(transposition)
     val partialTuningValues = keyboardMapping.values.map { pair =>
       val maybeScalePitchIndex = pair._2

--- a/core/src/main/scala/org/calinburloiu/music/microtonalist/core/PartialTuning.scala
+++ b/core/src/main/scala/org/calinburloiu/music/microtonalist/core/PartialTuning.scala
@@ -184,7 +184,7 @@ case class PartialTuning(override val deviations: Seq[Option[Double]],
   override def toString: String = {
     val pitches = deviations.zipWithIndex.map {
       case (Some(deviation), index) =>
-        Some(String.format(java.util.Locale.US, "%s = %.2f", PitchClass.nameOf(index) + " = " + deviation))
+        Some(String.format(java.util.Locale.US, "%s = %.2f", PitchClass.nameOf(index), deviation))
       case _ => None
     }.filter(_.nonEmpty).map(_.get)
     s"$name: ${pitches.mkString(", ")}"

--- a/core/src/main/scala/org/calinburloiu/music/microtonalist/core/PianoKeyboardTuningUtils.scala
+++ b/core/src/main/scala/org/calinburloiu/music/microtonalist/core/PianoKeyboardTuningUtils.scala
@@ -106,7 +106,7 @@ object PianoKeyboardTuningUtils {
 
     override def toPianoKeyboardString: String = {
       val asciiPiano = super.toPianoKeyboardString
-      s"${tuning.name}:\n$asciiPiano"
+      s"\"${tuning.name}\":\n$asciiPiano"
     }
 
     override protected def fromDeviationToString(deviation: Double) = f"$deviation%+06.2f"

--- a/core/src/main/scala/org/calinburloiu/music/microtonalist/core/TuningMapper.scala
+++ b/core/src/main/scala/org/calinburloiu/music/microtonalist/core/TuningMapper.scala
@@ -27,28 +27,27 @@ import org.calinburloiu.music.scmidi.PitchClass
  * This results in throwing a [[TuningMapperConflictException]].
  */
 trait TuningMapper {
-  /**
-   * Maps a scale to a tuning.
-   *
-   * @param scale Scale to map.
-   * @param transposition Interval by which the scale should be transposed before mapping it.
-   * @param ref Tuning reference.
-   * @return a partial tuning for the given scale.
-   */
-  def mapScale(scale: Scale[Interval], transposition: Interval, ref: TuningRef): PartialTuning
 
   /**
    * Maps a scale to a tuning.
    *
-   * The scale is not transposed before mapping.
+   * @param scale         Scale to map.
+   * @param ref           Tuning reference.
+   * @param transposition Interval by which the scale should be transposed before mapping it.
+   * @return a partial tuning for the given scale.
+   */
+  def mapScale(scale: Scale[Interval], ref: TuningRef, transposition: Interval): PartialTuning
+
+  /**
+   * Maps a scale to a tuning.
    *
-   * @param scale Scale to map.
-   * @param ref Tuning reference.
+   * @param scale         Scale to map.
+   * @param ref           Tuning reference.
    * @return a partial tuning for the given scale.
    */
   def mapScale(scale: Scale[Interval], ref: TuningRef): PartialTuning = {
     val unison = scale.intonationStandard.map(_.unison).getOrElse(RealInterval.Unison)
-    mapScale(scale, unison, ref)
+    mapScale(scale, ref, unison)
   }
 }
 

--- a/core/src/test/scala/org/calinburloiu/music/microtonalist/core/AutoTuningMapperTest.scala
+++ b/core/src/test/scala/org/calinburloiu/music/microtonalist/core/AutoTuningMapperTest.scala
@@ -532,6 +532,40 @@ class AutoTuningMapperTest extends AnyFlatSpec with Matchers with TableDrivenPro
     partialTuning.c should contain(-5.87)
   }
 
+  it should "avoid conflict with manually mapped pitches" in {
+    // Given
+    val scale = RatiosScale(1 /: 1, 88 /: 81, 12 /: 11, 32 /: 27, 4 /: 3)
+    val tuningRef = StandardTuningRef(PitchClass.D)
+    val overrideKeyboardMapping = KeyboardMapping(e = Some(1))
+    val mapper = AutoTuningMapper(shouldMapQuarterTonesLow = false, quarterToneTolerance = 13.0,
+      overrideKeyboardMapping = overrideKeyboardMapping)
+
+    // When
+    val partialTuning = mapper.mapScale(scale, tuningRef)
+
+    // Then
+    partialTuning.completedCount shouldEqual 5
+    partialTuning.eFlat should contain(50.64)
+    partialTuning.e should contain(-56.50)
+  }
+
+  // Test for bugfix https://github.com/calinburloiu/microtonalist/issues/76
+  it should "map just Cireșar scale" in {
+    // Given
+    val ciresar = RatiosScale("Cireșar", 1 /: 1, 9 /: 8, 6 /: 5, 9 /: 7, 3 /: 2, 8 /: 5, 9 /: 5, 27 /: 14, 9 /: 4)
+    val mapper = AutoTuningMapper(shouldMapQuarterTonesLow = false, quarterToneTolerance = 13)
+
+    // When
+    val partialTuning = mapper.mapScale(ciresar, cTuningRef)
+
+    // Then
+    partialTuning.completedCount shouldEqual 8
+    partialTuning.eFlat should contain(15.64)
+    partialTuning.e should contain(35.08)
+    partialTuning.bFlat should contain(17.6)
+    partialTuning.b should contain(37.04)
+  }
+
   behavior of "mapInterval"
 
   it should "map an interval to a pitch class with a deviation in cents" in {

--- a/core/src/test/scala/org/calinburloiu/music/microtonalist/core/AutoTuningMapperTest.scala
+++ b/core/src/test/scala/org/calinburloiu/music/microtonalist/core/AutoTuningMapperTest.scala
@@ -96,7 +96,7 @@ class AutoTuningMapperTest extends AnyFlatSpec with Matchers with TableDrivenPro
     result.f should contain(0.0)
 
     // When
-    result = autoTuningMapperWithHighQuarterTones.mapScale(maj4, EdoInterval(72, (5, 0)), cTuningRef)
+    result = autoTuningMapperWithHighQuarterTones.mapScale(maj4, cTuningRef, EdoInterval(72, (5, 0)))
     // Then
     result.completedCount shouldEqual 4
     result.f should contain(0.0)
@@ -115,12 +115,12 @@ class AutoTuningMapperTest extends AnyFlatSpec with Matchers with TableDrivenPro
     tuning.name shouldEqual "C maj-4"
 
     // When
-    tuning = autoTuningMapperWithHighQuarterTones.mapScale(maj4, 3 /: 2, cTuningRef)
+    tuning = autoTuningMapperWithHighQuarterTones.mapScale(maj4, cTuningRef, 3 /: 2)
     // Then
     tuning.name shouldEqual "G maj-4"
 
     // When
-    tuning = autoTuningMapperWithHighQuarterTones.mapScale(maj4, 6 /: 5, cTuningRef)
+    tuning = autoTuningMapperWithHighQuarterTones.mapScale(maj4, cTuningRef, 6 /: 5)
     // Then
     tuning.name shouldEqual "D♯/E♭ maj-4"
   }
@@ -135,7 +135,7 @@ class AutoTuningMapperTest extends AnyFlatSpec with Matchers with TableDrivenPro
     tuning.name shouldEqual "maj-4"
 
     // When
-    tuning = autoTuningMapperWithHighQuarterTones.mapScale(maj4, 3 /: 2, cTuningRef)
+    tuning = autoTuningMapperWithHighQuarterTones.mapScale(maj4, cTuningRef, 3 /: 2)
     tuning.name shouldEqual "maj-4"
   }
 

--- a/core/src/test/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapperTest.scala
+++ b/core/src/test/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapperTest.scala
@@ -90,14 +90,26 @@ class ManualTuningMapperTest extends AnyFlatSpec with Matchers {
     partialTuning.b should contain(-11.73)
   }
 
-  it should "fail if a deviation overflows" in {
+  it should "fail to map a scale if a deviation overflows" in {
     // Given
-    val scale = CentsScale(0.0, 200.0, 400.0, 500.0)
-    val mapping = KeyboardMapping(c = Some(0), cSharpOrDFlat = Some(1), e = Some(3), f = Some(4))
+    val scale = CentsScale(0.0, 233.33, 400.0, 500.0)
+    val mapping = KeyboardMapping(c = Some(0), cSharpOrDFlat = Some(1), e = Some(2), f = Some(3))
     val mapper = ManualTuningMapper(mapping)
     val tuningRef = StandardTuningRef(PitchClass.C)
     // Then
     assertThrows[TuningMapperOverflowException] {
+      mapper.mapScale(scale, tuningRef)
+    }
+  }
+
+  it should "fail to map scale if the mapping scale pitches indexes are out of bounds" in {
+    // Given
+    val scale = CentsScale(0.0, 200.0, 383.33, 500.0)
+    val mapping = KeyboardMapping(c = Some(0), g = Some(4))
+    val mapper = ManualTuningMapper(mapping)
+    val tuningRef = StandardTuningRef(PitchClass.C)
+    // Then
+    assertThrows[IllegalArgumentException] {
       mapper.mapScale(scale, tuningRef)
     }
   }

--- a/core/src/test/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapperTest.scala
+++ b/core/src/test/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapperTest.scala
@@ -69,8 +69,8 @@ class ManualTuningMapperTest extends AnyFlatSpec with Matchers {
   it should "map a large scale that can't be automatically mapped" in {
     // Given
     val scale = RatiosScale(
-      1 /: 1, 81 /: 80, 10 /: 9, 9 /: 8, 5 /: 4, 81 /: 64, 4 /: 3, 27 /: 20, 40 /: 27, 3 /: 2, 128 /: 81, 8 /: 5, 15
-        /: 8, 243 /: 128)
+      1 /: 1, 81 /: 80, 10 /: 9, 9 /: 8, 5 /: 4, 81 /: 64, 4 /: 3, 27 /: 20, 40 /: 27, 3 /: 2, 128 /: 81, 8 /: 5,
+      15 /: 8, 243 /: 128)
     val keyboardMapping = KeyboardMapping(c = Some(0), d = Some(3), e = Some(4), f = Some(6), g = Some(9),
       gSharpOrAFlat = Some(11), b = Some(12))
     val mapper = ManualTuningMapper(keyboardMapping)

--- a/core/src/test/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapperTest.scala
+++ b/core/src/test/scala/org/calinburloiu/music/microtonalist/core/ManualTuningMapperTest.scala
@@ -25,9 +25,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class ManualTuningMapperTest extends AnyFlatSpec with Matchers {
-  private val keyboardMapping = KeyboardMapping(c = Some(6), d = Some(0), e = Some(1), f = Some(2), g = Some(3),
-    a = Some(4), aSharpOrBFlat = Some(5))
-
   private val testTolerance: Double = 1e-2
   private implicit val doubleEquality: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(testTolerance)
 
@@ -40,27 +37,57 @@ class ManualTuningMapperTest extends AnyFlatSpec with Matchers {
     }
 
     assertThrows[IllegalArgumentException] {
-      // Negative scale degrees
+      // Given
+      val keyboardMapping = KeyboardMapping(c = Some(6), d = Some(0))
+      // Then: Negative scale degrees
       ManualTuningMapper(keyboardMapping.updated(PitchClass.C, Some(-6)))
     }
   }
 
   it should "map a scale with just quarter tones to custom keys" in {
     // Given
-    val scale = RatiosScale(1/:1, 13/:12, 32/:27, 4/:3, 3/:2, 13/:8, 16/:9)
+    val scale = RatiosScale(1 /: 1, 13 /: 12, 32 /: 27, 4 /: 3, 3 /: 2, 13 /: 8, 16 /: 9)
+    val keyboardMapping = KeyboardMapping(c = Some(6), d = Some(0), e = Some(1), f = Some(2), g = Some(3),
+      a = Some(4), aSharpOrBFlat = Some(5))
     val mapper = ManualTuningMapper(keyboardMapping)
-    val tuningRef = ConcertPitchTuningRef(2/:3, MidiNote.D4)
+    val tuningRef = ConcertPitchTuningRef(2 /: 3, MidiNote.D4)
+
     // When
     val partialTuning = mapper.mapScale(scale, tuningRef)
+
     // Then
     partialTuning.completedCount shouldEqual 7
-    partialTuning.d should contain (-1.95)
-    partialTuning.e should contain (-63.38)
-    partialTuning.f should contain (-7.82)
-    partialTuning.g should contain (-3.91)
-    partialTuning.a should contain (0.0)
-    partialTuning.bFlat should contain (38.57)
-    partialTuning.c should contain (-5.87)
+    partialTuning.d should contain(-1.95)
+    partialTuning.e should contain(-63.38)
+    partialTuning.f should contain(-7.82)
+    partialTuning.g should contain(-3.91)
+    partialTuning.a should contain(0.0)
+    partialTuning.bFlat should contain(38.57)
+    partialTuning.c should contain(-5.87)
+  }
+
+  it should "map a large scale that can't be automatically mapped" in {
+    // Given
+    val scale = RatiosScale(
+      1 /: 1, 81 /: 80, 10 /: 9, 9 /: 8, 5 /: 4, 81 /: 64, 4 /: 3, 27 /: 20, 40 /: 27, 3 /: 2, 128 /: 81, 8 /: 5, 15
+        /: 8, 243 /: 128)
+    val keyboardMapping = KeyboardMapping(c = Some(0), d = Some(3), e = Some(4), f = Some(6), g = Some(9),
+      gSharpOrAFlat = Some(11), b = Some(12))
+    val mapper = ManualTuningMapper(keyboardMapping)
+    val tuningRef = StandardTuningRef(PitchClass.C)
+
+    // When
+    val partialTuning = mapper.mapScale(scale, tuningRef)
+
+    // Then
+    partialTuning.completedCount shouldEqual 7
+    partialTuning.c should contain(0.0)
+    partialTuning.d should contain(3.91)
+    partialTuning.e should contain(-13.69)
+    partialTuning.f should contain(-1.96)
+    partialTuning.g should contain(1.96)
+    partialTuning.aFlat should contain(13.69)
+    partialTuning.b should contain(-11.73)
   }
 
   it should "fail if a deviation overflows" in {

--- a/core/src/test/scala/org/calinburloiu/music/microtonalist/core/PartialTuningTest.scala
+++ b/core/src/test/scala/org/calinburloiu/music/microtonalist/core/PartialTuningTest.scala
@@ -63,14 +63,20 @@ class PartialTuningTest extends AnyFlatSpec with Matchers {
     incompletePartialTuning.isComplete shouldEqual false
   }
 
-  "resolve" should "return some Tuning if this PartialTuning isComplete and None otherwise" in {
-    emptyPartialTuning.resolve should be(empty)
-    completePartialTuning.resolve should contain(OctaveTuning("foo",
+  "resolve" should "return a Tuning if this PartialTuning isComplete and None otherwise" in {
+    val standardTuning = OctaveTuning("", Array.fill(12)(0.0))
+    emptyPartialTuning.resolve shouldEqual standardTuning
+    completePartialTuning.resolve shouldEqual OctaveTuning("foo",
       100.0, 200.0, 300.0,
       400.0, 500.0, 600.0,
       700.0, 800.0, 900.0,
-      1000.0, 1100.0, 1200.0))
-    incompletePartialTuning.resolve should be(empty)
+      1000.0, 1100.0, 1200.0)
+    incompletePartialTuning.resolve shouldEqual OctaveTuning("",
+      0.0, 0.0, 270.0,
+      400.0, 500.0, 600.0,
+      700.0, 800.0, 900.0,
+      1000.0, 1100.0, 1200.0
+    )
   }
 
   "enrich" should "correctly do a best effort combine of PartialTunings" in {

--- a/core/src/test/scala/org/calinburloiu/music/microtonalist/core/PartialTuningTest.scala
+++ b/core/src/test/scala/org/calinburloiu/music/microtonalist/core/PartialTuningTest.scala
@@ -64,7 +64,7 @@ class PartialTuningTest extends AnyFlatSpec with Matchers {
   }
 
   "resolve" should "return a Tuning if this PartialTuning isComplete and None otherwise" in {
-    val standardTuning = OctaveTuning("", Array.fill(12)(0.0))
+    val standardTuning = OctaveTuning("", Seq.fill(12)(0.0))
     emptyPartialTuning.resolve shouldEqual standardTuning
     completePartialTuning.resolve shouldEqual OctaveTuning("foo",
       100.0, 200.0, 300.0,

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/Tuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/Tuner.scala
@@ -41,7 +41,7 @@ trait LoggerTuner extends Tuner with StrictLogging {
   import org.calinburloiu.music.microtonalist.core.PianoKeyboardTuningUtils._
 
   abstract override def tune(tuning: OctaveTuning): Unit = {
-    logger.info(s"Tuning to \"${tuning.toPianoKeyboardString}\"")
+    logger.info(s"Tuning to ${tuning.toPianoKeyboardString}")
 
     super.tune(tuning)
   }


### PR DESCRIPTION
* Resolves #76.
* Fixes an issue with `overrideKeyboardMapping` in `AutoTuningMapper` when manually mapped pitch classes are not excluded.