### PR TITLE
Use the term URL instead of URI in the file formats

### DIFF
--- a/app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala
+++ b/app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala
@@ -79,14 +79,14 @@ object MicrotonalistApp extends StrictLogging {
     val businessync = new Businessync(eventBus)
     val mainConfigManager = MainConfigManager(configPath)
 
-    val formatModule = new FormatModule(businessync, mainConfigManager.coreConfig.libraryBaseUri)
+    val formatModule = new FormatModule(businessync, mainConfigManager.coreConfig.libraryBaseUrl)
 
     val composition = formatModule.defaultCompositionRepo.read(inputUri)
     val tuningList = TuningList.fromComposition(composition)
 
     val tunerModule = new TunerModule(businessync, formatModule.defaultTrackRepo)
     val trackService = tunerModule.trackService
-    composition.tracksUri.foreach { uri =>
+    composition.tracksUrl.foreach { uri =>
       // TODO #87 This will be moved as part of a composition opening workflow
       Await.result(trackService.open(uri), 10 seconds)
     }

--- a/app/src/test/resources/app/La-Cornu--Calin-Andrei-Burloiu--72edo.mtlist
+++ b/app/src/test/resources/app/La-Cornu--Calin-Andrei-Burloiu--72edo.mtlist
@@ -16,7 +16,7 @@
     "tuningReference": {
         "basePitchClass": 0
     },
-  "baseUrl": "scales/burloiu-ottoman-72edo/",
+    "baseUrl": "scales/burloiu-ottoman-72edo/",
     "tunings": [
         {
             "transposition": [11, -1],

--- a/app/src/test/resources/app/La-Cornu--Calin-Andrei-Burloiu--72edo.mtlist
+++ b/app/src/test/resources/app/La-Cornu--Calin-Andrei-Burloiu--72edo.mtlist
@@ -16,7 +16,7 @@
     "tuningReference": {
         "basePitchClass": 0
     },
-    "baseUri": "scales/burloiu-ottoman-72edo/",
+  "baseUrl": "scales/burloiu-ottoman-72edo/",
     "tunings": [
         {
             "transposition": [11, -1],

--- a/app/src/test/resources/app/huseyni.mtlist
+++ b/app/src/test/resources/app/huseyni.mtlist
@@ -1,5 +1,5 @@
 {
-  "baseUri": "refs/",
+  "baseUrl": "refs/",
   "$ref": "common.json",
   "tunings": [
     {

--- a/app/src/test/scala/org/calinburloiu/music/microtonalist/TuningSeqMappingIntegrationTest.scala
+++ b/app/src/test/scala/org/calinburloiu/music/microtonalist/TuningSeqMappingIntegrationTest.scala
@@ -154,7 +154,7 @@ class TuningSeqMappingIntegrationTest extends AnyFlatSpec with Matchers {
     tuning(11) shouldEqual -16.67
   }
 
-  it should "successfully create a tuning sequence for a a composition with global settings, baseUri and a $ref" in {
+  it should "successfully create a tuning sequence for a a composition with global settings, baseUrl and a $ref" in {
     val composition = FormatTestUtils.readCompositionFromResources("app/huseyni.mtlist",
       formatModule.defaultCompositionRepo)
 

--- a/common/src/main/scala/org/calinburloiu/music/microtonalist/common/package.scala
+++ b/common/src/main/scala/org/calinburloiu/music/microtonalist/common/package.scala
@@ -23,14 +23,14 @@ import scala.util.Try
 package object common {
 
   /**
-   * Parses a string as a URI. The string can either be an absolute URI or a local path.
+   * Parses a string as a URL. The string can either be an absolute URL or a local path.
    *
-   * @param uriString string to parse
-   * @return URI for the given string
+   * @param urlString string to parse
+   * @return an option [[URI]] for the given string
    */
-  def parseUriOrPath(uriString: String): Option[URI] =
-    Try(new URI(uriString)).toOption.filter(_.isAbsolute) orElse Try(Paths.get(uriString)).toOption.map { path =>
-      mapPathToUri(path, uriString)
+  def parseUrlOrPath(urlString: String): Option[URI] =
+    Try(new URI(urlString)).toOption.filter(_.isAbsolute) orElse Try(Paths.get(urlString)).toOption.map { path =>
+      mapPathToUri(path, urlString)
     }
 
   /**

--- a/common/src/test/scala/org/calinburloiu/music/microtonalist/common/CommonPackageObjectTest.scala
+++ b/common/src/test/scala/org/calinburloiu/music/microtonalist/common/CommonPackageObjectTest.scala
@@ -24,28 +24,29 @@ import java.nio.file.Paths
 
 class CommonPackageObjectTest extends AnyFlatSpec with Matchers {
 
-  "parseUri" should "parse an absolute URI" in {
-    parseUriOrPath("https://example.org/path/to/file.json") should contain(new URI("https://example.org/path/to/file.json"))
-    parseUriOrPath("https://example.org/path/to/") should contain(new URI("https://example.org/path/to/"))
+  "parseUrlOrPath" should "parse an absolute URL" in {
+    parseUrlOrPath("https://example.org/path/to/file.json") should contain(new URI("https://example.org/path/to/file" +
+      ".json"))
+    parseUrlOrPath("https://example.org/path/to/") should contain(new URI("https://example.org/path/to/"))
 
-    parseUriOrPath("file:///path/to/file.json") should contain(new URI("file:///path/to/file.json"))
-    parseUriOrPath("file:///path/to/") should contain(new URI("file:///path/to/"))
+    parseUrlOrPath("file:///path/to/file.json") should contain(new URI("file:///path/to/file.json"))
+    parseUrlOrPath("file:///path/to/") should contain(new URI("file:///path/to/"))
   }
 
   it should "parse a UNIX path" in {
     var uri = CommonTestUtils.uriOfResource("config/")
-    parseUriOrPath(uri.getPath) should contain(uri)
+    parseUrlOrPath(uri.getPath) should contain(uri)
     uri = CommonTestUtils.uriOfResource("config/microtonalist.conf")
-    parseUriOrPath(uri.getPath) should contain(uri)
+    parseUrlOrPath(uri.getPath) should contain(uri)
 
-    parseUriOrPath("/Users/johnny/Music/microtonalist/lib/scales/rast.jscl") should contain(
+    parseUrlOrPath("/Users/johnny/Music/microtonalist/lib/scales/rast.jscl") should contain(
       new URI("file:///Users/johnny/Music/microtonalist/lib/scales/rast.jscl"))
-    parseUriOrPath("/Users/johnny/Music/microtonalist/lib/scales/") should contain(
+    parseUrlOrPath("/Users/johnny/Music/microtonalist/lib/scales/") should contain(
       new URI("file:///Users/johnny/Music/microtonalist/lib/scales/"))
 
     // Current working directory
     val cwd = Paths.get("").toAbsolutePath.toString
-    parseUriOrPath("scales/rast.scl") should contain(new URI(s"file://$cwd/scales/rast.scl"))
-    parseUriOrPath("scales/") should contain(new URI(s"file://$cwd/scales/"))
+    parseUrlOrPath("scales/rast.scl") should contain(new URI(s"file://$cwd/scales/rast.scl"))
+    parseUrlOrPath("scales/") should contain(new URI(s"file://$cwd/scales/"))
   }
 }

--- a/composition/src/main/scala/org/calinburloiu/music/microtonalist/composition/Composition.scala
+++ b/composition/src/main/scala/org/calinburloiu/music/microtonalist/composition/Composition.scala
@@ -24,19 +24,18 @@ import java.net.URI
 /**
  * A collection of scales to be mapped to tunings.
  *
- * @param url                          Optional URI associated with the composition which might have been used to
- *                                     load it from.
+ * @param url                    Optional URL associated with the composition which might have been used to
+ *                               load it from.
  * @param intonationStandard Specifies how intervals from the composition are expressed or interpreted.
  * @param tuningReference    Establishes the relation between the composition base pitch and a pitch class from the
  *                           keyboard instrument.
  * @param tuningSpecs        A sequence of specifications that defines each tuning based on scales.
- * @param tuningReducer      Strategy for reducing the number of tunings by merging them together.
+ * @param tuningReducer          Strategy for reducing the number of tunings by merging them.
  * @param fill               Specifies filling configuration for the tunings used in the composition.
  * @param metadata           Additional information about the composition.
- * @param tracksUrlOverride            Optional override for the URI of the tracks file used for configuring tracks.
- *                                     If not
- *                           provided the URI will be computed by appending `.tracks` to the path of the composition
- *                           URI.
+ * @param tracksUrlOverride      Optional override for the URL of the tracks file used for configuring tracks.
+ *                               If not provided, the URL will be computed by appending `.tracks` to the path of the
+ *                               composition URL.
  */
 case class Composition(url: Option[URI],
                        intonationStandard: IntonationStandard,

--- a/composition/src/main/scala/org/calinburloiu/music/microtonalist/composition/Composition.scala
+++ b/composition/src/main/scala/org/calinburloiu/music/microtonalist/composition/Composition.scala
@@ -24,7 +24,8 @@ import java.net.URI
 /**
  * A collection of scales to be mapped to tunings.
  *
- * @param uri                Optional URI associated with the composition which might have been used to load it from.
+ * @param url                          Optional URI associated with the composition which might have been used to
+ *                                     load it from.
  * @param intonationStandard Specifies how intervals from the composition are expressed or interpreted.
  * @param tuningReference    Establishes the relation between the composition base pitch and a pitch class from the
  *                           keyboard instrument.
@@ -32,21 +33,22 @@ import java.net.URI
  * @param tuningReducer      Strategy for reducing the number of tunings by merging them together.
  * @param fill               Specifies filling configuration for the tunings used in the composition.
  * @param metadata           Additional information about the composition.
- * @param tracksUriOverride  Optional override for the URI of the tracks file used for configuring tracks. If not
+ * @param tracksUrlOverride            Optional override for the URI of the tracks file used for configuring tracks.
+ *                                     If not
  *                           provided the URI will be computed by appending `.tracks` to the path of the composition
  *                           URI.
  */
-case class Composition(uri: Option[URI],
+case class Composition(url: Option[URI],
                        intonationStandard: IntonationStandard,
                        tuningReference: TuningReference,
                        tuningSpecs: Seq[TuningSpec],
                        tuningReducer: TuningReducer,
                        fill: FillSpec = FillSpec(),
                        metadata: Option[CompositionMetadata] = None,
-                       tracksUriOverride: Option[URI] = None) {
+                       tracksUrlOverride: Option[URI] = None) {
 
-  def tracksUri: Option[URI] = tracksUriOverride.orElse {
-    uri.map { uriValue =>
+  def tracksUrl: Option[URI] = tracksUrlOverride.orElse {
+    url.map { uriValue =>
       uriValue.resolve(s"${uriValue.getPath}.${Composition.TracksFileExtension}")
     }
   }

--- a/composition/src/test/scala/org/calinburloiu/music/microtonalist/composition/CompositionTest.scala
+++ b/composition/src/test/scala/org/calinburloiu/music/microtonalist/composition/CompositionTest.scala
@@ -33,11 +33,11 @@ class CompositionTest extends AnyFlatSpec with Matchers {
     fill = FillSpec()
   )
 
-  "tracksUrl" should "be derived from URI when there is no override" in {
+  "tracksUrl" should "be derived from URL when there is no override" in {
     sampleComposition.tracksUrl should contain(new URI("file:///path/to/composition.mtlist.tracks"))
   }
 
-  it should "be empty when URI is not defined" in {
+  it should "be empty when URL is not defined" in {
     val composition = sampleComposition.copy(url = None)
     composition.tracksUrl shouldBe empty
   }

--- a/composition/src/test/scala/org/calinburloiu/music/microtonalist/composition/CompositionTest.scala
+++ b/composition/src/test/scala/org/calinburloiu/music/microtonalist/composition/CompositionTest.scala
@@ -25,7 +25,7 @@ import java.net.URI
 
 class CompositionTest extends AnyFlatSpec with Matchers {
   val sampleComposition: Composition = Composition(
-    uri = Some(new URI("file:///path/to/composition.mtlist")),
+    url = Some(new URI("file:///path/to/composition.mtlist")),
     intonationStandard = CentsIntonationStandard,
     tuningReference = StandardTuningReference(PitchClass.C),
     tuningSpecs = Seq(),
@@ -33,18 +33,18 @@ class CompositionTest extends AnyFlatSpec with Matchers {
     fill = FillSpec()
   )
 
-  "tracksUri" should "be derived from URI when there is no override" in {
-    sampleComposition.tracksUri should contain(new URI("file:///path/to/composition.mtlist.tracks"))
+  "tracksUrl" should "be derived from URI when there is no override" in {
+    sampleComposition.tracksUrl should contain(new URI("file:///path/to/composition.mtlist.tracks"))
   }
 
   it should "be empty when URI is not defined" in {
-    val composition = sampleComposition.copy(uri = None)
-    composition.tracksUri shouldBe empty
+    val composition = sampleComposition.copy(url = None)
+    composition.tracksUrl shouldBe empty
   }
 
   it should "overridden" in {
     val uri = new URI("file:///path/to/special.mtlist.tracks")
-    val composition = sampleComposition.copy(tracksUriOverride = Some(uri))
-    composition.tracksUri should contain(uri)
+    val composition = sampleComposition.copy(tracksUrlOverride = Some(uri))
+    composition.tracksUrl should contain(uri)
   }
 }

--- a/config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigPropertyException.scala
+++ b/config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigPropertyException.scala
@@ -19,7 +19,7 @@ package org.calinburloiu.music.microtonalist.config
 /**
  * Exception thrown when an error occurred while deserializing a config property.
  *
- * @param propertyPath HOCON config property path (e.g. `"core.libraryBaseUri"`)
+ * @param propertyPath HOCON config property path (e.g. `"core.libraryBaseUrl"`)
  * @param propertyRequirementMessage message that describes the requirement for the above property (e.g. "must be a
  *                                   valid URI or file system path")
  */

--- a/config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigPropertyException.scala
+++ b/config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigPropertyException.scala
@@ -21,7 +21,7 @@ package org.calinburloiu.music.microtonalist.config
  *
  * @param propertyPath HOCON config property path (e.g. `"core.libraryBaseUrl"`)
  * @param propertyRequirementMessage message that describes the requirement for the above property (e.g. "must be a
- *                                   valid URI or file system path")
+ *                                   valid URL or file system path")
  */
 class ConfigPropertyException(propertyPath: String, propertyRequirementMessage: String, cause: Throwable = null)
   extends ConfigException(s"$propertyPath $propertyRequirementMessage", cause)

--- a/config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala
+++ b/config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala
@@ -24,11 +24,11 @@ import org.calinburloiu.music.microtonalist.common.{PlatformUtils, parseUriOrPat
 import java.net.URI
 import java.nio.file.Paths
 
-case class CoreConfig(libraryBaseUri: URI = CoreConfig.defaultLibraryUri,
+case class CoreConfig(libraryBaseUrl: URI = CoreConfig.defaultLibraryBaseUrl,
                       metaConfig: MetaConfig = MetaConfig()) extends Configured
 
 object CoreConfig {
-  val defaultLibraryUri: URI = if (PlatformUtils.isMac) {
+  val defaultLibraryBaseUrl: URI = if (PlatformUtils.isMac) {
     val homePath = Paths.get(System.getProperty("user.home"))
     homePath.resolve("Music/microtonalist/lib/").toUri
   } else {
@@ -57,15 +57,15 @@ class CoreConfigManager(mainConfigManager: MainConfigManager)
     )
 
     hoconConfig
-      .withAnyRefValue("libraryBaseUri", config.libraryBaseUri.toString)
+      .withAnyRefValue("libraryBaseUrl", config.libraryBaseUrl.toString)
       .withAnyRefValue("metaConfig", metaConfigMap)
   }
 
   override protected def deserialize(hoconConfig: HoconConfig): CoreConfig = CoreConfig(
-    libraryBaseUri = hoconConfig.getAs[String]("libraryBaseUri")
+    libraryBaseUrl = hoconConfig.getAs[String]("libraryBaseUrl")
       .map(uri => parseUriOrPath(uri).getOrElse(throw new ConfigPropertyException(
-        s"$configRootPath.libraryBaseUri", "must be a valid URI or a local path")))
-      .getOrElse(CoreConfig.defaultLibraryUri),
+        s"$configRootPath.libraryBaseUrl", "must be a valid URI or a local path")))
+      .getOrElse(CoreConfig.defaultLibraryBaseUrl),
     metaConfig = hoconConfig.getAs[MetaConfig]("metaConfig").getOrElse(MetaConfig())
   )
 }

--- a/config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala
+++ b/config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala
@@ -19,7 +19,7 @@ package org.calinburloiu.music.microtonalist.config
 import com.typesafe.config.Config as HoconConfig
 import net.ceedubs.ficus.Ficus.*
 import net.ceedubs.ficus.readers.ValueReader
-import org.calinburloiu.music.microtonalist.common.{PlatformUtils, parseUriOrPath}
+import org.calinburloiu.music.microtonalist.common.{PlatformUtils, parseUrlOrPath}
 
 import java.net.URI
 import java.nio.file.Paths
@@ -63,8 +63,8 @@ class CoreConfigManager(mainConfigManager: MainConfigManager)
 
   override protected def deserialize(hoconConfig: HoconConfig): CoreConfig = CoreConfig(
     libraryBaseUrl = hoconConfig.getAs[String]("libraryBaseUrl")
-      .map(uri => parseUriOrPath(uri).getOrElse(throw new ConfigPropertyException(
-        s"$configRootPath.libraryBaseUrl", "must be a valid URI or a local path")))
+      .map(uri => parseUrlOrPath(uri).getOrElse(throw new ConfigPropertyException(
+        s"$configRootPath.libraryBaseUrl", "must be a valid URL or a local path")))
       .getOrElse(CoreConfig.defaultLibraryBaseUrl),
     metaConfig = hoconConfig.getAs[MetaConfig]("metaConfig").getOrElse(MetaConfig())
   )

--- a/config/src/test/resources/microtonalist.conf
+++ b/config/src/test/resources/microtonalist.conf
@@ -1,5 +1,5 @@
 core {
-  libraryBaseUri: "/Users/johnny/Music/microtonalist/lib/scales/"
+  libraryBaseUrl: "/Users/johnny/Music/microtonalist/lib/scales/"
   metaConfig {
     saveIntervalMillis = 2000
     saveOnExit = false

--- a/config/src/test/scala/org/calinburloiu/music/microtonalist/config/CoreConfigTest.scala
+++ b/config/src/test/scala/org/calinburloiu/music/microtonalist/config/CoreConfigTest.scala
@@ -23,7 +23,7 @@ class CoreConfigTest extends SubConfigTest[CoreConfig, CoreConfigManager] {
   override lazy val subConfigManager: CoreConfigManager = mainConfigManager.coreConfigManager
 
   override lazy val expectedSubConfigRead: CoreConfig = CoreConfig(
-    libraryBaseUri = new URI("file:///Users/johnny/Music/microtonalist/lib/scales/"),
+    libraryBaseUrl = new URI("file:///Users/johnny/Music/microtonalist/lib/scales/"),
     metaConfig = MetaConfig(
       saveIntervalMillis = 2000,
       saveOnExit = false
@@ -38,7 +38,7 @@ class CoreConfigTest extends SubConfigTest[CoreConfig, CoreConfigManager] {
       )
     ),
     expectedSubConfigRead.copy(
-      libraryBaseUri = new URI("file:///tmp/scales/")
+      libraryBaseUrl = new URI("file:///tmp/scales/")
     )
   )
 }
@@ -48,7 +48,7 @@ class CoreConfigDefaultsTest extends CoreConfigTest {
   override def configResource: String = SubConfigTest.defaultConfigResourceWithDefaults
 
   override lazy val expectedSubConfigRead: CoreConfig = CoreConfig(
-    libraryBaseUri = CoreConfig.defaultLibraryUri,
+    libraryBaseUrl = CoreConfig.defaultLibraryBaseUrl,
     metaConfig = MetaConfig(
       saveIntervalMillis = 5000,
       saveOnExit = true

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/CompositionRepr.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/CompositionRepr.scala
@@ -34,7 +34,7 @@ case class CompositionRepr(metadata: Option[CompositionMetadata],
                            tunings: Seq[TuningSpecRepr],
                            tuningReducer: Option[TuningReducer] = None,
                            fill: FillSpecRepr = FillSpecRepr(),
-                           tracksUri: Option[URI] = None) {
+                           tracksUrl: Option[URI] = None) {
 
   var context: CompositionFormatContext = uninitialized
 

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/FormatModule.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/FormatModule.scala
@@ -24,7 +24,7 @@ import java.net.http.HttpClient
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 class FormatModule(businessync: Businessync,
-                   libraryBaseUri: URI,
+                   libraryBaseUrl: URI,
                    synchronousAwaitTimeout: FiniteDuration = 1 minute) {
   lazy val jsonPreprocessor: JsonPreprocessor = new JsonPreprocessor(
     Seq(jsonPreprocessorFileRefLoader, jsonPreprocessorHttpRefLoader)
@@ -46,7 +46,7 @@ class FormatModule(businessync: Businessync,
   lazy val fileScaleRepo: FileScaleRepo = new FileScaleRepo(scaleFormatRegistry)
   lazy val httpScaleRepo: HttpScaleRepo = new HttpScaleRepo(httpClient, scaleFormatRegistry)
   lazy val libraryScaleRepo: LibraryScaleRepo = new LibraryScaleRepo(
-    libraryBaseUri, fileScaleRepo, httpScaleRepo)
+    libraryBaseUrl, fileScaleRepo, httpScaleRepo)
 
   lazy val defaultScaleRepo: ScaleRepo = new DefaultScaleRepo(
     Some(fileScaleRepo), Some(httpScaleRepo), Some(libraryScaleRepo), scaleContextConverter)
@@ -66,7 +66,7 @@ class FormatModule(businessync: Businessync,
 
   lazy val fileTrackRepo: FileTrackRepo = new FileTrackRepo(trackFormat, synchronousAwaitTimeout)
   lazy val httpTrackRepo: HttpTrackRepo = new HttpTrackRepo(httpClient, trackFormat, synchronousAwaitTimeout)
-  lazy val libraryTrackRepo: LibraryTrackRepo = new LibraryTrackRepo(libraryBaseUri, fileTrackRepo, httpTrackRepo)
+  lazy val libraryTrackRepo: LibraryTrackRepo = new LibraryTrackRepo(libraryBaseUrl, fileTrackRepo, httpTrackRepo)
 
   lazy val defaultTrackRepo: TrackRepo = new DefaultTrackRepo(
     Some(fileTrackRepo), Some(httpTrackRepo), Some(libraryTrackRepo))

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/JsonCompositionFormat.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/JsonCompositionFormat.scala
@@ -60,8 +60,8 @@ class JsonCompositionFormat(scaleRepo: ScaleRepo,
     val json = Json.parse(inputStream)
     val context = new CompositionFormatContext
 
-    (json \ "baseUri").validateOpt[URI].flatMap { overrideBaseUri =>
-      val baseUri = resolveBaseUriWithOverride(compositionUri, overrideBaseUri)
+    (json \ "baseUrl").validateOpt[URI].flatMap { overrideBaseUrl =>
+      val baseUri = resolveBaseUriWithOverride(compositionUri, overrideBaseUrl)
       val preprocessedJson = jsonPreprocessor.preprocess(json, baseUri)
 
       context.uri = compositionUri
@@ -132,20 +132,20 @@ class JsonCompositionFormat(scaleRepo: ScaleRepo,
     val tuningSpecs = compositionRepr.tunings.map(convertTuningSpec)
     val tuningReducer = compositionRepr.tuningReducer.getOrElse(TuningReducer.Default)
     val fillSpec = convertFillSpec(compositionRepr.fill)
-    val tracksUriOverride = for (
-      uri <- compositionRepr.tracksUri;
+    val tracksUrlOverride = for (
+      uri <- compositionRepr.tracksUrl;
       baseUri <- context.baseUri
     ) yield baseUri.resolve(uri)
 
     Composition(
-      uri = context.uri,
+      url = context.uri,
       intonationStandard = context.intonationStandard,
       tuningReference = tuningReference,
       tuningSpecs = tuningSpecs,
       tuningReducer = tuningReducer,
       fill = fillSpec,
       metadata = compositionRepr.metadata,
-      tracksUriOverride = tracksUriOverride
+      tracksUrlOverride = tracksUrlOverride
     )
   }
 

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/LibraryScaleRepo.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/LibraryScaleRepo.scala
@@ -25,15 +25,15 @@ import scala.concurrent.Future
 /**
  * Special scale repository implementation that accesses scales from user's configured private Microtonalist Library.
  *
- * The user can configure a base URI for the library, `libraryBaseUrl`, which can be a file system path or a remote HTTP
- * URL. Scales can then be imported by using a special URI with format `microtonalist:///<path-in-library>`, where
- * `<path-in-library>` is relative to the configured base URI.
+ * The user can configure a base URL for the library, `libraryBaseUrl`, which can be a file system path or a remote HTTP
+ * URL. Scales can then be imported by using a special URL with format `microtonalist:///<path-in-library>`, where
+ * `<path-in-library>` is relative to the configured base URL.
  *
- * For example, if the user configures `file:///Users/john/Music/microtonalist/lib/` as the base URI for the library,
- * the Microtonalist Library URI `microtonalist:///scales/lydian.scl` used in a scale import will actually point to
+ * For example, if the user configures `file:///Users/john/Music/microtonalist/lib/` as the base URL for the library,
+ * the Microtonalist Library URL `microtonalist:///scales/lydian.scl` used in a scale import will actually point to
  * `/Users/john/Music/microtonalist/lib/scales/lydian.scl`.
  *
- * @param libraryBaseUrl base URI for Microtonalist Library
+ * @param libraryBaseUrl base URL for Microtonalist Library
  * @param fileScaleRepo  a [[FileScaleRepo]] instance
  * @param httpScaleRepo  an [[HttpScaleRepo]] instance
  */
@@ -44,8 +44,8 @@ class LibraryScaleRepo(libraryBaseUrl: URI,
     Some(fileScaleRepo), Some(httpScaleRepo), None)
 
   override def read(uri: URI, context: Option[ScaleFormatContext]): Scale[Interval] = {
-    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
-    repoSelector.selectRepoOrThrow(resolvedUri).read(resolvedUri, context)
+    val resolvedUrl = resolveLibraryUrl(uri, libraryBaseUrl)
+    repoSelector.selectRepoOrThrow(resolvedUrl).read(resolvedUrl, context)
   }
 
   override def readAsync(uri: URI, context: Option[ScaleFormatContext]): Future[Scale[Interval]] = {

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/LibraryScaleRepo.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/LibraryScaleRepo.scala
@@ -25,7 +25,7 @@ import scala.concurrent.Future
 /**
  * Special scale repository implementation that accesses scales from user's configured private Microtonalist Library.
  *
- * The user can configure a base URI for the library, `libraryBaseUri`, which can be a file system path or a remote HTTP
+ * The user can configure a base URI for the library, `libraryBaseUrl`, which can be a file system path or a remote HTTP
  * URL. Scales can then be imported by using a special URI with format `microtonalist:///<path-in-library>`, where
  * `<path-in-library>` is relative to the configured base URI.
  *
@@ -33,23 +33,23 @@ import scala.concurrent.Future
  * the Microtonalist Library URI `microtonalist:///scales/lydian.scl` used in a scale import will actually point to
  * `/Users/john/Music/microtonalist/lib/scales/lydian.scl`.
  *
- * @param libraryBaseUri base URI for Microtonalist Library
+ * @param libraryBaseUrl base URI for Microtonalist Library
  * @param fileScaleRepo  a [[FileScaleRepo]] instance
  * @param httpScaleRepo  an [[HttpScaleRepo]] instance
  */
-class LibraryScaleRepo(libraryBaseUri: URI,
+class LibraryScaleRepo(libraryBaseUrl: URI,
                        fileScaleRepo: FileScaleRepo,
                        httpScaleRepo: HttpScaleRepo) extends ScaleRepo {
   private val repoSelector: RepoSelector[ScaleRepo] = new DefaultRepoSelector(
     Some(fileScaleRepo), Some(httpScaleRepo), None)
 
   override def read(uri: URI, context: Option[ScaleFormatContext]): Scale[Interval] = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).read(resolvedUri, context)
   }
 
   override def readAsync(uri: URI, context: Option[ScaleFormatContext]): Future[Scale[Interval]] = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).readAsync(resolvedUri, context)
   }
 
@@ -57,7 +57,7 @@ class LibraryScaleRepo(libraryBaseUri: URI,
                      uri: URI,
                      mediaType: Option[MediaType],
                      context: Option[ScaleFormatContext]): Unit = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).write(scale, resolvedUri, mediaType, context)
   }
 
@@ -65,7 +65,7 @@ class LibraryScaleRepo(libraryBaseUri: URI,
                           uri: URI,
                           mediaType: Option[MediaType],
                           context: Option[ScaleFormatContext]): Future[Unit] = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).writeAsync(scale, resolvedUri, mediaType, context)
   }
 }

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/LibraryTrackRepo.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/LibraryTrackRepo.scala
@@ -25,7 +25,7 @@ import scala.concurrent.Future
  * Special track specification repository implementation that accesses scales from user's configured private
  * Microtonalist Library.
  *
- * The user can configure a base URI for the library, `libraryBaseUri`, which can be a file system path or a remote HTTP
+ * The user can configure a base URI for the library, `libraryBaseUrl`, which can be a file system path or a remote HTTP
  * URL. Scales can then be imported by using a special URI with format `microtonalist:///<path-in-library>`, where
  * `<path-in-library>` is relative to the configured base URI.
  *
@@ -33,11 +33,11 @@ import scala.concurrent.Future
  * the Microtonalist Library URI `microtonalist:///tracks/default.mtlist.tracks` used as a tracks file URI will
  * actually point to `/Users/john/Music/microtonalist/lib/tracks/default.mtlist.tracks`.
  *
- * @param libraryBaseUri base URI for Microtonalist Library
+ * @param libraryBaseUrl base URI for Microtonalist Library
  * @param fileTrackRepo  a [[FileTrackRepo]] instance
  * @param httpTrackRepo  an [[HttpTrackRepo]] instance
  */
-class LibraryTrackRepo(libraryBaseUri: URI,
+class LibraryTrackRepo(libraryBaseUrl: URI,
                        fileTrackRepo: FileTrackRepo,
                        httpTrackRepo: HttpTrackRepo) extends TrackRepo {
 
@@ -45,22 +45,22 @@ class LibraryTrackRepo(libraryBaseUri: URI,
     Some(fileTrackRepo), Some(httpTrackRepo), None)
 
   override def readTracks(uri: URI): TrackSpecs = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).readTracks(resolvedUri)
   }
 
   override def readTracksAsync(uri: URI): Future[TrackSpecs] = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).readTracksAsync(resolvedUri)
   }
 
   override def writeTracks(trackSpecs: TrackSpecs, uri: URI): Unit = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).writeTracks(trackSpecs, resolvedUri)
   }
 
   override def writeTracksAsync(trackSpecs: TrackSpecs, uri: URI): Future[Unit] = {
-    val resolvedUri = resolveLibraryUri(uri, libraryBaseUri)
+    val resolvedUri = resolveLibraryUrl(uri, libraryBaseUrl)
     repoSelector.selectRepoOrThrow(resolvedUri).writeTracksAsync(trackSpecs, resolvedUri)
   }
 }

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/package.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/package.scala
@@ -40,10 +40,10 @@ package object format {
   }
 
   /**
-   * When a resource is loaded its URI will be used as the base URI for all resources referred inside it. That base
+   * When a resource is loaded, its URI will be used as the base URI for all resources referred inside it. That base
    * URI may be overridden to further simplify the URIs referred inside it.
    *
-   * E.g. A composition resource is loaded from file:///Users/john/Music/composition.mtlist. All scales referenced
+   * E.g., A composition resource is loaded from file:///Users/john/Music/composition.mtlist. All scales referenced
    * inside it will use its URI as base URI. So a scale from file:///Users/john/Music/scales/rast.jscl can be referenced
    * as simply "scales/rast.jscl". But this relative URI can be further simplified by defining an override URI
    * "scales/". Then, the same scale may be referenced as simply "rast.jscl".
@@ -62,20 +62,20 @@ package object format {
   }
 
   /**
-   * Maps a URI with `microtonalist` scheme to the actual URI as configured via `libraryBaseUri`
+   * Maps a URI with `microtonalist` scheme to the actual URI as configured via `libraryBaseUrl`
    *
-   * @param uri     URI of resource from the library.
-   * @param libraryBaseUri Base URI of the library.
+   * @param url            URL of a resource from the library.
+   * @param libraryBaseUrl Base URI of the library.
    * @return the actual URI.
    */
-  def resolveLibraryUri(uri: URI, libraryBaseUri: URI): URI = {
-    require(uri.isAbsolute && uri.getScheme == UriScheme.MicrotonalistLibrary,
+  def resolveLibraryUrl(url: URI, libraryBaseUrl: URI): URI = {
+    require(url.isAbsolute && url.getScheme == UriScheme.MicrotonalistLibrary,
       "URI must be absolute and have microtonalist scheme!")
 
     // Making the path relative to root. E.g. "/path/to/file" => "path/to/file"
-    val rootUri = uri.resolve("/")
-    val relativeToRootUri = rootUri.relativize(uri)
-    libraryBaseUri.resolve(relativeToRootUri)
+    val rootUri = url.resolve("/")
+    val relativeToRootUri = rootUri.relativize(url)
+    libraryBaseUrl.resolve(relativeToRootUri)
   }
 
   lazy val uint7Format: Format[Int] = {

--- a/format/src/main/scala/org/calinburloiu/music/microtonalist/format/package.scala
+++ b/format/src/main/scala/org/calinburloiu/music/microtonalist/format/package.scala
@@ -62,15 +62,15 @@ package object format {
   }
 
   /**
-   * Maps a URI with `microtonalist` scheme to the actual URI as configured via `libraryBaseUrl`
+   * Maps a URL with `microtonalist` scheme to the actual URL as configured via `libraryBaseUrl`
    *
    * @param url            URL of a resource from the library.
-   * @param libraryBaseUrl Base URI of the library.
-   * @return the actual URI.
+   * @param libraryBaseUrl Base URL of the library.
+   * @return the actual URL.
    */
   def resolveLibraryUrl(url: URI, libraryBaseUrl: URI): URI = {
     require(url.isAbsolute && url.getScheme == UriScheme.MicrotonalistLibrary,
-      "URI must be absolute and have microtonalist scheme!")
+      "URL must be absolute and have microtonalist scheme!")
 
     // Making the path relative to root. E.g. "/path/to/file" => "path/to/file"
     val rootUri = url.resolve("/")

--- a/format/src/test/resources/format/file-io-test-01.mtlist
+++ b/format/src/test/resources/format/file-io-test-01.mtlist
@@ -7,7 +7,7 @@
     "tuningReference": {
         "basePitchClass": "C"
     },
-    "#baseUri": "",
+    "#baseUrl": "",
     "tunings": [
         {
             "scale": "scales/maj-4-cents.jscl"
@@ -24,5 +24,5 @@
             "scale": "http://localhost:8080/scales/min-4-cents.scl"
         }
     ],
-    "#tracksUri": "test.mtlist.tracks"
+    "#tracksUrl": "test.mtlist.tracks"
 }

--- a/format/src/test/resources/format/file-io-test-01.mtlist
+++ b/format/src/test/resources/format/file-io-test-01.mtlist
@@ -26,3 +26,4 @@
     ],
     "#tracksUrl": "test.mtlist.tracks"
 }
+

--- a/format/src/test/resources/format/intonation-standard-conversion.mtlist
+++ b/format/src/test/resources/format/intonation-standard-conversion.mtlist
@@ -6,7 +6,7 @@
   "tuningReference": {
     "basePitchClass": "D"
   },
-  "baseUri": "scales/",
+  "baseUrl": "scales/",
   "tunings": [
     {
       "transposition": 0,

--- a/format/src/test/resources/format/minor-major.mtlist
+++ b/format/src/test/resources/format/minor-major.mtlist
@@ -12,7 +12,7 @@
   "tuningReference": {
     "basePitchClass": 2
   },
-  "baseUri": "scales/",
+  "baseUrl": "scales/",
   "tunings": [
     {
       "transposition": "1",

--- a/format/src/test/resources/format/tracksUrlOverride.mtlist
+++ b/format/src/test/resources/format/tracksUrlOverride.mtlist
@@ -7,5 +7,5 @@
     "basePitchClass": "Bb"
   },
   "tunings": [],
-  "tracksUri": "file:///Users/john/tracks.mtlist"
+  "tracksUrl": "file:///Users/john/tracks.mtlist"
 }

--- a/format/src/test/scala/org/calinburloiu/music/microtonalist/format/FormatPackageObjectTest.scala
+++ b/format/src/test/scala/org/calinburloiu/music/microtonalist/format/FormatPackageObjectTest.scala
@@ -25,23 +25,23 @@ import java.nio.file.Paths
 
 class FormatPackageObjectTest extends AnyFlatSpec with Matchers {
 
-  "filePathOf" should "convert an absolute URI to a file system path" in {
+  "filePathOf" should "convert an absolute URL to a file system path" in {
     filePathOf(new URI("file:///Users/john/Music/phrygian.scl")) shouldEqual Paths
       .get("/", "Users", "john", "Music", "phrygian.scl")
   }
 
-  it should "convert a relative URI to file system path" in {
+  it should "convert a relative URL to file system path" in {
     filePathOf(new URI("Music/phrygian.scl")) shouldEqual Paths
       .get("Music", "phrygian.scl")
   }
 
-  it should "fail for a non file URI" in {
+  it should "fail for a non file URL" in {
     assertThrows[IllegalArgumentException] {
       filePathOf(new URI("https://example.org/path/to/file.scl"))
     }
   }
 
-  it should "resolve an override base URI against an initial base URI" in {
+  it should "resolve an override base URL against an initial base URL" in {
     def uri(str: String) = Some(new URI(str))
 
     resolveBaseUriWithOverride(
@@ -79,7 +79,7 @@ class FormatPackageObjectTest extends AnyFlatSpec with Matchers {
     // No validation on write
   }
 
-  "resolveLibraryUrl" should "resolve an URI with microtonalist scheme" in {
+  "resolveLibraryUrl" should "resolve an URL with microtonalist scheme" in {
     val uri = URI("microtonalist:///scales/dorian.scl")
 
     resolveLibraryUrl(uri, URI("file:///Users/grey/Music/Library/")) shouldEqual URI(
@@ -88,7 +88,7 @@ class FormatPackageObjectTest extends AnyFlatSpec with Matchers {
       "https://microtonalist.org/library/grey/scales/dorian.scl")
   }
 
-  it should "fail for a relative URI" in {
+  it should "fail for a relative URL" in {
     val uri = URI("scales/dorian.scl")
 
     assertThrows[IllegalArgumentException] {
@@ -96,7 +96,7 @@ class FormatPackageObjectTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "fail for URIs that don't have a microtonalist scheme" in {
+  it should "fail for URLs that don't have a microtonalist scheme" in {
     val libraryBaseUrl = URI("file:///Users/grey/Music/Library/")
 
     assertThrows[IllegalArgumentException] {

--- a/format/src/test/scala/org/calinburloiu/music/microtonalist/format/FormatPackageObjectTest.scala
+++ b/format/src/test/scala/org/calinburloiu/music/microtonalist/format/FormatPackageObjectTest.scala
@@ -79,12 +79,12 @@ class FormatPackageObjectTest extends AnyFlatSpec with Matchers {
     // No validation on write
   }
 
-  "resolveLibraryUri" should "resolve an URI with microtonalist scheme" in {
+  "resolveLibraryUrl" should "resolve an URI with microtonalist scheme" in {
     val uri = URI("microtonalist:///scales/dorian.scl")
 
-    resolveLibraryUri(uri, URI("file:///Users/grey/Music/Library/")) shouldEqual URI(
+    resolveLibraryUrl(uri, URI("file:///Users/grey/Music/Library/")) shouldEqual URI(
       "file:///Users/grey/Music/Library/scales/dorian.scl")
-    resolveLibraryUri(uri, URI("https://microtonalist.org/library/grey/")) shouldEqual URI(
+    resolveLibraryUrl(uri, URI("https://microtonalist.org/library/grey/")) shouldEqual URI(
       "https://microtonalist.org/library/grey/scales/dorian.scl")
   }
 
@@ -92,18 +92,18 @@ class FormatPackageObjectTest extends AnyFlatSpec with Matchers {
     val uri = URI("scales/dorian.scl")
 
     assertThrows[IllegalArgumentException] {
-      resolveLibraryUri(uri, URI("file:///Users/grey/Music/Library/")) shouldEqual uri
+      resolveLibraryUrl(uri, URI("file:///Users/grey/Music/Library/")) shouldEqual uri
     }
   }
 
   it should "fail for URIs that don't have a microtonalist scheme" in {
-    val libraryBaseUri = URI("file:///Users/grey/Music/Library/")
+    val libraryBaseUrl = URI("file:///Users/grey/Music/Library/")
 
     assertThrows[IllegalArgumentException] {
-      resolveLibraryUri(URI("file:///Users/grey/Music/Library/scales/dorian.scl"), libraryBaseUri)
+      resolveLibraryUrl(URI("file:///Users/grey/Music/Library/scales/dorian.scl"), libraryBaseUrl)
     }
     assertThrows[IllegalArgumentException] {
-      resolveLibraryUri(URI("https://microtonalist.org/library/grey/scales/dorian.scl"), libraryBaseUri)
+      resolveLibraryUrl(URI("https://microtonalist.org/library/grey/scales/dorian.scl"), libraryBaseUrl)
     }
   }
 }

--- a/format/src/test/scala/org/calinburloiu/music/microtonalist/format/JsonCompositionFormatTest.scala
+++ b/format/src/test/scala/org/calinburloiu/music/microtonalist/format/JsonCompositionFormatTest.scala
@@ -105,7 +105,7 @@ class JsonCompositionFormatTest extends AnyFlatSpec with Matchers with Inside wi
     composition.tuningSpecs.head.transposition shouldEqual EdoInterval(72, (4, -1))
     composition.tuningSpecs.head.scale shouldEqual EdoScale("segah-3", 72, (0, 0), (1, 1), (3, 1))
 
-    composition.tracksUriOverride shouldEqual None
+    composition.tracksUrlOverride shouldEqual None
   }
 
   it should "successfully read an in-context scale with just intonation intervals in 72-EDO intonation standard" in {
@@ -248,27 +248,27 @@ class JsonCompositionFormatTest extends AnyFlatSpec with Matchers with Inside wi
     )
   }
 
-  it should "populate the URI of a composition when reading it from one" in {
+  it should "populate the URL of a composition when reading it from one" in {
     val composition = readCompositionFromResources("format/minor-major.mtlist", compositionRepo)
 
-    val uri = composition.uri
-    uri.isDefined shouldBe true
-    uri.get.getScheme shouldEqual "file"
-    uri.get.toString should include("minor-major.mtlist")
+    val url = composition.url
+    url.isDefined shouldBe true
+    url.get.getScheme shouldEqual "file"
+    url.get.toString should include("minor-major.mtlist")
 
-    composition.tracksUriOverride shouldBe empty
+    composition.tracksUrlOverride shouldBe empty
 
-    val tracksUri = composition.tracksUri
-    tracksUri.isDefined shouldBe true
-    tracksUri.get.getScheme shouldEqual "file"
-    tracksUri.get.toString should include("minor-major.mtlist.tracks")
+    val tracksUrl = composition.tracksUrl
+    tracksUrl.isDefined shouldBe true
+    tracksUrl.get.getScheme shouldEqual "file"
+    tracksUrl.get.toString should include("minor-major.mtlist.tracks")
   }
 
-  it should "read tracksUri override" in {
-    val composition = readCompositionFromResources("format/tracksUriOverride.mtlist", compositionRepo)
+  it should "read tracksUrl override" in {
+    val composition = readCompositionFromResources("format/tracksUrlOverride.mtlist", compositionRepo)
 
     val expectedUri = new URI("file:///Users/john/tracks.mtlist")
-    composition.tracksUriOverride should contain(expectedUri)
-    composition.tracksUri should contain(expectedUri)
+    composition.tracksUrlOverride should contain(expectedUri)
+    composition.tracksUrl should contain(expectedUri)
   }
 }

--- a/json-schemas/v1/composition/composition.schema.json
+++ b/json-schemas/v1/composition/composition.schema.json
@@ -14,7 +14,7 @@
         "metadata": { "$ref": "compositionMetadata.schema.json" },
         "intonationStandard": { "$ref": "../common/intonationStandard.schema.json" },
         "tuningReference": { "$ref": "tuningReference.schema.json" },
-      "baseUrl": {
+        "baseUrl": {
             "type": "string",
             "title": "Base URL",
             "description": "Custom base URL to be used for all internal URLs in this file. For local files this property allows changing the current directory.",
@@ -54,7 +54,7 @@
         },
         "fill": { "$ref": "#/$defs/fill" },
         "tuningReducer": { "$ref": "tuningReducer.schema.json" },
-      "tracksUrl": {
+        "tracksUrl": {
             "type": "string",
             "title": "Tracks URL",
             "description": "Optional URL for the Tracks file. If not provided, the \".tracks\" extension is appended to the composition URL. E.g. Composition with URL \"file:///path/to/composition.mtlist\" has the default Tracks file with URL \"file:///path/to/composition.mtlist.tracks\".",

--- a/json-schemas/v1/composition/composition.schema.json
+++ b/json-schemas/v1/composition/composition.schema.json
@@ -14,7 +14,7 @@
         "metadata": { "$ref": "compositionMetadata.schema.json" },
         "intonationStandard": { "$ref": "../common/intonationStandard.schema.json" },
         "tuningReference": { "$ref": "tuningReference.schema.json" },
-        "baseUri": {
+      "baseUrl": {
             "type": "string",
             "title": "Base URI",
             "description": "Custom base URI to be used for all internal URIs in this file. For local files this property allows changing the current directory.",
@@ -54,7 +54,7 @@
         },
         "fill": { "$ref": "#/$defs/fill" },
         "tuningReducer": { "$ref": "tuningReducer.schema.json" },
-        "tracksUri": {
+      "tracksUrl": {
             "type": "string",
             "title": "Tracks URI",
             "description": "Optional URI for the Tracks file. If not provided, the \".tracks\" extension is appended to the composition URI. E.g. Composition with URI \"file:///path/to/composition.mtlist\" has the default Tracks file with URI \"file:///path/to/composition.mtlist.tracks\".",

--- a/json-schemas/v1/composition/composition.schema.json
+++ b/json-schemas/v1/composition/composition.schema.json
@@ -16,8 +16,8 @@
         "tuningReference": { "$ref": "tuningReference.schema.json" },
       "baseUrl": {
             "type": "string",
-            "title": "Base URI",
-            "description": "Custom base URI to be used for all internal URIs in this file. For local files this property allows changing the current directory.",
+            "title": "Base URL",
+            "description": "Custom base URL to be used for all internal URLs in this file. For local files this property allows changing the current directory.",
             "format": "uri-reference"
         },
         "definitions": {
@@ -28,7 +28,7 @@
                 "scales": {
                     "type": "object",
                     "title": "Scale Definitions",
-                    "description": "Key-value pairs, where keys are scale identifiers to be referenced in other sections of the composition file, and values are scale definitions which include both inline scale or an external URI for the scale. Keys should only use basic Latin letters, numbers, hyphens and underscores.",
+                    "description": "Key-value pairs, where keys are scale identifiers to be referenced in other sections of the composition file, and values are scale definitions which include both inline scale or an external URL for the scale. Keys should only use basic Latin letters, numbers, hyphens and underscores.",
                     "patternProperties": {
                         "^[\\w\\-_]+$": { "$ref": "../scale/scale-inContext.schema.json" }
                     },
@@ -56,8 +56,8 @@
         "tuningReducer": { "$ref": "tuningReducer.schema.json" },
       "tracksUrl": {
             "type": "string",
-            "title": "Tracks URI",
-            "description": "Optional URI for the Tracks file. If not provided, the \".tracks\" extension is appended to the composition URI. E.g. Composition with URI \"file:///path/to/composition.mtlist\" has the default Tracks file with URI \"file:///path/to/composition.mtlist.tracks\".",
+            "title": "Tracks URL",
+            "description": "Optional URL for the Tracks file. If not provided, the \".tracks\" extension is appended to the composition URL. E.g. Composition with URL \"file:///path/to/composition.mtlist\" has the default Tracks file with URL \"file:///path/to/composition.mtlist.tracks\".",
             "format": "uri-reference"
         },
         "settings": {
@@ -132,7 +132,7 @@
             "oneOf": [
                 { "$ref": "tuningSpec.schema.json" },
                 {
-                    "$comment": "A URI fragment that references a tuning spec declared locally.",
+                    "$comment": "A URL fragment that references a tuning spec declared locally.",
                     "type": "string",
                     "pattern": "^#[\\w\\-_]+$"
                 }

--- a/json-schemas/v1/scale/scale-inContext.schema.json
+++ b/json-schemas/v1/scale/scale-inContext.schema.json
@@ -12,7 +12,7 @@
             "items": { "$ref": "pitch.schema.json" }
         },
         {
-            "$comment": "A URI for the scale.",
+            "$comment": "A URL for the scale.",
             "type": "string",
             "format": "uri-reference"
         }


### PR DESCRIPTION
* In composition files:
    - `baseUri` is renamed to `baseUrl`
    - `tracksUri` is renamed to `tracksUrl`
* In configuration files:
    - `libraryBaseUri` is renamed to `libraryBaseUrl`.