### PR TITLE
Add Claude Code development support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,13 @@ project/plugins/project/
 .cache
 .lib/
 .bsp/
+.bloop/
+project/.bloop/
+
+# Metals MCP
+.metals/
+project/metals.sbt
+project/project/
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
@@ -67,3 +74,8 @@ fabric.properties
 
 # Sample JSON
 json-schemas/v1/samples/
+
+# Claude Code
+.claude/worktrees/
+.mcp.json
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,33 @@ At the start of every conversation, check whether the Metals MCP is available by
 - **Find usages** — find all references to a symbol across the project (`mcp__metals__get-usages`)
 - **Read source** — retrieve source of any symbol on the classpath, including JDK and library classes (
   `mcp__metals__get-source`)
-- **Read docs** — retrieve ScalaDoc for any symbol (`mcp__metals__get-docs`)
+- **Read docs** — retrieve ScalaDoc/JavaDoc for any symbol (`mcp__metals__get-docs`)
 - **Compile** — compile the full project or a single module (`mcp__metals__compile-full`, `mcp__metals__compile-module`)
 - **Dependency lookup** — find available versions of Maven dependencies via Coursier (`mcp__metals__find-dep`)
+
+Prefer the Metals MCP over calling `sbt` processes for compiling code as detailed in the Build section below.
+
+Prefer the Metals MCP over `grep` for symbol inspection, symbol search, finding usages, and understanding class/trait
+hierachy. Use symbol search to reduce duplicated code by finding already implemented functionality. Use the read docs
+functionality to understand external code.
+
+## Symbol search file focus
+
+`mcp__metals__glob-search` and `mcp__metals__typed-glob-search` require a `fileInFocus` parameter — they cannot infer
+the build target without it. The search scope is limited to the classpath of the inferred build target, so always use a
+file from a module with the broadest classpath.
+
+The top-level modules and the representative files to use as `fileInFocus` for project-wide symbol searches are:
+
+- `app` — covers `appConfig`, `businessync`, `common`, `composition`, `intonation`, `format`, `scMidi`, `tuner`, `ui`:
+  `app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala`
+- `cli` — separate executable covering `scMidi`; may contain symbols not in `app`:
+  `cli/src/main/scala/org/calinburloiu/music/microtonalist/cli/MicrotonalistToolApp.scala`
+- `experiments` — separate executable covering `intonation`; may contain symbols not in `app`:
+  `experiments/src/main/scala/org/calinburloiu/music/microtonalist/experiments/SoftChromaticGenusStudy.scala`
+
+For a full project-wide search, query all three in parallel. Only use a lower-level module file when intentionally
+scoping the search to that module's classpath.
 
 # Build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,355 @@
+# AGENTS.md / CLAUDE.md
+
+This file provides guidance to coding agents (e.g. Claude Code) when working with code in this repository.
+
+Microtonalist is a microtuner application that allows tuning musical keyboards and synthesizers in real-time for playing
+music with microtones. It supports various protocols for tuning output instruments like MIDI Tuning Standard (MTS),
+Monophonic Pitch Bend and MIDI Polyphonic Expression (MPE). It is built as a stand-alone multi-platform desktop
+application that runs on JVM. The code is written in Scala 3.
+
+# Build
+
+The repository is built using SBT 1, Scala 3 and Java 23. It is split in multiple SBT projects that act as modules,
+libraries or separate executable applications. Each project is in the repository root. Check `build.sbt` for details.
+The `root` SBT project aggregates all the other projects. The executable application is in `app` SBT project.
+
+Compiling the whole `root` project:
+
+```bash
+sbt compile
+```
+
+Building the fat JAR for the executable application:
+
+```bash
+sbt assembly
+```
+
+It is recommended to compile, build or test the whole project before committing changes.
+
+For small changes, it is recommended to only compile individual SBT projects.
+
+Compiling a single SBT project `${PROJECT}`:
+
+```bash
+sbt "${PROJECT}/compile"
+```
+
+# Test
+
+Tests and production code follow the default Scala and SBT directory structure. For each SBT project, production code is
+in `src/main/scala` and tests are in `src/test/scala`. Tests are written using ScalaTest 3. Use `src/test/resources` for
+test data if necessary.
+
+Conventionally, the tests for a given production class use the same package and class name is suffixed with `Test`. For
+example, the test class for `org.calinburloiu.music.intonation.RatioInterval` is
+`org.calinburloiu.music.intonation.RatioIntervalTest`.
+
+Running all tests:
+
+```bash
+sbt test
+```
+
+For small changes, it is recommended to only test individual files or SBT projects.
+
+Testing a single SBT project `${PROJECT}`:
+
+```bash
+sbt "${PROJECT}/test"
+```
+
+Testing a single test class `${CLASS}` (declared with fully qualified name) in an SBT project `${PROJECT}`:
+
+```bash
+sbt "${PROJECT}/testOnly ${CLASS}"
+```
+
+For example:
+
+```bash
+sbt "intonation/testOnly org.calinburloiu.music.intonation.RatioIntervalTest"
+```
+
+# Architecture
+
+## Module Overview
+
+The project uses a layered module structure. Dependency direction flows from `app` downward:
+
+```
+app
+├── ui            (GUI, depends on tuner)
+├── composition   (domain model, depends on intonation + tuner)
+├── format        (JSON/file I/O, depends on composition + tuner)
+├── tuner         (MIDI tuning, depends on sc-midi + businessync)
+├── sc-midi       (Java MIDI wrappers, depends on businessync)
+├── intonation    (interval math, no application deps)
+├── businessync   (event bus + threading, no application deps)
+├── common        (shared utilities)
+└── config        (HOCON config, depends on common)
+```
+
+`cli` is a separate executable (utility tool) that depends only on `sc-midi`.
+
+## Key Domain Concepts
+
+**Intonation (`intonation` module, `org.calinburloiu.music.intonation`):**
+
+- `Interval` (sealed trait) — base for `RatioInterval`, `CentsInterval`, `EdoInterval`, `RealInterval`; all support
+  arithmetic in logarithmic space and conversion to cents
+- `Scale[I <: Interval]` — ordered sequence of intervals with direction, helper methods for relative intervals and
+  softness (entropy)
+- `IntonationStandard` — enum-like sealed trait describing how intervals are expressed (`CentsIntonationStandard`,
+  `JustIntonationStandard`, `EdoIntonationStandard`)
+
+**Composition (`composition` module, `org.calinburloiu.music.microtonalist.composition`):**
+
+- `Composition` — top-level container: holds an `IntonationStandard`, a `TuningReference`, a sequence of `TuningSpec`, a
+  `TuningReducer`, and fill configuration
+- `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
+- `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
+
+**Tuner (`tuner` module, `org.calinburloiu.music.microtonalist.tuner`):**
+
+- `Tuning` — 12 optional cent offsets for pitch classes; `Tuning.Standard` is 12-EDO
+- `Tuner` (trait, Plugin) — processes MIDI messages: `reset()`, `tune(tuning)`, `process(message)`; implementations
+  cover all MTS Octave variants, MPE and monophonic tuning via Pitch Bend
+- `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages (e.g.,
+  `PedalTuningChanger`)
+- `Track` — one instrument pipeline: input device → `TuningChangeProcessor` → `TunerProcessor` → output device
+- `TuningSession` / `TuningService` — holds current tuning index and exposes thread-safe API for changing it
+- `TrackManager` — lifecycle manager for tracks; reacts to MIDI device events
+
+**Plugin pattern:** `Tuner`, `TuningMapper`, `TuningReducer`, `TuningReference`, and `TuningChanger` all extend
+`Plugin` (from `common`). Each plugin has a `familyName` and `typeName` used for JSON (de)serialization via Play JSON.
+
+## Threading Model (Businessync)
+
+`Businessync` (`businessync` module) manages two threads:
+
+- **Business thread** — all domain/MIDI logic; annotate handlers with `@Subscribe` and call `businessync.run {}`
+- **UI thread** — all GUI updates; use `businessync.runOnUi {}`
+
+Cross-thread calls use `businessync.callAsync`. Never mutate domain state from the UI thread directly.
+
+## Data Flow
+
+```
+JSON composition file
+  → DefaultCompositionRepo (format module)
+  → Composition
+  → TuningList.fromComposition()   (applies TuningMapper, TuningReducer, fill)
+  → TuningSession.tunings
+  → TuningIndexUpdatedEvent (via Businessync)
+  → TrackManager → Track.tune()
+  → TunerProcessor → Tuner
+  → MTS/MPE MIDI messages
+  → MIDI output device
+```
+
+## Format / Serialization
+
+All file I/O is in the `format` module (`org.calinburloiu.music.microtonalist.format`). Key types:
+
+- `CompositionFormat` / `CompositionRepo` — reads JSON `.mtlist` composition files
+- `ScaleFormat` / `ScaleRepo` — reads embedded JSON `.jscl` scales or Huygens-Fokker `.scl` files; scales can be inlined
+  or referenced by URI
+- `TrackFormat` / `TrackRepo` — reads `.mtlist.tracks` JSON files
+- `JsonPreprocessor` — resolves `$ref`-style URIs (file or HTTP) before parsing
+- `FormatModule` — lazy-initializes all repos/formats; inject this rather than constructing individual components
+
+## Application Entry Point
+
+`MicrotonalistApp` (`app` module) wires everything:
+
+1. Parses CLI args (composition URI, optional config file)
+2. Creates `Businessync` and starts business thread
+3. Builds `FormatModule`, loads `Composition`, builds `TuningList`
+4. Builds `TunerModule`, loads tracks
+5. Opens `TuningListFrame` (Swing GUI)
+6. Registers JVM shutdown hook for cleanup
+
+Application config (HOCON) lives at `~/.microtonalist/microtonalist.conf` on macOS.
+
+# Coding Conventions
+
+* Indentation is done with 2 spaces.
+* Lines have a maximum length of 120 characters.
+* Currently, we use IntelliJ IDEA for formatting code with the default settings.
+* All public identifiers (classes, methods, fields, etc.) are properly documented via ScalaDocs.
+
+## Follow the TDD cycle: red/green/refactor
+
+Use strict Test Driven Development (TDD) by following the red/green/refactor cycle.
+
+Write a failing test first — if the compiler requires it, create the thinnest possible stub (`???` bodies, no logic) to
+get it to compile, then confirm the test fails for the right reason. Write only enough production code to make it pass,
+no more. Once green, refactor the structure and naming freely, keeping the suite green throughout. Never write logic
+without a preceding failing test, never commit red production code, and never mix refactoring with behavioral changes.
+
+## Use brace syntax
+
+Use the old classic brace Scala syntax, not the new indentation Scala 3 syntax.
+
+Wrong:
+
+```scala
+case class Person(name: String, age: Int):
+  def greet: String = s"Hi, I'm $name"
+```
+
+Correct:
+
+```scala
+case class Person(name: String, age: Int) {
+  def greet: String = s"Hi, I'm $name"
+}
+```
+
+## Use `enum`
+
+Use Scala 3 `enum` instead of `sealed trait` for simple enumerations.
+
+Wrong:
+
+```scala
+sealed trait MpeInputMode
+
+case object NonMpe extends MpeInputMode
+
+case object Mpe extends MpeInputMode
+```
+
+Correct:
+
+```scala
+enum MpeInputMode {
+  case NonMpe
+  case Mpe
+}
+```
+
+## Avoid `case class` for mutable data structures
+
+Avoid using case classes for data structures that expose mutable fields.
+
+Wrong:
+
+```scala
+case class ActiveNote(midiNote: MidiNote,
+                      var expressivePitchBend: Int = 0)
+```
+
+Correct:
+
+```scala
+class ActiveNote(val midiNote: MidiNote,
+                 var expressivePitchBend: Int = 0)
+```
+
+## TODOs have issue numbers
+
+All TODOs in the code use `// TODO #<issue_number>`, where `<issue_number>` is the issue number on the project's GitHub
+repository: https://github.com/calinburloiu/microtonalist
+
+Wrong:
+
+```scala
+// TODO Add support for Windows
+```
+
+Correct:
+
+```scala
+// TODO #149 Add support for Windows
+```
+
+## Prefer for-comprehensions for nested monads
+
+Using a deep chain of `flatMap`, `map`, ..., `map` for nested monads can be hard to follow. Prefer for-comprehensions
+for them.
+
+Wrong:
+
+```scala
+val optionsList: List[Option[Int]] = List(Some(1), None, Some(2))
+optionsList.flatMap(list => list.map(item => item * 2))
+```
+
+Correct:
+
+```scala
+val optionsList: List[Option[Int]] = List(Some(1), None, Some(2))
+for {
+  itemOption <- optionsList
+  item <- itemOption
+} yield item * 2
+```
+
+## Avoid `new` when instantiating a class
+
+Wrong:
+
+```scala
+val c = new MyClass(x, y)
+```
+
+Correct:
+
+```scala
+val c = MyClass(x, y)
+```
+
+## No `return`
+
+The `return` statement is deprecated in Scala 3. When a Scala idiomatic approach is cumbersome, use a `boundary.break`
+instead. A typical case is an early return, an initial condition in a method, where a Scala idiomatic `if` would cause
+most of the code to be overindented.
+
+Wrong:
+
+```scala
+class C {
+  def method(): Int = {
+    if (notValid) {
+      return -1
+    }
+
+    // Large block of code
+    // ...
+  }
+}
+```
+
+Correct:
+
+```scala
+class C {
+  def method(): Int = boundary {
+    if (notValid) {
+      boundary.break(-1)
+    }
+
+    // Large block of code
+    // ...
+  }
+}
+```
+
+## Class private internal backing variables for public getter / setter
+
+If a class has a public getter or setter that is backed by an internal `private` or `protected` variable, use the same
+name for the interval variable with the getter / setter but prefixed by an underscore.
+
+```scala
+class C {
+  private var _value: Int
+
+  def value: Int = _value
+
+  def value_=(newValue: Int): Unit = {
+    _value = newValue
+  }
+}
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,42 @@ music with microtones. It supports various protocols for tuning output instrumen
 Monophonic Pitch Bend and MIDI Polyphonic Expression (MPE). It is built as a stand-alone multi-platform desktop
 application that runs on JVM. The code is written in Scala 3.
 
+# Metals MCP
+
+At the start of every conversation, check whether the Metals MCP is available by attempting to call
+`mcp__metals__list-modules`. If it is available, you have the following capabilities through it:
+
+- **Symbol inspection** — inspect classes, traits, objects, and methods by fully qualified name (`mcp__metals__inspect`)
+- **Symbol search** — search for symbols by name glob (`mcp__metals__glob-search`) or by type (
+  `mcp__metals__typed-glob-search`)
+- **Find usages** — find all references to a symbol across the project (`mcp__metals__get-usages`)
+- **Read source** — retrieve source of any symbol on the classpath, including JDK and library classes (
+  `mcp__metals__get-source`)
+- **Read docs** — retrieve ScalaDoc for any symbol (`mcp__metals__get-docs`)
+- **Compile** — compile the full project or a single module (`mcp__metals__compile-full`, `mcp__metals__compile-module`)
+- **Dependency lookup** — find available versions of Maven dependencies via Coursier (`mcp__metals__find-dep`)
+
 # Build
 
-The repository is built using SBT 1, Scala 3 and Java 23. It is split in multiple SBT projects that act as modules,
-libraries or separate executable applications. Each project is in the repository root. Check `build.sbt` for details.
+The repository is built using SBT 1, Scala 3, and Java 23. It is split into multiple SBT projects that act as modules,
+libraries, or separate executable applications. Each project is in the repository root. Check `build.sbt` for details.
 The `root` SBT project aggregates all the other projects. The executable application is in `app` SBT project.
+
+## Metals MCP warm-up
+
+At the start of every conversation, if the Metals MCP is available, run a full compile via `mcp__metals__compile-full`
+to warm up the Metals index. This ensures SemanticDB is populated so that symbol resolution, find-usages, and other
+semantic tools work correctly from the first query. Require sbt to be running as a BSP server beforehand (the user is
+responsible for that).
+
+## Compiling
+
+Prefer the Metals MCP for compiling when it is available:
+
+- Compile the whole project: `mcp__metals__compile-full`
+- Compile a single module `${MODULE}`: `mcp__metals__compile-module` with `module = "${MODULE}"`
+
+Fall back to `sbt` only when the Metals MCP is not available, or for a final full build or fat JAR assembly:
 
 Compiling the whole `root` project:
 
@@ -25,11 +56,11 @@ Building the fat JAR for the executable application:
 sbt assembly
 ```
 
-It is recommended to compile, build or test the whole project before committing changes.
+It is recommended to compile, build, or test the whole project before committing changes.
 
 For small changes, it is recommended to only compile individual SBT projects.
 
-Compiling a single SBT project `${PROJECT}`:
+Compiling a single SBT project `${PROJECT}` via sbt:
 
 ```bash
 sbt "${PROJECT}/compile"
@@ -44,6 +75,8 @@ test data if necessary.
 Conventionally, the tests for a given production class use the same package and class name is suffixed with `Test`. For
 example, the test class for `org.calinburloiu.music.intonation.RatioInterval` is
 `org.calinburloiu.music.intonation.RatioIntervalTest`.
+
+Currently, Metals MCP cannot run tests with this setup (with SBT and BSP). So run all tests by starting `sbt` processes.
 
 Running all tests:
 
@@ -114,7 +147,7 @@ app
 
 - `Tuning` — 12 optional cent offsets for pitch classes; `Tuning.Standard` is 12-EDO
 - `Tuner` (trait, Plugin) — processes MIDI messages: `reset()`, `tune(tuning)`, `process(message)`; implementations
-  cover all MTS Octave variants, MPE and monophonic tuning via Pitch Bend
+  cover all MTS Octave variants, MPE, and monophonic tuning via Pitch Bend
 - `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages (e.g.,
   `PedalTuningChanger`)
 - `Track` — one instrument pipeline: input device → `TuningChangeProcessor` → `TunerProcessor` → output device

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/development-setup/metals-mcp-claude-code.md
+++ b/docs/development-setup/metals-mcp-claude-code.md
@@ -95,7 +95,7 @@ running for the entire Claude Code session — when you Ctrl-C it, the MCP serve
 
 ```bash
 cd ~/Development/microtonalist
-metals-standalone-client --verbose .
+metals-standalone-client --verbose . -- -Dmetals.mcpClient=claude
 ```
 
 What happens behind the scenes:

--- a/docs/development-setup/metals-mcp-claude-code.md
+++ b/docs/development-setup/metals-mcp-claude-code.md
@@ -1,18 +1,27 @@
-# Metals MCP with Claude Code (SBT as BSP)
+# Metals MCP with Claude Code (headless, SBT as BSP)
 
-This guide explains how to install [Scala Metals](https://scalameta.org/metals/) and configure
-its built-in MCP (Model Context Protocol) server so that [Claude Code](https://claude.com/claude-code)
-can use Metals' Scala language intelligence (compile, find references, inspect symbols, etc.)
-while working in this repository. Metals is configured to use **SBT as its BSP server**, so the
-build state stays consistent with what `sbt` produces on the command line — important for a
-multi-module project like Microtonalist.
+This guide explains how to run [Scala Metals](https://scalameta.org/metals/) **headlessly**
+(without a graphical editor) so that its built-in MCP (Model Context Protocol) server is
+available to [Claude Code](https://claude.com/claude-code) inside this repository. Metals is
+configured to use **SBT as its BSP server**, so Metals' compilation state stays consistent
+with what `sbt` produces on the command line — important for a multi-module project like
+Microtonalist.
+
+The Metals language server itself does not (yet) ship a first-class "just start the MCP
+server on this folder" command — it expects an LSP client (an editor) to drive it. To avoid
+needing VS Code or any other editor, this guide uses the community
+[`metals-standalone-client`](https://github.com/jpablo/metals-standalone-client), which acts
+as a tiny headless LSP host whose only job is to start Metals, enable its MCP server, and
+keep the session alive. This is the path explicitly endorsed by the Metals maintainers in
+the [v1.6.1 Osmium release notes](https://scalameta.org/metals/blog/2025/07/31/osmium/).
 
 ## 1. Prerequisites
 
 - JDK 23 (the same JDK used to build the project — see `CLAUDE.md`).
-- [Coursier](https://get-coursier.io/docs/cli-installation) (`cs`) — used to install Metals.
+- [Coursier](https://get-coursier.io/docs/cli-installation) (`cs`) — used to fetch Metals.
 - SBT 1.x (already used by this project).
-- Claude Code CLI (`claude`) installed and on `PATH`.
+- Claude Code CLI (`claude`) on `PATH`.
+- macOS (the commands below use the macOS pre-built binary; Linux equivalents exist).
 
 Verify:
 
@@ -25,72 +34,85 @@ claude --version
 
 ## 2. Install Metals
 
-Install the Metals language server via Coursier. Metals 1.5.x or later is required for the
-MCP server feature (introduced in the Strontium release).
+Install the Metals language server via Coursier. Metals 1.6.x or later is recommended for
+the standalone-MCP path.
 
 ```bash
 cs install metals
-```
-
-This puts a `metals` launcher on `PATH`. Check the version:
-
-```bash
 metals --version
 ```
 
-If you already have an older Metals installed (e.g. via an editor extension), update it the
-same way; the MCP server only ships in recent versions.
+If you already have an older Metals (e.g. via an editor extension), update it the same way.
 
-## 3. Make SBT the BSP server
+## 3. Install `metals-standalone-client`
+
+Install the macOS pre-built binary into a directory on your `PATH`:
+
+```bash
+mkdir -p ~/.local/bin
+curl -L -o ~/.local/bin/metals-standalone-client \
+  https://github.com/jpablo/metals-standalone-client/releases/latest/download/metals-standalone-client-macos-executable
+chmod +x ~/.local/bin/metals-standalone-client
+```
+
+(Alternative: clone the repo and run `scala-cli run .` from inside it. That requires
+`scala-cli` on `PATH` and is mostly useful if you want to track `main`.)
+
+You can pin a specific Metals version through an env var, e.g.
+`METALS_VERSION=1.6.5 metals-standalone-client …`.
+
+## 4. Make sure SBT is the BSP server for this workspace
 
 Microtonalist already contains `.bsp/sbt.json`, so SBT is the registered BSP server for the
-workspace. If that file ever goes missing, you can regenerate it from the project root with:
+workspace and Metals will pick it up automatically. If that file is ever missing, regenerate
+it from the project root with:
 
 ```bash
 sbt bspConfig
 ```
 
-To make sure Metals always picks SBT (instead of Bloop) for any newly opened workspace, set
-the following in your **global** Metals user settings (see
-[Metals user configuration](https://scalameta.org/metals/docs/editors/user-configuration/)):
+Using SBT (instead of Bloop) as the BSP server matters because — as the Metals docs note —
+it guarantees that whether you compile from the editor, from the terminal, or via an MCP
+tool call from Claude, everything sees the same compilation state.
 
-```json
-{
-  "metals.defaultBspToBuildTool": true
-}
+## 5. Warm up SBT (optional but recommended)
+
+In a dedicated terminal, start an SBT shell from the repo root and leave it open for the
+duration of your Claude Code session:
+
+```bash
+cd ~/Development/microtonalist
+sbt
 ```
 
-In VS Code this goes into `settings.json`. For other editors, the same key is exposed by the
-Metals language server via `workspace/didChangeConfiguration`. Keeping the build tool as the
-BSP server matters because — as the Metals docs note — it guarantees that whether you compile
-from the editor, the terminal, or via an MCP tool call from Claude, everything sees the same
-compilation state.
+When Metals connects via BSP it will reuse this server, which makes the initial workspace
+import noticeably faster and keeps incremental compiles snappy.
 
-## 4. Enable the Metals MCP server
+## 6. Start Metals headlessly with the standalone client
 
-In the same Metals user settings, enable the MCP server and tell Metals which client will
-connect to it:
+In a second terminal, from the repo root, launch the standalone client. Keep this process
+running for the entire Claude Code session — when you Ctrl-C it, the MCP server goes away.
 
-```json
-{
-  "metals.defaultBspToBuildTool": true,
-  "metals.startMcpServer": true,
-  "metals.mcpClient": "claude"
-}
+```bash
+cd ~/Development/microtonalist
+metals-standalone-client --verbose .
 ```
 
-- `startMcpServer` makes Metals start an HTTP/SSE MCP endpoint when it opens a workspace.
-- `mcpClient: "claude"` tells Metals to write a Claude-compatible config file
-  (`.mcp.json`) into the workspace root so Claude Code can auto-discover the server.
+What happens behind the scenes:
 
-After saving the settings, **reload / restart Metals** in your editor so it picks up the new
-configuration and imports the SBT build via BSP. Watch the Metals log — it will print the
-local URL the MCP server is listening on (something like `http://localhost:54640/sse`).
+1. The client discovers / launches Metals as a subprocess via Coursier.
+2. It performs the LSP `initialize` / `initialized` handshake over stdin/stdout.
+3. It pushes the user settings `startMcpServer: true` and `mcpClient: claude` into Metals.
+4. Metals imports the build through BSP — using SBT, because of `.bsp/sbt.json` — and
+   starts its built-in MCP server on a chosen local port.
+5. Metals writes a `.mcp.json` file at the repo root containing the URL Claude should use.
+6. The standalone client keeps the LSP session alive and health-checks the MCP endpoint.
 
-## 5. Verify the generated `.mcp.json`
+Watch the console for the URL and for any BSP import errors.
 
-Once Metals has started inside the Microtonalist workspace, it will create a `.mcp.json` file
-at the repository root that looks roughly like this:
+## 7. Verify the generated `.mcp.json`
+
+After Metals has imported the build, a `.mcp.json` will appear at the repo root, roughly:
 
 ```json
 {
@@ -103,76 +125,100 @@ at the repository root that looks roughly like this:
 }
 ```
 
-The port is chosen dynamically — don't hard-code it. You may want to add `.mcp.json` to
-`.gitignore` (or to your global gitignore) since the URL is local and machine-specific.
+The port is chosen dynamically and changes between runs — don't hard-code it. Add `.mcp.json`
+to your local / global gitignore since it's machine- and session-specific.
 
-## 6. Connect Claude Code
+## 8. Connect Claude Code
 
-From the Microtonalist project root, launch Claude Code:
+In a third terminal, launch Claude Code from the repo root:
 
 ```bash
 cd ~/Development/microtonalist
 claude
 ```
 
-On first launch in this workspace, Claude Code detects `.mcp.json` and prompts you to
-authorize the newly discovered `metals` MCP server. Approve it and choose to remember the
-choice for the workspace. You can confirm the server is connected with:
+On first launch Claude Code detects `.mcp.json` and prompts you to authorize the newly
+discovered `metals` server. Approve it (and optionally save the choice for the workspace).
+Confirm the connection inside Claude Code with:
 
 ```
 /mcp
 ```
 
-inside Claude Code — `metals` should appear in the list with its tools enabled.
+`metals` should appear in the list with its tools available.
 
-## 7. What you get
+## 9. What you get
 
-The Metals MCP server exposes a small set of Scala-aware tools that Claude Code can call,
-including (names may vary across Metals versions):
+Once connected, Claude Code can call Metals' MCP tools, including (names may vary slightly
+across Metals versions):
 
-- `compile-file` / `compile-module` — compile a single file or a whole module via BSP/SBT and
+- `compile-file` / `compile-module` — compile a chosen file or build target via BSP/SBT and
   return diagnostics.
-- `find-usages` / `find-references` — locate where a symbol is used.
-- `inspect` — get type / signature information for a Scala symbol.
-- `test` — run tests for a target.
+- `test` — run a Scala test suite (single class identified by its fully-qualified name; the
+  MCP equivalent of `sbt "intonation/testOnly org.calinburloiu.music.intonation.RatioIntervalTest"`).
+- `inspect` / `get-docs` / `get-usages` — Scala-aware symbol inspection, documentation, and
+  reference search.
+- `glob-search` / `typed-glob-search` — symbol search across the workspace.
+- `import-build` — re-import the build after changes to `build.sbt` or `project/*.sbt`.
+- `find-dep` — search for dependencies via Coursier.
 
-Because BSP is backed by SBT, a `compile-file` call after a previous successful `sbt compile`
-returns almost instantly with either success or precise error diagnostics, which Claude can
-then act on.
+Because BSP is backed by SBT, a `compile-file` after a previous successful compile returns
+almost instantly with success or precise diagnostics, which Claude can then act on.
 
-## 8. Recommended workflow with this repo
+## 10. Recommended workflow with this repo
 
-1. Run `sbt` once in a separate terminal so the SBT server is warm — Metals will reuse it via
-   BSP and incremental compiles stay fast.
-2. Open Claude Code in the project root.
-3. Ask Claude to make changes; it will compile via Metals MCP rather than spawning fresh
-   `sbt compile` shells.
-4. For tests, you can still invoke them the way `CLAUDE.md` recommends, e.g.
-   `sbt "intonation/testOnly org.calinburloiu.music.intonation.RatioIntervalTest"`, or let
-   Claude use Metals' `test` tool when appropriate.
+1. Terminal A — `sbt` shell, kept warm.
+2. Terminal B — `metals-standalone-client --verbose .`, kept running.
+3. Terminal C — `claude`, your interactive session.
+4. Let Claude prefer the Metals MCP tools (`compile-file`, `compile-module`, `test`,
+   `inspect`, `get-usages`) over shelling out to `sbt`. Fall back to the `sbt` commands in
+   `CLAUDE.md` for full builds (`sbt assembly`), running the `app`/`cli` executables, or
+   anything sensitive to JVM startup (e.g. options in `.sbtopts`).
+5. After editing `build.sbt` or `project/*.sbt`, ask Claude to call `import-build` (or
+   restart the standalone client) so Metals re-imports.
 
-## 9. Troubleshooting
+## 11. Troubleshooting
 
 - **Claude Code doesn't see the server.** Make sure `.mcp.json` exists at the workspace root
   and that you launched `claude` from that directory. Run `/mcp` to inspect the connection.
-- **Metals didn't write `.mcp.json`.** Confirm `metals.startMcpServer` is `true` and
-  `metals.mcpClient` is `"claude"`, then restart the Metals server. Check the Metals output
-  log for the chosen port.
-- **BSP imports Bloop instead of SBT.** Delete the `.bloop/` directory, ensure
-  `.bsp/sbt.json` exists, set `metals.defaultBspToBuildTool: true`, and re-import the build
-  from your editor's Metals command palette.
-- **Compile errors that don't match `sbt compile`.** Almost always means BSP is not actually
-  talking to SBT. Re-run `sbt bspConfig` and re-import.
-- **Stale state after large refactors.** From an editor command palette run
-  *Metals: Restart build server*, or just stop/start the SBT shell and re-import.
+  If the standalone client was killed, the URL in `.mcp.json` is stale.
+- **`metals-standalone-client` exits immediately.** Re-run with `--verbose` and check that
+  Coursier can reach the network and that the configured `METALS_VERSION` exists.
+- **BSP imports Bloop instead of SBT.** Delete the `.bloop/` directory, ensure `.bsp/sbt.json`
+  exists (`sbt bspConfig` to regenerate), and restart the standalone client.
+- **Compile errors that don't match `sbt compile`.** Almost always means BSP isn't actually
+  talking to SBT. Re-run `sbt bspConfig` and restart the standalone client.
+- **Stale state after large refactors or `build.sbt` edits.** Stop the standalone client,
+  stop the warm `sbt` shell, and start both again. Then ask Claude to call `import-build`.
+- **Port already in use.** Kill any leftover Metals JVMs (`jps` / `pkill -f metals`) and
+  re-run the standalone client.
+
+## 12. Alternative: editor-driven setup
+
+If you ever do want to drive Metals from an editor instead of headlessly, the only changes
+are:
+
+- Skip steps 3 and 6 (no `metals-standalone-client`).
+- In your editor's Metals user settings, set:
+  ```json
+  {
+    "metals.defaultBspToBuildTool": true,
+    "metals.startMcpServer": true,
+    "metals.mcpClient": "claude"
+  }
+  ```
+- Open the workspace in the editor; Metals will write the same `.mcp.json` as in step 7.
+
+Everything from step 8 onward is identical.
 
 ## References
 
 - [Metals user configuration](https://scalameta.org/metals/docs/editors/user-configuration/)
-- [Metals v1.5.3 — Strontium release notes (MCP server)](https://scalameta.org/metals/blog/2025/05/13/strontium/)
+- [Metals v1.5.3 — Strontium release notes (MCP server introduction)](https://scalameta.org/metals/blog/2025/05/13/strontium/)
+- [Metals v1.6.1 — Osmium release notes (standalone MCP support)](https://scalameta.org/metals/blog/2025/07/31/osmium/)
 - [Metals blog](https://scalameta.org/metals/blog/)
 - [sbt BSP support in Metals](https://scalameta.org/metals/blog/2020/11/06/sbt-BSP-support/)
+- [`metals-standalone-client` on GitHub](https://github.com/jpablo/metals-standalone-client)
 - [Claude Code, Metals, and NVIM — Chris Kipp](https://www.chris-kipp.io/blog/claude-code-metals-and-nvim)
 - [A Beginner's Guide to Using Scala Metals With its MCP Server — SoftwareMill](https://softwaremill.com/a-beginners-guide-to-using-scala-metals-with-its-model-context-protocol-server/)
 - [Adding an MCP server to Claude Code — MCPcat](https://mcpcat.io/guides/adding-an-mcp-server-to-claude-code/)
-- [`metals-standalone-client` (alternative headless runner)](https://github.com/jpablo/metals-standalone-client)

--- a/docs/development-setup/metals-mcp-claude-code.md
+++ b/docs/development-setup/metals-mcp-claude-code.md
@@ -1,0 +1,178 @@
+# Metals MCP with Claude Code (SBT as BSP)
+
+This guide explains how to install [Scala Metals](https://scalameta.org/metals/) and configure
+its built-in MCP (Model Context Protocol) server so that [Claude Code](https://claude.com/claude-code)
+can use Metals' Scala language intelligence (compile, find references, inspect symbols, etc.)
+while working in this repository. Metals is configured to use **SBT as its BSP server**, so the
+build state stays consistent with what `sbt` produces on the command line — important for a
+multi-module project like Microtonalist.
+
+## 1. Prerequisites
+
+- JDK 23 (the same JDK used to build the project — see `CLAUDE.md`).
+- [Coursier](https://get-coursier.io/docs/cli-installation) (`cs`) — used to install Metals.
+- SBT 1.x (already used by this project).
+- Claude Code CLI (`claude`) installed and on `PATH`.
+
+Verify:
+
+```bash
+java -version
+cs --version
+sbt --version
+claude --version
+```
+
+## 2. Install Metals
+
+Install the Metals language server via Coursier. Metals 1.5.x or later is required for the
+MCP server feature (introduced in the Strontium release).
+
+```bash
+cs install metals
+```
+
+This puts a `metals` launcher on `PATH`. Check the version:
+
+```bash
+metals --version
+```
+
+If you already have an older Metals installed (e.g. via an editor extension), update it the
+same way; the MCP server only ships in recent versions.
+
+## 3. Make SBT the BSP server
+
+Microtonalist already contains `.bsp/sbt.json`, so SBT is the registered BSP server for the
+workspace. If that file ever goes missing, you can regenerate it from the project root with:
+
+```bash
+sbt bspConfig
+```
+
+To make sure Metals always picks SBT (instead of Bloop) for any newly opened workspace, set
+the following in your **global** Metals user settings (see
+[Metals user configuration](https://scalameta.org/metals/docs/editors/user-configuration/)):
+
+```json
+{
+  "metals.defaultBspToBuildTool": true
+}
+```
+
+In VS Code this goes into `settings.json`. For other editors, the same key is exposed by the
+Metals language server via `workspace/didChangeConfiguration`. Keeping the build tool as the
+BSP server matters because — as the Metals docs note — it guarantees that whether you compile
+from the editor, the terminal, or via an MCP tool call from Claude, everything sees the same
+compilation state.
+
+## 4. Enable the Metals MCP server
+
+In the same Metals user settings, enable the MCP server and tell Metals which client will
+connect to it:
+
+```json
+{
+  "metals.defaultBspToBuildTool": true,
+  "metals.startMcpServer": true,
+  "metals.mcpClient": "claude"
+}
+```
+
+- `startMcpServer` makes Metals start an HTTP/SSE MCP endpoint when it opens a workspace.
+- `mcpClient: "claude"` tells Metals to write a Claude-compatible config file
+  (`.mcp.json`) into the workspace root so Claude Code can auto-discover the server.
+
+After saving the settings, **reload / restart Metals** in your editor so it picks up the new
+configuration and imports the SBT build via BSP. Watch the Metals log — it will print the
+local URL the MCP server is listening on (something like `http://localhost:54640/sse`).
+
+## 5. Verify the generated `.mcp.json`
+
+Once Metals has started inside the Microtonalist workspace, it will create a `.mcp.json` file
+at the repository root that looks roughly like this:
+
+```json
+{
+  "mcpServers": {
+    "metals": {
+      "url": "http://localhost:54640/sse",
+      "type": "sse"
+    }
+  }
+}
+```
+
+The port is chosen dynamically — don't hard-code it. You may want to add `.mcp.json` to
+`.gitignore` (or to your global gitignore) since the URL is local and machine-specific.
+
+## 6. Connect Claude Code
+
+From the Microtonalist project root, launch Claude Code:
+
+```bash
+cd ~/Development/microtonalist
+claude
+```
+
+On first launch in this workspace, Claude Code detects `.mcp.json` and prompts you to
+authorize the newly discovered `metals` MCP server. Approve it and choose to remember the
+choice for the workspace. You can confirm the server is connected with:
+
+```
+/mcp
+```
+
+inside Claude Code — `metals` should appear in the list with its tools enabled.
+
+## 7. What you get
+
+The Metals MCP server exposes a small set of Scala-aware tools that Claude Code can call,
+including (names may vary across Metals versions):
+
+- `compile-file` / `compile-module` — compile a single file or a whole module via BSP/SBT and
+  return diagnostics.
+- `find-usages` / `find-references` — locate where a symbol is used.
+- `inspect` — get type / signature information for a Scala symbol.
+- `test` — run tests for a target.
+
+Because BSP is backed by SBT, a `compile-file` call after a previous successful `sbt compile`
+returns almost instantly with either success or precise error diagnostics, which Claude can
+then act on.
+
+## 8. Recommended workflow with this repo
+
+1. Run `sbt` once in a separate terminal so the SBT server is warm — Metals will reuse it via
+   BSP and incremental compiles stay fast.
+2. Open Claude Code in the project root.
+3. Ask Claude to make changes; it will compile via Metals MCP rather than spawning fresh
+   `sbt compile` shells.
+4. For tests, you can still invoke them the way `CLAUDE.md` recommends, e.g.
+   `sbt "intonation/testOnly org.calinburloiu.music.intonation.RatioIntervalTest"`, or let
+   Claude use Metals' `test` tool when appropriate.
+
+## 9. Troubleshooting
+
+- **Claude Code doesn't see the server.** Make sure `.mcp.json` exists at the workspace root
+  and that you launched `claude` from that directory. Run `/mcp` to inspect the connection.
+- **Metals didn't write `.mcp.json`.** Confirm `metals.startMcpServer` is `true` and
+  `metals.mcpClient` is `"claude"`, then restart the Metals server. Check the Metals output
+  log for the chosen port.
+- **BSP imports Bloop instead of SBT.** Delete the `.bloop/` directory, ensure
+  `.bsp/sbt.json` exists, set `metals.defaultBspToBuildTool: true`, and re-import the build
+  from your editor's Metals command palette.
+- **Compile errors that don't match `sbt compile`.** Almost always means BSP is not actually
+  talking to SBT. Re-run `sbt bspConfig` and re-import.
+- **Stale state after large refactors.** From an editor command palette run
+  *Metals: Restart build server*, or just stop/start the SBT shell and re-import.
+
+## References
+
+- [Metals user configuration](https://scalameta.org/metals/docs/editors/user-configuration/)
+- [Metals v1.5.3 — Strontium release notes (MCP server)](https://scalameta.org/metals/blog/2025/05/13/strontium/)
+- [Metals blog](https://scalameta.org/metals/blog/)
+- [sbt BSP support in Metals](https://scalameta.org/metals/blog/2020/11/06/sbt-BSP-support/)
+- [Claude Code, Metals, and NVIM — Chris Kipp](https://www.chris-kipp.io/blog/claude-code-metals-and-nvim)
+- [A Beginner's Guide to Using Scala Metals With its MCP Server — SoftwareMill](https://softwaremill.com/a-beginners-guide-to-using-scala-metals-with-its-model-context-protocol-server/)
+- [Adding an MCP server to Claude Code — MCPcat](https://mcpcat.io/guides/adding-an-mcp-server-to-claude-code/)
+- [`metals-standalone-client` (alternative headless runner)](https://github.com/jpablo/metals-standalone-client)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,10 +21,10 @@ object Dependencies {
   val coreMidi4jVersion = "1.6"
   val ficusVersion = "1.5.2"
   val guavaVersion = "33.4.0-jre"
-  val logbackVersion = "1.5.17"
+  val logbackVersion = "1.5.32"
   val playJsonVersion = "3.0.4"
   val scalaLoggingVersion = "3.9.5"
-  val scalaMockVersion = "7.2.0"
+  val scalaMockVersion = "7.5.5"
   val scalaTestVersion = "3.2.19"
 
   // # Dependency definitions

--- a/scripts/development/README.md
+++ b/scripts/development/README.md
@@ -1,0 +1,101 @@
+# `scripts/development/`
+
+Helper scripts for local development of Microtonalist. Each script is documented
+in its own section below.
+
+## `start-metals-mcp.sh`
+
+Launches [Scala Metals](https://scalameta.org/metals/) headlessly for this
+workspace so that [Claude Code](https://claude.com/claude-code) can use its MCP
+(Model Context Protocol) tools. See
+[`docs/development-setup/metals-mcp-claude-code.md`](../../docs/development-setup/metals-mcp-claude-code.md)
+for background and prerequisites (Metals, Coursier, `metals-standalone-client`).
+
+The script starts two background processes and then blocks:
+
+1. `sbt` — an interactive SBT shell that also hosts SBT's BSP server, so Metals
+   can reuse a single warm SBT process.
+2. `metals-standalone-client --verbose . -- -Dmetals.mcpClient=claude` — drives
+   Metals as a headless LSP client and makes Metals write `.mcp.json` at the
+   repo root for Claude Code to pick up.
+
+Once `.mcp.json` is written, the script warms up the build by sending `compile`
+to the running SBT shell (SBT and Metals share the same BSP state, so this
+also warms what Metals' MCP tools later see).
+
+Output goes to three log files under `logs/` at the repo root:
+
+- `logs/sbt.log`
+- `logs/metals-standalone-client.log`
+- `logs/start-metals-mcp.log` (only when run in the background, see below)
+
+Older logs are discarded on each run.
+
+### Run in the foreground
+
+From the repo root:
+
+```bash
+./scripts/development/start-metals-mcp.sh
+```
+
+The script blocks until you stop it. Press **Ctrl-C** to shut it down — the
+trap will stop both background processes and remove the FIFO it uses for SBT's
+stdin.
+
+### Run in the background
+
+```bash
+nohup ./scripts/development/start-metals-mcp.sh > logs/start-metals-mcp.log 2>&1 &
+echo $! > logs/start-metals-mcp.pid
+disown
+```
+
+- `nohup` prevents SIGHUP from killing the script when the terminal closes.
+- `> logs/start-metals-mcp.log 2>&1` captures the wrapper's stdout/stderr.
+  (The two per-process logs are still written to `logs/sbt.log` and
+  `logs/metals-standalone-client.log`.)
+- `echo $! > logs/start-metals-mcp.pid` records the PID so you can stop it
+  later.
+- `disown` removes the job from the shell's job table so closing the shell
+  won't affect it.
+
+Tail the logs to follow progress:
+
+```bash
+tail -f logs/start-metals-mcp.log
+tail -f logs/metals-standalone-client.log
+tail -f logs/sbt.log
+```
+
+### Stopping a background run
+
+Use default `kill` (which sends **SIGTERM**):
+
+```bash
+kill "$(cat logs/start-metals-mcp.pid)" && rm logs/start-metals-mcp.pid
+```
+
+The script's trap will then:
+
+1. Kill `metals-standalone-client`.
+2. Send `exit` to SBT via the FIFO it uses as SBT's stdin, wait a few seconds,
+   and force-kill SBT if it hasn't stopped.
+3. Remove the FIFO under `logs/`.
+
+**Do not use `kill -INT`** to stop a backgrounded run. When bash backgrounds a
+job with `&`, it pre-sets SIGINT to `SIG_IGN` for the child, and POSIX says a
+signal ignored on entry to a shell cannot be re-trapped — so the script's
+`trap … INT` is silently a no-op for backgrounded invocations and `kill -INT`
+does nothing. SIGTERM (the default) is unaffected and triggers the trap
+normally.
+
+**Avoid `kill -9` / `kill -KILL`** — it bypasses the trap, leaving SBT,
+`metals-standalone-client`, the FIFO, and a stale `.mcp.json` behind. Only use
+it as a last resort, and then clean up manually:
+
+```bash
+pkill -f metals-standalone-client
+pkill -f 'sbt$'
+rm -f .mcp.json logs/.sbt-stdin.fifo logs/start-metals-mcp.pid
+```

--- a/scripts/development/start-metals-mcp.sh
+++ b/scripts/development/start-metals-mcp.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Calin-Andrei Burloiu
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+# start-metals-mcp.sh — launch Metals MCP headlessly for this workspace.
+#
+# Starts, as background processes:
+#   1. `sbt` (interactive shell), which also hosts SBT's BSP server so Metals
+#      can reuse a single warm SBT process.
+#   2. `metals-standalone-client --verbose . -- -Dmetals.mcpClient=claude`,
+#      which drives Metals as a headless LSP client and makes Metals write
+#      `.mcp.json` at the repo root for Claude Code to pick up.
+#
+# Output of both processes is captured into `logs/*.log` at the repo root.
+# Older logs are discarded on each run.
+#
+# Once `.mcp.json` has appeared, the script optionally warms up the build by
+# sending `compile` to the running SBT shell. Because SBT and Metals share the
+# same BSP/SBT state, this also warms what Metals' MCP tools see.
+#
+# The script blocks until interrupted (Ctrl-C or SIGTERM) or until one of the
+# background processes exits. On shutdown it stops both background processes.
+#
+# See docs/development-setup/metals-mcp-claude-code.md for the full setup.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+cd "$repo_root"
+
+logs_dir="$repo_root/logs"
+sbt_log="$logs_dir/sbt.log"
+metals_log="$logs_dir/metals-standalone-client.log"
+sbt_fifo="$logs_dir/.sbt-stdin.fifo"
+
+log() { echo "[start-metals-mcp] $*"; }
+err() { echo "[start-metals-mcp] $*" >&2; }
+
+# Sanity-check required commands.
+for cmd in sbt metals-standalone-client; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    err "Required command not found on PATH: $cmd"
+    exit 1
+  fi
+done
+
+mkdir -p "$logs_dir"
+
+# Discard older logs.
+rm -f "$sbt_log" "$metals_log"
+
+# Recreate the FIFO used as SBT's stdin so SBT stays alive and we can push
+# commands (e.g. `compile`, `exit`) into it.
+rm -f "$sbt_fifo"
+mkfifo "$sbt_fifo"
+
+sbt_pid=""
+metals_pid=""
+sbt_fd_open=0
+
+cleanup() {
+  trap - EXIT INT TERM
+  echo
+  log "Stopping background processes..."
+
+  if [[ -n "$metals_pid" ]] && kill -0 "$metals_pid" 2>/dev/null; then
+    kill "$metals_pid" 2>/dev/null || true
+  fi
+
+  if [[ -n "$sbt_pid" ]] && kill -0 "$sbt_pid" 2>/dev/null; then
+    # Ask SBT to exit cleanly via its stdin FIFO, then close the FD so SBT
+    # sees EOF if it ignored the `exit` command.
+    if [[ "$sbt_fd_open" -eq 1 ]]; then
+      echo "exit" >&9 2>/dev/null || true
+      exec 9>&- 2>/dev/null || true
+      sbt_fd_open=0
+    fi
+    # Give SBT a few seconds to stop on its own, then force it.
+    for _ in 1 2 3 4 5; do
+      kill -0 "$sbt_pid" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "$sbt_pid" 2>/dev/null; then
+      kill "$sbt_pid" 2>/dev/null || true
+    fi
+  fi
+
+  # Make sure the FD is released even if SBT was never started.
+  if [[ "$sbt_fd_open" -eq 1 ]]; then
+    exec 9>&- 2>/dev/null || true
+    sbt_fd_open=0
+  fi
+
+  rm -f "$sbt_fifo"
+  wait 2>/dev/null || true
+  log "Done."
+}
+trap cleanup EXIT INT TERM
+
+log "Repo root: $repo_root"
+log "Logs:      $logs_dir"
+
+# Start SBT first so that it becomes the FIFO's reader. Opening a FIFO for
+# read-only blocks until a writer appears, and opening for write-only blocks
+# until a reader appears — so we must have the reader (SBT) in progress before
+# we open the writer end below. Backgrounded SBT's stdin redirection will
+# block on open() until the parent opens FD 9 for writing.
+log "Starting SBT (log: $sbt_log)..."
+sbt <"$sbt_fifo" >"$sbt_log" 2>&1 &
+sbt_pid=$!
+log "SBT PID: $sbt_pid"
+
+# Now open the write end. This rendezvous unblocks both SBT's read-open and
+# our own write-open. FD 9 stays open for the lifetime of the script so SBT
+# never sees EOF on its stdin; we also use it to push commands (e.g. the
+# warm-up `compile` and the shutdown `exit`).
+exec 9>"$sbt_fifo"
+sbt_fd_open=1
+
+log "Starting metals-standalone-client (log: $metals_log)..."
+metals-standalone-client --verbose . -- -Dmetals.mcpClient=claude \
+  >"$metals_log" 2>&1 &
+metals_pid=$!
+log "metals-standalone-client PID: $metals_pid"
+
+# Wait for Metals to write .mcp.json, then warm up the build.
+mcp_file="$repo_root/.mcp.json"
+log "Waiting for $mcp_file to be written by Metals..."
+for _ in $(seq 1 180); do
+  if [[ -f "$mcp_file" ]]; then
+    log "$mcp_file is ready."
+    break
+  fi
+  if ! kill -0 "$metals_pid" 2>/dev/null; then
+    err "metals-standalone-client exited; see $metals_log"
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ -f "$mcp_file" ]]; then
+  # Warm up: ask the running SBT shell to do a full compile. SBT and Metals
+  # share the same BSP state, so this also warms what Metals' MCP tools see.
+  # (A proper MCP `compile-full` call would require speaking JSON-RPC over SSE,
+  # which is impractical from a shell script.)
+  log "Warming up: sending 'compile' to SBT..."
+  echo "compile" >&9 || true
+else
+  err "Warning: $mcp_file did not appear within timeout; skipping warm-up."
+fi
+
+echo
+log "Metals MCP is running."
+log "  Tail SBT log:    tail -f $sbt_log"
+log "  Tail Metals log: tail -f $metals_log"
+log "Launch Claude Code from $repo_root in another terminal and run /mcp to verify."
+log "Press Ctrl-C to stop."
+
+# Block until either child exits (or until we are signalled).
+while kill -0 "$sbt_pid" 2>/dev/null && kill -0 "$metals_pid" 2>/dev/null; do
+  sleep 2
+done
+
+log "A background process exited. Shutting down."


### PR DESCRIPTION
## Summary

This PR establishes first-class Claude Code support for the Microtonalist repository. It introduces the agent guide (`AGENTS.md` / `CLAUDE.md`) that gives Claude Code the context it needs to work effectively in this codebase, and then extends that support with deep Scala integration via the [Scala Metals](https://scalameta.org/metals/) MCP server.

### Changes

- **`AGENTS.md`** (new) — The primary agent-facing guide, read by Claude Code at the start of every conversation. Covers project overview, Metals MCP capabilities, build/test instructions, module architecture, data flow, and all coding conventions (TDD cycle, brace syntax, enum usage, etc.).

- **`CLAUDE.md`** (new symlink → `AGENTS.md`) — Symlink so Claude Code picks up the guide under its conventional filename without duplicating content.

- **`docs/development-setup/metals-mcp-claude-code.md`** (new) — Step-by-step setup guide for running Metals headlessly via [`metals-standalone-client`](https://github.com/jpablo/metals-standalone-client) with SBT as the BSP server, connecting it to Claude Code, and troubleshooting common problems.

- **`scripts/development/start-metals-mcp.sh`** (new) — Shell script that automates the full startup sequence: launches an SBT shell (which also hosts the BSP server), starts `metals-standalone-client`, waits for `.mcp.json` to be written, and then warms up the build by sending `compile` to the running SBT process.

- **`scripts/development/README.md`** (new) — Documents the `start-metals-mcp.sh` script, including foreground/background usage, log locations, and how to stop a backgrounded run safely.

- **`.gitignore`** — Added entries for Metals/Bloop generated files (`.bloop/`, `.metals/`, `project/metals.sbt`, `project/project/`), the session-specific `.mcp.json`, and Claude Code worktrees (`.claude/worktrees/`).

### How it fits together

`AGENTS.md` is the foundation: it tells Claude Code who it is working with, how the project is structured, and how to behave. The Metals MCP integration then elevates Claude from a text-based assistant to a semantically-aware Scala developer — it can compile, inspect symbols, trace usages, and get real diagnostics without ever leaving the conversation.

```
Terminal A: sbt (warm BSP server)
Terminal B: metals-standalone-client → drives Metals headlessly → writes .mcp.json
Terminal C: claude (reads AGENTS.md, connects to Metals MCP via .mcp.json)
```

Because SBT is the BSP server, compilation state is shared between `sbt compile`, Metals' MCP `compile-full`, and any direct `sbt` invocations — so diagnostics seen by Claude always match what the terminal build sees.

### Metals MCP tools available to Claude

- `compile-full` / `compile-module` — compile with real SBT diagnostics
- `inspect` / `get-docs` / `get-usages` — semantic symbol analysis
- `glob-search` / `typed-glob-search` — symbol search across the workspace
- `get-source` — read source for any symbol on the classpath (including JDK/libraries)
- `find-dep` — dependency version lookup via Coursier
- `list-modules` — enumerate build modules