### PR TITLE
[#167] Use ScMidiChannelStateTracker in monophonic and MPE tuners

### DIFF
--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
@@ -19,7 +19,7 @@ package org.calinburloiu.music.microtonalist.tuner
 import com.typesafe.scalalogging.StrictLogging
 import org.calinburloiu.music.scmidi.message.*
 import org.calinburloiu.music.scmidi.message.JavaMidiConverters.*
-import org.calinburloiu.music.scmidi.{MidiNote, PitchBendSensitivity, PitchBendSensitivityMessages, clampValue, mapShortMessageChannel}
+import org.calinburloiu.music.scmidi.{MidiNote, PitchBendSensitivity, PitchBendSensitivityMessages, ScMidiChannelStateTracker, clampValue, mapShortMessageChannel}
 
 import javax.sound.midi.{MidiMessage, ShortMessage}
 import scala.collection.mutable
@@ -39,12 +39,14 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   require(0 <= outputChannel && outputChannel <= 15,
     s"Output MIDI channel must be between 0 and 15, but was $outputChannel!")
 
+  import MonophonicPitchBendTuner.TrackedChannel
+
   override val typeName: String = MonophonicPitchBendTuner.TypeName
 
   private var _currTuning: Tuning = Tuning.Standard
   private var _pitchBendSensitivity: PitchBendSensitivity = defaultPitchBendSensitivity
 
-  private val noteStack: mutable.Stack[MidiNote] = mutable.Stack()
+  private val tracker: ScMidiChannelStateTracker = ScMidiChannelStateTracker()
   private var _lastSingleNote: MidiNote = 0
 
   /** Pitch bend applied by the performer to the current note before applying the extra tuning value */
@@ -56,11 +58,6 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   private var _lastNoteOnVelocity = NoteOnScMidiMessage.DefaultVelocity
   private var _lastNoteOffVelocity = NoteOffScMidiMessage.DefaultVelocity
 
-  private var _sustainPedal: Int = 0
-  private var _sostenutoPedal: Int = 0
-  private var _rpnLsb: Int = ScMidiRpn.NullLsb
-  private var _rpnMsb: Int = ScMidiRpn.NullMsb
-
   override def reset(): Seq[MidiMessage] = {
     this._resetState()
     this._init()
@@ -69,17 +66,13 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   private def _resetState(): Unit = {
     _currTuning = Tuning.Standard
     _pitchBendSensitivity = defaultPitchBendSensitivity
-    noteStack.clear()
+    tracker.reset()
     _lastSingleNote = 0
     _currExpressionPitchBend = 0
     _currTuningPitchBend = 0
     _unsentPitchBend = false
     _lastNoteOnVelocity = NoteOnScMidiMessage.DefaultVelocity
     _lastNoteOffVelocity = NoteOffScMidiMessage.DefaultVelocity
-    _sustainPedal = 0
-    _sostenutoPedal = 0
-    _rpnLsb = ScMidiRpn.NullLsb
-    _rpnMsb = ScMidiRpn.NullMsb
   }
 
   private def _init(): Seq[MidiMessage] = PitchBendSensitivityMessages.create(
@@ -96,8 +89,9 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     val forwardMessage = () => mapShortMessageChannel(message, _ => outputChannel)
 
     val buffer = mutable.Buffer[MidiMessage]()
+    val scMessage = message.asScala
 
-    message.asScala match {
+    scMessage match {
       case NoteOnScMidiMessage(_, note, 0) =>
         turnNoteOff(buffer, note, 0)
       case NoteOnScMidiMessage(_, note, velocity) =>
@@ -111,18 +105,6 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
       case PitchBendScMidiMessage(_, newExpressionPitchBend) =>
         currExpressionPitchBend = newExpressionPitchBend
         applyPitchBend(buffer)
-      case CcScMidiMessage(_, ScMidiCc.SustainPedal, value) =>
-        _sustainPedal = value
-        buffer += forwardMessage()
-      case CcScMidiMessage(_, ScMidiCc.SostenutoPedal, value) =>
-        _sostenutoPedal = value
-        buffer += forwardMessage()
-      case CcScMidiMessage(_, ScMidiCc.RpnLsb, value) =>
-        _rpnLsb = value
-        buffer += forwardMessage()
-      case CcScMidiMessage(_, ScMidiCc.RpnMsb, value) =>
-        _rpnMsb = value
-        buffer += forwardMessage()
       case CcScMidiMessage(_, ScMidiCc.DataEntryMsb, value) =>
         buffer += forwardMessage()
         applyPitchBendSensitivityMsb(buffer, value)
@@ -133,7 +115,22 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
         buffer += forwardMessage()
     }
 
+    sendToTracker(scMessage)
     buffer.toSeq
+  }
+
+  private def sendToTracker(scMessage: ScMidiMessage): Unit = {
+    val normalized = scMessage match {
+      case m: NoteOnScMidiMessage => m.copy(channel = TrackedChannel)
+      case m: NoteOffScMidiMessage => m.copy(channel = TrackedChannel)
+      case m: PitchBendScMidiMessage => m.copy(channel = TrackedChannel)
+      case m: CcScMidiMessage => m.copy(channel = TrackedChannel)
+      case m: ChannelPressureScMidiMessage => m.copy(channel = TrackedChannel)
+      case m: PolyPressureScMidiMessage => m.copy(channel = TrackedChannel)
+      case m: ProgramChangeScMidiMessage => m.copy(channel = TrackedChannel)
+      case m => m
+    }
+    tracker.send(normalized)
   }
 
   private def currTuning: Tuning = _currTuning
@@ -149,7 +146,8 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def isSettingPitchBendSensitivity: Boolean =
-    _rpnLsb == ScMidiRpn.PitchBendSensitivityLsb && _rpnMsb == ScMidiRpn.PitchBendSensitivityMsb
+    tracker.rpnSelector(TrackedChannel) == ScMidiChannelStateTracker.RpnSelector.Rpn(
+      ScMidiRpn.PitchBendSensitivityMsb, ScMidiRpn.PitchBendSensitivityLsb)
 
   private def applyPitchBendSensitivityMsb(buffer: mutable.Buffer[MidiMessage], value: Int): Unit = {
     if (isSettingPitchBendSensitivity) {
@@ -176,9 +174,10 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     }
   }
 
-  private def lastNote: MidiNote = noteStack.headOption.getOrElse(_lastSingleNote)
+  private def lastNote: MidiNote =
+    tracker.orderedActiveNotes(TrackedChannel).lastOption.getOrElse(_lastSingleNote)
 
-  private def isAnyNoteOn: Boolean = noteStack.nonEmpty
+  private def isAnyNoteOn: Boolean = tracker.orderedActiveNotes(TrackedChannel).nonEmpty
 
   private def applyNoteOn(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int): Unit = {
     _lastNoteOnVelocity = velocity
@@ -196,8 +195,6 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     interruptPedals(buffer)
     applyPitchBend(buffer)
     applyNoteOn(buffer, note, velocity)
-
-    noteStack.push(note)
   }
 
   private def applyNoteOff(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int): Unit = {
@@ -213,33 +210,29 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def turnNoteOff(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int): Unit = {
-    if (!isAnyNoteOn) {
-      // Unexpected note off message! According to the internal state no note is known to be on.
-      return
-    }
-
-    if (note == noteStack.head) {
+    val notes = tracker.orderedActiveNotes(TrackedChannel)
+    if (notes.nonEmpty && notes.last == note) {
       applyNoteOff(buffer, note, velocity)
 
-      val oldOffset = currTuning(lastNote.pitchClass)
-      noteStack.pop()
-      // Play the next note from the top of the stack if available
-      if (isAnyNoteOn) {
-        val newOffset = currTuning(lastNote.pitchClass)
+      val oldOffset = currTuning(note.pitchClass)
+      val notesAfter = notes.init
+      // Play the next note from the previous one held down, if available
+      if (notesAfter.nonEmpty) {
+        val newLast = notesAfter.last
+        val newOffset = currTuning(newLast.pitchClass)
         if (oldOffset != newOffset) {
           currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(newOffset, pitchBendSensitivity)
         }
 
         interruptPedals(buffer)
         applyPitchBend(buffer)
-        applyNoteOn(buffer, lastNote, _lastNoteOnVelocity)
+        applyNoteOn(buffer, newLast, _lastNoteOnVelocity)
       } else {
         _lastSingleNote = note
       }
-    } else {
-      // Removed from the tail of the stack
-      noteStack -= note
     }
+    // Otherwise: either no note is on (unexpected note off) or the released note is not the active one;
+    // tracker.send at the end of process will handle removing the note from the active set if needed.
   }
 
   /**
@@ -247,14 +240,17 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
    * by stopping the sustained notes.
    */
   private def interruptPedals(buffer: mutable.Buffer[MidiMessage]): Unit = {
-    if (_sustainPedal > 0) {
+    val sustain = tracker.cc(TrackedChannel, ScMidiCc.SustainPedal, Some(0))
+    if (sustain > 0) {
       buffer += CcScMidiMessage(outputChannel, ScMidiCc.SustainPedal, 0).asJava
-      buffer += CcScMidiMessage(outputChannel, ScMidiCc.SustainPedal, _sustainPedal).asJava
+      buffer += CcScMidiMessage(outputChannel, ScMidiCc.SustainPedal, sustain).asJava
     }
 
-    if (_sostenutoPedal > 0) {
-      // Sostenuto pedal only has effect if depressed after playing a note, so there is no sense in depressing it again
-      _sostenutoPedal = 0
+    val sostenuto = tracker.cc(TrackedChannel, ScMidiCc.SostenutoPedal, Some(0))
+    if (sostenuto > 0) {
+      // Sostenuto pedal only has effect if depressed after playing a note, so there is no sense in depressing it again.
+      // Replay a SostenutoPedal=0 to the tracker to reflect the interrupted state internally.
+      tracker.send(CcScMidiMessage(TrackedChannel, ScMidiCc.SostenutoPedal, 0))
 
       buffer += CcScMidiMessage(outputChannel, ScMidiCc.SostenutoPedal, 0).asJava
     }
@@ -304,4 +300,7 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
 
 object MonophonicPitchBendTuner {
   val TypeName: String = "monophonicPitchBend"
+
+  /** Channel used internally to track per-channel state in the [[ScMidiChannelStateTracker]]. */
+  private val TrackedChannel: Int = 0
 }

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
@@ -94,22 +94,23 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     val scMessage = message.asScala
 
     // `turnNoteOn` / `turnNoteOff` need to know which notes were held down *before* this message.
-    // Capture the pre-state once, then update the tracker so all other reads (CC values, RPN selector,
-    // Channel Pressure, etc.) see fresh state during the rest of the handling.
-    val preNotes = tracker.orderedActiveNotes(trackedChannel)
+    // Capture the pre-message state once, then update the tracker so all other reads (CC values,
+    // RPN selector, Channel Pressure, etc.) see fresh state during the rest of the handling.
+    val prevNotes = tracker.orderedActiveNotes(trackedChannel)
+    val prevLastNote = prevNotes.lastOption.getOrElse(_lastSingleNote)
     sendToTracker(scMessage)
 
     scMessage match {
       case NoteOnScMidiMessage(_, note, 0) =>
-        turnNoteOff(buffer, note, 0, preNotes)
+        turnNoteOff(buffer, note, 0, prevNotes)
       case NoteOnScMidiMessage(_, note, velocity) =>
         // Only monophonic playing is allowed, if a note is on, turn it off
-        if (preNotes.nonEmpty) {
-          applyNoteOff(buffer, preNotes.last, _lastNoteOffVelocity)
+        if (prevNotes.nonEmpty) {
+          applyNoteOff(buffer, prevLastNote, _lastNoteOffVelocity)
         }
-        turnNoteOn(buffer, note, velocity, preNotes)
+        turnNoteOn(buffer, note, velocity, prevLastNote)
       case NoteOffScMidiMessage(_, note, velocity) =>
-        turnNoteOff(buffer, note, velocity, preNotes)
+        turnNoteOff(buffer, note, velocity, prevNotes)
       case PitchBendScMidiMessage(_, newExpressionPitchBend) =>
         currExpressionPitchBend = newExpressionPitchBend
         applyPitchBend(buffer)
@@ -193,11 +194,10 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def turnNoteOn(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int,
-                         preNotes: Seq[MidiNote]): Unit = {
+                         prevLastNote: MidiNote): Unit = {
     // Update currTuningPitchBend by comparing against the tuning offset of the previously held note
-    val prevLast = preNotes.lastOption.getOrElse(_lastSingleNote)
     val newOffset = currTuning(note.pitchClass)
-    if (currTuning(prevLast.pitchClass) != newOffset) {
+    if (currTuning(prevLastNote.pitchClass) != newOffset) {
       currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(newOffset, pitchBendSensitivity)
     }
 
@@ -219,8 +219,8 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def turnNoteOff(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int,
-                          preNotes: Seq[MidiNote]): Unit = {
-    if (preNotes.nonEmpty && preNotes.last == note) {
+                          prevNotes: Seq[MidiNote]): Unit = {
+    if (prevNotes.nonEmpty && prevNotes.last == note) {
       applyNoteOff(buffer, note, velocity)
 
       val oldOffset = currTuning(note.pitchClass)

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
@@ -128,6 +128,16 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def sendToTracker(scMessage: ScMidiMessage): Unit = {
+    // Re-pressing an already-active note must move it to the most-recently-inserted position so
+    // that `tracker.orderedActiveNotes(...).last` continues to reflect the audibly sounding note.
+    // The tracker stores active notes in a `LinkedHashMap`, which keeps the original position
+    // when an existing key is updated, so explicitly remove the note first.
+    scMessage match {
+      case m: NoteOnScMidiMessage if m.velocity > 0 && tracker.isNoteActive(trackedChannel, m.midiNote) =>
+        tracker.send(NoteOffScMidiMessage(trackedChannel, m.midiNote))
+      case _ =>
+    }
+
     val normalized = scMessage match {
       case m: NoteOnScMidiMessage => m.copy(channel = trackedChannel)
       case m: NoteOffScMidiMessage => m.copy(channel = trackedChannel)

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
@@ -39,9 +39,11 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   require(0 <= outputChannel && outputChannel <= 15,
     s"Output MIDI channel must be between 0 and 15, but was $outputChannel!")
 
-  import MonophonicPitchBendTuner.TrackedChannel
-
   override val typeName: String = MonophonicPitchBendTuner.TypeName
+
+  // The tuner is monophonic and channel-agnostic on input, so all incoming messages are normalized to a
+  // single tracker slot. `outputChannel` is reused as that slot — it's already a valid 0..15 channel.
+  private def trackedChannel: Int = outputChannel
 
   private var _currTuning: Tuning = Tuning.Standard
   private var _pitchBendSensitivity: PitchBendSensitivity = defaultPitchBendSensitivity
@@ -91,17 +93,23 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     val buffer = mutable.Buffer[MidiMessage]()
     val scMessage = message.asScala
 
+    // `turnNoteOn` / `turnNoteOff` need to know which notes were held down *before* this message.
+    // Capture the pre-state once, then update the tracker so all other reads (CC values, RPN selector,
+    // Channel Pressure, etc.) see fresh state during the rest of the handling.
+    val preNotes = tracker.orderedActiveNotes(trackedChannel)
+    sendToTracker(scMessage)
+
     scMessage match {
       case NoteOnScMidiMessage(_, note, 0) =>
-        turnNoteOff(buffer, note, 0)
+        turnNoteOff(buffer, note, 0, preNotes)
       case NoteOnScMidiMessage(_, note, velocity) =>
         // Only monophonic playing is allowed, if a note is on, turn it off
-        if (isAnyNoteOn) {
-          applyNoteOff(buffer, lastNote, _lastNoteOffVelocity)
+        if (preNotes.nonEmpty) {
+          applyNoteOff(buffer, preNotes.last, _lastNoteOffVelocity)
         }
-        turnNoteOn(buffer, note, velocity)
+        turnNoteOn(buffer, note, velocity, preNotes)
       case NoteOffScMidiMessage(_, note, velocity) =>
-        turnNoteOff(buffer, note, velocity)
+        turnNoteOff(buffer, note, velocity, preNotes)
       case PitchBendScMidiMessage(_, newExpressionPitchBend) =>
         currExpressionPitchBend = newExpressionPitchBend
         applyPitchBend(buffer)
@@ -115,19 +123,18 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
         buffer += forwardMessage()
     }
 
-    sendToTracker(scMessage)
     buffer.toSeq
   }
 
   private def sendToTracker(scMessage: ScMidiMessage): Unit = {
     val normalized = scMessage match {
-      case m: NoteOnScMidiMessage => m.copy(channel = TrackedChannel)
-      case m: NoteOffScMidiMessage => m.copy(channel = TrackedChannel)
-      case m: PitchBendScMidiMessage => m.copy(channel = TrackedChannel)
-      case m: CcScMidiMessage => m.copy(channel = TrackedChannel)
-      case m: ChannelPressureScMidiMessage => m.copy(channel = TrackedChannel)
-      case m: PolyPressureScMidiMessage => m.copy(channel = TrackedChannel)
-      case m: ProgramChangeScMidiMessage => m.copy(channel = TrackedChannel)
+      case m: NoteOnScMidiMessage => m.copy(channel = trackedChannel)
+      case m: NoteOffScMidiMessage => m.copy(channel = trackedChannel)
+      case m: PitchBendScMidiMessage => m.copy(channel = trackedChannel)
+      case m: CcScMidiMessage => m.copy(channel = trackedChannel)
+      case m: ChannelPressureScMidiMessage => m.copy(channel = trackedChannel)
+      case m: PolyPressureScMidiMessage => m.copy(channel = trackedChannel)
+      case m: ProgramChangeScMidiMessage => m.copy(channel = trackedChannel)
       case m => m
     }
     tracker.send(normalized)
@@ -146,7 +153,7 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def isSettingPitchBendSensitivity: Boolean =
-    tracker.rpnSelector(TrackedChannel) == ScMidiChannelStateTracker.RpnSelector.Rpn(
+    tracker.rpnSelector(trackedChannel) == ScMidiChannelStateTracker.RpnSelector.Rpn(
       ScMidiRpn.PitchBendSensitivityMsb, ScMidiRpn.PitchBendSensitivityLsb)
 
   private def applyPitchBendSensitivityMsb(buffer: mutable.Buffer[MidiMessage], value: Int): Unit = {
@@ -175,9 +182,9 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def lastNote: MidiNote =
-    tracker.orderedActiveNotes(TrackedChannel).lastOption.getOrElse(_lastSingleNote)
+    tracker.orderedActiveNotes(trackedChannel).lastOption.getOrElse(_lastSingleNote)
 
-  private def isAnyNoteOn: Boolean = tracker.orderedActiveNotes(TrackedChannel).nonEmpty
+  private def isAnyNoteOn: Boolean = tracker.orderedActiveNotes(trackedChannel).nonEmpty
 
   private def applyNoteOn(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int): Unit = {
     _lastNoteOnVelocity = velocity
@@ -185,10 +192,12 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     buffer += NoteOnScMidiMessage(outputChannel, note, velocity).asJava
   }
 
-  private def turnNoteOn(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int): Unit = {
-    // Update currTuningPitchBend
+  private def turnNoteOn(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int,
+                         preNotes: Seq[MidiNote]): Unit = {
+    // Update currTuningPitchBend by comparing against the tuning offset of the previously held note
+    val prevLast = preNotes.lastOption.getOrElse(_lastSingleNote)
     val newOffset = currTuning(note.pitchClass)
-    if (currTuning(lastNote.pitchClass) != newOffset) {
+    if (currTuning(prevLast.pitchClass) != newOffset) {
       currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(newOffset, pitchBendSensitivity)
     }
 
@@ -209,13 +218,14 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     }
   }
 
-  private def turnNoteOff(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int): Unit = {
-    val notes = tracker.orderedActiveNotes(TrackedChannel)
-    if (notes.nonEmpty && notes.last == note) {
+  private def turnNoteOff(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int,
+                          preNotes: Seq[MidiNote]): Unit = {
+    if (preNotes.nonEmpty && preNotes.last == note) {
       applyNoteOff(buffer, note, velocity)
 
       val oldOffset = currTuning(note.pitchClass)
-      val notesAfter = notes.init
+      // After tracker.send the released note is gone, so the post-state can be read fresh
+      val notesAfter = tracker.orderedActiveNotes(trackedChannel)
       // Play the next note from the previous one held down, if available
       if (notesAfter.nonEmpty) {
         val newLast = notesAfter.last
@@ -231,8 +241,8 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
         _lastSingleNote = note
       }
     }
-    // Otherwise: either no note is on (unexpected note off) or the released note is not the active one;
-    // tracker.send at the end of process will handle removing the note from the active set if needed.
+    // Otherwise: either no note was on (unexpected note off) or the released note was not the most recent;
+    // the tracker has already removed it on send, so no audible change is needed.
   }
 
   /**
@@ -240,17 +250,17 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
    * by stopping the sustained notes.
    */
   private def interruptPedals(buffer: mutable.Buffer[MidiMessage]): Unit = {
-    val sustain = tracker.cc(TrackedChannel, ScMidiCc.SustainPedal, Some(0))
+    val sustain = tracker.cc(trackedChannel, ScMidiCc.SustainPedal, Some(0))
     if (sustain > 0) {
       buffer += CcScMidiMessage(outputChannel, ScMidiCc.SustainPedal, 0).asJava
       buffer += CcScMidiMessage(outputChannel, ScMidiCc.SustainPedal, sustain).asJava
     }
 
-    val sostenuto = tracker.cc(TrackedChannel, ScMidiCc.SostenutoPedal, Some(0))
+    val sostenuto = tracker.cc(trackedChannel, ScMidiCc.SostenutoPedal, Some(0))
     if (sostenuto > 0) {
       // Sostenuto pedal only has effect if depressed after playing a note, so there is no sense in depressing it again.
       // Replay a SostenutoPedal=0 to the tracker to reflect the interrupted state internally.
-      tracker.send(CcScMidiMessage(TrackedChannel, ScMidiCc.SostenutoPedal, 0))
+      tracker.send(CcScMidiMessage(trackedChannel, ScMidiCc.SostenutoPedal, 0))
 
       buffer += CcScMidiMessage(outputChannel, ScMidiCc.SostenutoPedal, 0).asJava
     }
@@ -300,7 +310,4 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
 
 object MonophonicPitchBendTuner {
   val TypeName: String = "monophonicPitchBend"
-
-  /** Channel used internally to track per-channel state in the [[ScMidiChannelStateTracker]]. */
-  private val TrackedChannel: Int = 0
 }

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -318,7 +318,7 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     ccNumber match {
       // RPN state machine — the selector is tracked by `tracker`; just forward the message
       case ScMidiCc.RpnLsb | ScMidiCc.RpnMsb =>
-        buffer += CcScMidiMessage(inputChannel, ccNumber, ccValue).asJava
+        buffer += msg.asJava
       case ScMidiCc.DataEntryMsb if isMcmRpn && (inputChannel == 0 || inputChannel == 15) =>
         processMcm(buffer, inputChannel, ccValue)
       case ScMidiCc.DataEntryMsb | ScMidiCc.DataEntryLsb if isPbsRpn =>

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -77,14 +77,10 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
   // Track input->output channel mapping for MPE input mode
   private val mpeInputChannelMap: mutable.Map[Int, Int] = mutable.Map.empty
 
-  // Per-input-channel control dimension state used to seed the output Member Channel at Note On
-  // (MPE input mode only). Non-MPE inputs seed Member Channels with neutral defaults.
-  private val channelPressureMap: mutable.Map[Int, Int] = mutable.Map.empty
-  private val channelSlideMap: mutable.Map[Int, Int] = mutable.Map.empty
-
-  // RPN state machine: tracks last received CC#100 (RPN LSB) and CC#101 (RPN MSB) per channel
-  private val rpnLsbState: mutable.Map[Int, Int] = mutable.Map.empty
-  private val rpnMsbState: mutable.Map[Int, Int] = mutable.Map.empty
+  // Per-input-channel state derived from incoming MIDI messages: Channel Pressure, CC #74 (MPE Slide /
+  // timbre), and the RPN selector state machine. Used to seed the output Member Channel at Note On
+  // (MPE input mode only) and to drive the RPN-based protocol for MCM and PBS.
+  private val tracker: ScMidiChannelStateTracker = ScMidiChannelStateTracker()
 
   /**
    * @return current [[MpeZones]] configuration for the Lower and Upper Zones.
@@ -142,10 +138,7 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     _tuning = Tuning.Standard
     noteChannelMap.clear()
     mpeInputChannelMap.clear()
-    channelPressureMap.clear()
-    channelSlideMap.clear()
-    rpnLsbState.clear()
-    rpnMsbState.clear()
+    tracker.reset()
 
     lowerAllocator = createAllocator(lowerZone)
     upperAllocator = createAllocator(upperZone)
@@ -167,8 +160,10 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
 
   private def processShortMessage(message: ShortMessage): Seq[MidiMessage] = {
     val buffer = mutable.Buffer[MidiMessage]()
+    val scMessage = message.asScala
+    tracker.send(scMessage)
 
-    message.asScala match {
+    scMessage match {
       case msg: NoteOnScMidiMessage if msg.velocity > 0 =>
         processNoteOn(buffer, msg)
       case msg: NoteOnScMidiMessage =>
@@ -241,10 +236,10 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
         // across Note boundaries. In non-MPE mode, sender CC #74 / CP arrive on the Master Channel
         // as Zone-level controls, so the Member Channel is initialized to neutral defaults
         // (MPE spec §3.3.5 Initial-64 for CC #74, §3.3.4 CP=0) to avoid double-counting.
-        val slide = if (inputMode == MpeInputMode.Mpe) channelSlideMap.getOrElse(inputChannel, 64) else 64
+        val slide = if (inputMode == MpeInputMode.Mpe) tracker.cc(inputChannel, ScMidiCc.MpeSlide) else 64
         buffer += CcScMidiMessage(outChannel, ScMidiCc.MpeSlide, slide).asJava
 
-        val pressure = if (inputMode == MpeInputMode.Mpe) channelPressureMap.getOrElse(inputChannel, 0) else 0
+        val pressure = if (inputMode == MpeInputMode.Mpe) tracker.channelPressure(inputChannel) else 0
         buffer += ChannelPressureScMidiMessage(outChannel, pressure).asJava
 
         // Note On
@@ -315,18 +310,14 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     val inputChannel = msg.channel
     val ccNumber = msg.number
     val ccValue = msg.value
-    val rpnLsb = rpnLsbState.getOrElse(inputChannel, ScMidiRpn.NullLsb)
-    val rpnMsb = rpnMsbState.getOrElse(inputChannel, ScMidiRpn.NullMsb)
-    val isMcmRpn = rpnMsb == ScMidiRpn.MpeConfigurationMessageMsb && rpnLsb == ScMidiRpn.MpeConfigurationMessageLsb
-    val isPbsRpn = rpnMsb == ScMidiRpn.PitchBendSensitivityMsb && rpnLsb == ScMidiRpn.PitchBendSensitivityLsb
+    val isMcmRpn = tracker.rpnSelector(inputChannel) == ScMidiChannelStateTracker.RpnSelector.Rpn(
+      ScMidiRpn.MpeConfigurationMessageMsb, ScMidiRpn.MpeConfigurationMessageLsb)
+    val isPbsRpn = tracker.rpnSelector(inputChannel) == ScMidiChannelStateTracker.RpnSelector.Rpn(
+      ScMidiRpn.PitchBendSensitivityMsb, ScMidiRpn.PitchBendSensitivityLsb)
 
     ccNumber match {
-      // RPN state machine
-      case ScMidiCc.RpnLsb =>
-        rpnLsbState(inputChannel) = ccValue
-        buffer += CcScMidiMessage(inputChannel, ccNumber, ccValue).asJava
-      case ScMidiCc.RpnMsb =>
-        rpnMsbState(inputChannel) = ccValue
+      // RPN state machine — the selector is tracked by `tracker`; just forward the message
+      case ScMidiCc.RpnLsb | ScMidiCc.RpnMsb =>
         buffer += CcScMidiMessage(inputChannel, ccNumber, ccValue).asJava
       case ScMidiCc.DataEntryMsb if isMcmRpn && (inputChannel == 0 || inputChannel == 15) =>
         processMcm(buffer, inputChannel, ccValue)
@@ -338,7 +329,6 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
       // (MPE spec §2.6: CC #74 is both Note-Level and Zone-Level).
       case ScMidiCc.MpeSlide =>
         if (inputMode == MpeInputMode.Mpe) {
-          channelSlideMap(inputChannel) = ccValue
           forwardToMemberChannel(buffer, inputChannel, CcScMidiMessage(_, ScMidiCc.MpeSlide, ccValue))
         } else {
           forwardOnZoneMasterChannel(buffer, inputChannel, CcScMidiMessage(_, ScMidiCc.MpeSlide, ccValue))
@@ -486,7 +476,6 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
 
     if (inputMode == MpeInputMode.Mpe) {
       // Per-note pressure in MPE input: route to the allocated Member Channel.
-      channelPressureMap(inputChannel) = pressure
       forwardToMemberChannel(buffer, inputChannel, ChannelPressureScMidiMessage(_, pressure))
     } else {
       // Non-MPE input: Channel Pressure applies to all notes on the input channel. Route to the

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/PedalTuningChanger.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/PedalTuningChanger.scala
@@ -148,7 +148,7 @@ object PedalTuningChanger {
             nextTuningCcTrigger: Int = ScMidiCc.SostenutoPedal,
             threshold: Int = DefaultThreshold,
             triggersThru: Boolean = DefaultTriggersThru): PedalTuningChanger = {
-    new PedalTuningChanger(
+    PedalTuningChanger(
       TuningChangeTriggers(next = Some(nextTuningCcTrigger), previous = Some(previousTuningCcTrigger)),
       threshold, triggersThru
     )

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTunerTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTunerTest.scala
@@ -592,4 +592,28 @@ class MonophonicPitchBendTunerTest extends AnyFlatSpec with Matchers with Inside
     inside(outputNotes(3)) { case NoteOffScMidiMessage(_, note, _) => note.number shouldEqual noteA4 }
     inside(outputNotes(4)) { case NoteOnScMidiMessage(_, note, _) => note.number shouldEqual noteBb4 }
   }
+
+  it should "revert to a still-held note after re-pressing then releasing an already-played note" in
+    new Fixture {
+      // Given a microtonal tuning so pitch-bend updates are observable
+      output ++= tuner.tune(customTuning)
+      output.clear()
+
+      // When holding C, then E, then re-articulating C while E is still held, then releasing C
+      output ++= tuner.process(NoteOnScMidiMessage(inputChannel, noteC4).asJava)
+      output ++= tuner.process(NoteOnScMidiMessage(inputChannel, noteE4).asJava)
+      output ++= tuner.process(NoteOnScMidiMessage(inputChannel, noteC4).asJava)
+      output ++= tuner.process(NoteOffScMidiMessage(inputChannel, noteC4).asJava)
+
+      // Then the last release should turn off C and revert to the still-held E
+      val outputNotes: Seq[ScMidiMessage] = filterNotes(scMidiOutput)
+      outputNotes should have size 7
+      inside(outputNotes.head) { case NoteOnScMidiMessage(_, note, _) => note.number shouldEqual noteC4 }
+      inside(outputNotes(1)) { case NoteOffScMidiMessage(_, note, _) => note.number shouldEqual noteC4 }
+      inside(outputNotes(2)) { case NoteOnScMidiMessage(_, note, _) => note.number shouldEqual noteE4 }
+      inside(outputNotes(3)) { case NoteOffScMidiMessage(_, note, _) => note.number shouldEqual noteE4 }
+      inside(outputNotes(4)) { case NoteOnScMidiMessage(_, note, _) => note.number shouldEqual noteC4 }
+      inside(outputNotes(5)) { case NoteOffScMidiMessage(_, note, _) => note.number shouldEqual noteC4 }
+      inside(outputNotes(6)) { case NoteOnScMidiMessage(_, note, _) => note.number shouldEqual noteE4 }
+    }
 }


### PR DESCRIPTION
Resolves #167.

## Summary

Replace per-channel state tracking that `MonophonicPitchBendTuner` and `MpeTuner` had been doing themselves with reads from a `ScMidiChannelStateTracker`. The tracker already understands RPN selectors, CC values, Channel Pressure, and active notes, so the local maps and flags duplicated its work.

### `MonophonicPitchBendTuner`

Removed in favour of tracker reads:
- `noteStack` — replaced with `tracker.orderedActiveNotes(...)`.
- `_sustainPedal`, `_sostenutoPedal` — replaced with `tracker.cc(...)`. For sostenuto, the interrupt path now replays a `SostenutoPedal=0` to the tracker so its internal state mirrors the audible interrupt (the original code achieved this with a manual `_sostenutoPedal = 0`).
- `_rpnLsb`, `_rpnMsb` — replaced with `tracker.rpnSelector(...)`.

Kept (would change behaviour or model):
- `_pitchBendSensitivity` — single global value; the setter detects change to recompute the tuning pitch bend, which doesn't map cleanly to the tracker's per-channel RPN values without restructuring.
- `_lastNoteOnVelocity` / `_lastNoteOffVelocity` — these are the *most recently received* velocities used as defaults for auto-generated note messages, not the per-note velocities the tracker stores.
- `_lastSingleNote` — held over after all notes are released.

Because the tuner is monophonic and the original state was global (channel-agnostic), incoming messages are normalized to a single tracked channel before being sent to the tracker.

### `MpeTuner`

Removed in favour of tracker reads:
- `channelPressureMap` — replaced with `tracker.channelPressure(inputChannel)`.
- `channelSlideMap` — replaced with `tracker.cc(inputChannel, ScMidiCc.MpeSlide)` (the tracker's `DefaultCcValues` already supplies the MPE Initial-64 default).
- `rpnLsbState`, `rpnMsbState` — replaced with `tracker.rpnSelector(inputChannel)`.

Every incoming `ShortMessage` is fed to the tracker at the top of `processShortMessage`.

### Drive-by

Drops a redundant `new` from `PedalTuningChanger.apply`, matching the project convention.

## Test plan

- [x] `sbt "tuner/testOnly org.calinburloiu.music.microtonalist.tuner.MonophonicPitchBendTunerTest"` — 31/31 pass.
- [x] `sbt "tuner/testOnly org.calinburloiu.music.microtonalist.tuner.MpeTunerTest"` — 106/106 pass.
- [x] `sbt tuner/test` — 289/289 pass.
- [x] `mcp__metals__compile-full` — full project compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)