### PR TITLE
[#169] Add `mapChannel` to `ChannelScMidiMessage`

### DIFF
--- a/sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/ScMidiMessage.scala
+++ b/sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/ScMidiMessage.scala
@@ -39,6 +39,15 @@ sealed trait ScMidiMessage
  */
 sealed abstract class ChannelScMidiMessage(val channel: Int) extends ScMidiMessage {
   MidiRequirements.requireChannel(channel)
+
+  /**
+   * Returns a copy of this message with its `channel` rewritten by applying `map` to the current channel.
+   *
+   * The returned value has the same concrete subtype as `this`.
+   *
+   * @param map Function from the current channel (0-15) to the new channel (0-15).
+   */
+  def mapChannel(map: Int => Int): ChannelScMidiMessage
 }
 
 /** Base trait for MIDI System Common messages. */
@@ -81,7 +90,10 @@ abstract class NoteScMidiMessage(channel: Int,
 case class NoteOnScMidiMessage(override val channel: Int,
                                override val midiNote: MidiNote,
                                override val velocity: Int = NoteOnScMidiMessage.DefaultVelocity)
-  extends NoteScMidiMessage(channel, midiNote, velocity)
+  extends NoteScMidiMessage(channel, midiNote, velocity) {
+
+  override def mapChannel(map: Int => Int): NoteOnScMidiMessage = copy(channel = map(channel))
+}
 
 /**
  * Companion object for [[NoteOnScMidiMessage]].
@@ -103,7 +115,10 @@ object NoteOnScMidiMessage {
 case class NoteOffScMidiMessage(override val channel: Int,
                                 override val midiNote: MidiNote,
                                 override val velocity: Int = NoteOffScMidiMessage.DefaultVelocity)
-  extends NoteScMidiMessage(channel, midiNote, velocity)
+  extends NoteScMidiMessage(channel, midiNote, velocity) {
+
+  override def mapChannel(map: Int => Int): NoteOffScMidiMessage = copy(channel = map(channel))
+}
 
 /**
  * Companion object for [[NoteOffScMidiMessage]] used for default values.
@@ -125,6 +140,8 @@ case class PolyPressureScMidiMessage(override val channel: Int, midiNote: MidiNo
   extends ChannelScMidiMessage(channel) {
   midiNote.assertValid()
   MidiRequirements.requireUnsigned7BitValue("value", value)
+
+  override def mapChannel(map: Int => Int): PolyPressureScMidiMessage = copy(channel = map(channel))
 }
 
 /**
@@ -140,6 +157,8 @@ case class CcScMidiMessage(override val channel: Int, number: Int, value: Int)
   extends ChannelScMidiMessage(channel) {
   MidiRequirements.requireUnsigned7BitValue("number", number)
   MidiRequirements.requireUnsigned7BitValue("value", value)
+
+  override def mapChannel(map: Int => Int): CcScMidiMessage = copy(channel = map(channel))
 }
 
 /**
@@ -154,6 +173,8 @@ case class CcScMidiMessage(override val channel: Int, number: Int, value: Int)
 case class ProgramChangeScMidiMessage(override val channel: Int, program: Int)
   extends ChannelScMidiMessage(channel) {
   MidiRequirements.requireUnsigned7BitValue("program", program)
+
+  override def mapChannel(map: Int => Int): ProgramChangeScMidiMessage = copy(channel = map(channel))
 }
 
 /**
@@ -165,6 +186,8 @@ case class ProgramChangeScMidiMessage(override val channel: Int, program: Int)
 case class ChannelPressureScMidiMessage(override val channel: Int, value: Int)
   extends ChannelScMidiMessage(channel) {
   MidiRequirements.requireUnsigned7BitValue("value", value)
+
+  override def mapChannel(map: Int => Int): ChannelPressureScMidiMessage = copy(channel = map(channel))
 }
 
 /**
@@ -196,6 +219,8 @@ case class PitchBendScMidiMessage(override val channel: Int, value: Int)
    * @return The pitch bend amount in cents.
    */
   def cents(implicit pitchBendSensitivity: PitchBendSensitivity): Double = centsFor(pitchBendSensitivity)
+
+  override def mapChannel(map: Int => Int): PitchBendScMidiMessage = copy(channel = map(channel))
 }
 
 /**

--- a/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/message/ChannelScMidiMessageMapChannelTest.scala
+++ b/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/message/ChannelScMidiMessageMapChannelTest.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Calin-Andrei Burloiu
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.calinburloiu.music.scmidi.message
+
+import org.calinburloiu.music.scmidi.MidiNote
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ChannelScMidiMessageMapChannelTest extends AnyFlatSpec with Matchers {
+
+  behavior of "ChannelScMidiMessage#mapChannel"
+
+  it should "rewrite the channel of a NoteOnScMidiMessage" in {
+    // Given
+    val original = NoteOnScMidiMessage(3, MidiNote(60), 96)
+
+    // When
+    val mapped = original.mapChannel(_ + 5)
+
+    // Then
+    mapped shouldBe NoteOnScMidiMessage(8, MidiNote(60), 96)
+  }
+
+  it should "rewrite the channel of a NoteOffScMidiMessage" in {
+    // Given
+    val original = NoteOffScMidiMessage(3, MidiNote(60), 80)
+
+    // When
+    val mapped = original.mapChannel(_ => 10)
+
+    // Then
+    mapped shouldBe NoteOffScMidiMessage(10, MidiNote(60), 80)
+  }
+
+  it should "rewrite the channel of a PolyPressureScMidiMessage" in {
+    // Given
+    val original = PolyPressureScMidiMessage(2, MidiNote(60), 100)
+
+    // When
+    val mapped = original.mapChannel(_ => 7)
+
+    // Then
+    mapped shouldBe PolyPressureScMidiMessage(7, MidiNote(60), 100)
+  }
+
+  it should "rewrite the channel of a CcScMidiMessage" in {
+    // Given
+    val original = CcScMidiMessage(0, ScMidiCc.SustainPedal, 64)
+
+    // When
+    val mapped = original.mapChannel(_ => 9)
+
+    // Then
+    mapped shouldBe CcScMidiMessage(9, ScMidiCc.SustainPedal, 64)
+  }
+
+  it should "rewrite the channel of a ProgramChangeScMidiMessage" in {
+    // Given
+    val original = ProgramChangeScMidiMessage(4, 42)
+
+    // When
+    val mapped = original.mapChannel(_ => 0)
+
+    // Then
+    mapped shouldBe ProgramChangeScMidiMessage(0, 42)
+  }
+
+  it should "rewrite the channel of a ChannelPressureScMidiMessage" in {
+    // Given
+    val original = ChannelPressureScMidiMessage(5, 110)
+
+    // When
+    val mapped = original.mapChannel(_ => 1)
+
+    // Then
+    mapped shouldBe ChannelPressureScMidiMessage(1, 110)
+  }
+
+  it should "rewrite the channel of a PitchBendScMidiMessage" in {
+    // Given
+    val original = PitchBendScMidiMessage(6, -2048)
+
+    // When
+    val mapped = original.mapChannel(_ => 11)
+
+    // Then
+    mapped shouldBe PitchBendScMidiMessage(11, -2048)
+  }
+
+  it should "preserve the concrete subtype in the return type" in {
+    // Given
+    val noteOn = NoteOnScMidiMessage(0, MidiNote(60))
+    val noteOff = NoteOffScMidiMessage(0, MidiNote(60))
+    val polyPressure = PolyPressureScMidiMessage(0, MidiNote(60), 80)
+    val cc = CcScMidiMessage(0, ScMidiCc.ModulationMsb, 32)
+    val programChange = ProgramChangeScMidiMessage(0, 5)
+    val channelPressure = ChannelPressureScMidiMessage(0, 64)
+    val pitchBend = PitchBendScMidiMessage(0, 0)
+
+    // When / Then
+    val mappedNoteOn: NoteOnScMidiMessage = noteOn.mapChannel(_ => 1)
+    mappedNoteOn.channel shouldBe 1
+
+    val mappedNoteOff: NoteOffScMidiMessage = noteOff.mapChannel(_ => 1)
+    mappedNoteOff.channel shouldBe 1
+
+    val mappedPolyPressure: PolyPressureScMidiMessage = polyPressure.mapChannel(_ => 1)
+    mappedPolyPressure.channel shouldBe 1
+
+    val mappedCc: CcScMidiMessage = cc.mapChannel(_ => 1)
+    mappedCc.channel shouldBe 1
+
+    val mappedProgramChange: ProgramChangeScMidiMessage = programChange.mapChannel(_ => 1)
+    mappedProgramChange.channel shouldBe 1
+
+    val mappedChannelPressure: ChannelPressureScMidiMessage = channelPressure.mapChannel(_ => 1)
+    mappedChannelPressure.channel shouldBe 1
+
+    val mappedPitchBend: PitchBendScMidiMessage = pitchBend.mapChannel(_ => 1)
+    mappedPitchBend.channel shouldBe 1
+  }
+}

--- a/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/message/ChannelScMidiMessageMapChannelTest.scala
+++ b/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/message/ChannelScMidiMessageMapChannelTest.scala
@@ -22,115 +22,92 @@ import org.scalatest.matchers.should.Matchers
 
 class ChannelScMidiMessageMapChannelTest extends AnyFlatSpec with Matchers {
 
+  // One sample per concrete ChannelScMidiMessage subtype, used by the tests below as the input
+  // message whose channel is mapped. Each sample uses non-default field values so that a faulty
+  // implementation that drops or resets non-channel fields would be caught.
+  private val noteOnSample = NoteOnScMidiMessage(3, MidiNote(60), 96)
+  private val noteOffSample = NoteOffScMidiMessage(3, MidiNote(60), 80)
+  private val polyPressureSample = PolyPressureScMidiMessage(2, MidiNote(60), 100)
+  private val ccSample = CcScMidiMessage(0, ScMidiCc.SustainPedal, 64)
+  private val programChangeSample = ProgramChangeScMidiMessage(4, 42)
+  private val channelPressureSample = ChannelPressureScMidiMessage(5, 110)
+  private val pitchBendSample = PitchBendScMidiMessage(6, -2048)
+
   behavior of "ChannelScMidiMessage#mapChannel"
 
   it should "rewrite the channel of a NoteOnScMidiMessage" in {
-    // Given
-    val original = NoteOnScMidiMessage(3, MidiNote(60), 96)
-
     // When
-    val mapped = original.mapChannel(_ + 5)
+    val mapped = noteOnSample.mapChannel(_ + 5)
 
     // Then
     mapped shouldBe NoteOnScMidiMessage(8, MidiNote(60), 96)
   }
 
   it should "rewrite the channel of a NoteOffScMidiMessage" in {
-    // Given
-    val original = NoteOffScMidiMessage(3, MidiNote(60), 80)
-
     // When
-    val mapped = original.mapChannel(_ => 10)
+    val mapped = noteOffSample.mapChannel(_ => 10)
 
     // Then
     mapped shouldBe NoteOffScMidiMessage(10, MidiNote(60), 80)
   }
 
   it should "rewrite the channel of a PolyPressureScMidiMessage" in {
-    // Given
-    val original = PolyPressureScMidiMessage(2, MidiNote(60), 100)
-
     // When
-    val mapped = original.mapChannel(_ => 7)
+    val mapped = polyPressureSample.mapChannel(_ => 7)
 
     // Then
     mapped shouldBe PolyPressureScMidiMessage(7, MidiNote(60), 100)
   }
 
   it should "rewrite the channel of a CcScMidiMessage" in {
-    // Given
-    val original = CcScMidiMessage(0, ScMidiCc.SustainPedal, 64)
-
     // When
-    val mapped = original.mapChannel(_ => 9)
+    val mapped = ccSample.mapChannel(_ => 9)
 
     // Then
     mapped shouldBe CcScMidiMessage(9, ScMidiCc.SustainPedal, 64)
   }
 
   it should "rewrite the channel of a ProgramChangeScMidiMessage" in {
-    // Given
-    val original = ProgramChangeScMidiMessage(4, 42)
-
     // When
-    val mapped = original.mapChannel(_ => 0)
+    val mapped = programChangeSample.mapChannel(_ => 0)
 
     // Then
     mapped shouldBe ProgramChangeScMidiMessage(0, 42)
   }
 
   it should "rewrite the channel of a ChannelPressureScMidiMessage" in {
-    // Given
-    val original = ChannelPressureScMidiMessage(5, 110)
-
     // When
-    val mapped = original.mapChannel(_ => 1)
+    val mapped = channelPressureSample.mapChannel(_ => 1)
 
     // Then
     mapped shouldBe ChannelPressureScMidiMessage(1, 110)
   }
 
   it should "rewrite the channel of a PitchBendScMidiMessage" in {
-    // Given
-    val original = PitchBendScMidiMessage(6, -2048)
-
     // When
-    val mapped = original.mapChannel(_ => 11)
+    val mapped = pitchBendSample.mapChannel(_ => 11)
 
     // Then
     mapped shouldBe PitchBendScMidiMessage(11, -2048)
   }
 
   it should "preserve the concrete subtype in the return type" in {
-    // Given
-    val noteOn = NoteOnScMidiMessage(0, MidiNote(60))
-    val noteOff = NoteOffScMidiMessage(0, MidiNote(60))
-    val polyPressure = PolyPressureScMidiMessage(0, MidiNote(60), 80)
-    val cc = CcScMidiMessage(0, ScMidiCc.ModulationMsb, 32)
-    val programChange = ProgramChangeScMidiMessage(0, 5)
-    val channelPressure = ChannelPressureScMidiMessage(0, 64)
-    val pitchBend = PitchBendScMidiMessage(0, 0)
+    // When
+    val mappedNoteOn: NoteOnScMidiMessage = noteOnSample.mapChannel(_ => 1)
+    val mappedNoteOff: NoteOffScMidiMessage = noteOffSample.mapChannel(_ => 1)
+    val mappedPolyPressure: PolyPressureScMidiMessage = polyPressureSample.mapChannel(_ => 1)
+    val mappedCc: CcScMidiMessage = ccSample.mapChannel(_ => 1)
+    val mappedProgramChange: ProgramChangeScMidiMessage = programChangeSample.mapChannel(_ => 1)
+    val mappedChannelPressure: ChannelPressureScMidiMessage = channelPressureSample.mapChannel(_ => 1)
+    val mappedPitchBend: PitchBendScMidiMessage = pitchBendSample.mapChannel(_ => 1)
 
-    // When / Then
-    val mappedNoteOn: NoteOnScMidiMessage = noteOn.mapChannel(_ => 1)
+    // Then
     mappedNoteOn.channel shouldBe 1
-
-    val mappedNoteOff: NoteOffScMidiMessage = noteOff.mapChannel(_ => 1)
     mappedNoteOff.channel shouldBe 1
-
-    val mappedPolyPressure: PolyPressureScMidiMessage = polyPressure.mapChannel(_ => 1)
     mappedPolyPressure.channel shouldBe 1
-
-    val mappedCc: CcScMidiMessage = cc.mapChannel(_ => 1)
     mappedCc.channel shouldBe 1
-
-    val mappedProgramChange: ProgramChangeScMidiMessage = programChange.mapChannel(_ => 1)
     mappedProgramChange.channel shouldBe 1
-
-    val mappedChannelPressure: ChannelPressureScMidiMessage = channelPressure.mapChannel(_ => 1)
     mappedChannelPressure.channel shouldBe 1
-
-    val mappedPitchBend: PitchBendScMidiMessage = pitchBend.mapChannel(_ => 1)
     mappedPitchBend.channel shouldBe 1
   }
 }

--- a/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/message/ChannelScMidiMessageMapChannelTest.scala
+++ b/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/message/ChannelScMidiMessageMapChannelTest.scala
@@ -22,92 +22,115 @@ import org.scalatest.matchers.should.Matchers
 
 class ChannelScMidiMessageMapChannelTest extends AnyFlatSpec with Matchers {
 
-  // One sample per concrete ChannelScMidiMessage subtype, used by the tests below as the input
-  // message whose channel is mapped. Each sample uses non-default field values so that a faulty
-  // implementation that drops or resets non-channel fields would be caught.
-  private val noteOnSample = NoteOnScMidiMessage(3, MidiNote(60), 96)
-  private val noteOffSample = NoteOffScMidiMessage(3, MidiNote(60), 80)
-  private val polyPressureSample = PolyPressureScMidiMessage(2, MidiNote(60), 100)
-  private val ccSample = CcScMidiMessage(0, ScMidiCc.SustainPedal, 64)
-  private val programChangeSample = ProgramChangeScMidiMessage(4, 42)
-  private val channelPressureSample = ChannelPressureScMidiMessage(5, 110)
-  private val pitchBendSample = PitchBendScMidiMessage(6, -2048)
-
   behavior of "ChannelScMidiMessage#mapChannel"
 
   it should "rewrite the channel of a NoteOnScMidiMessage" in {
+    // Given
+    val original = NoteOnScMidiMessage(3, MidiNote(60), 96)
+
     // When
-    val mapped = noteOnSample.mapChannel(_ + 5)
+    val mapped = original.mapChannel(_ + 5)
 
     // Then
     mapped shouldBe NoteOnScMidiMessage(8, MidiNote(60), 96)
   }
 
   it should "rewrite the channel of a NoteOffScMidiMessage" in {
+    // Given
+    val original = NoteOffScMidiMessage(3, MidiNote(60), 80)
+
     // When
-    val mapped = noteOffSample.mapChannel(_ => 10)
+    val mapped = original.mapChannel(_ => 10)
 
     // Then
     mapped shouldBe NoteOffScMidiMessage(10, MidiNote(60), 80)
   }
 
   it should "rewrite the channel of a PolyPressureScMidiMessage" in {
+    // Given
+    val original = PolyPressureScMidiMessage(2, MidiNote(60), 100)
+
     // When
-    val mapped = polyPressureSample.mapChannel(_ => 7)
+    val mapped = original.mapChannel(_ => 7)
 
     // Then
     mapped shouldBe PolyPressureScMidiMessage(7, MidiNote(60), 100)
   }
 
   it should "rewrite the channel of a CcScMidiMessage" in {
+    // Given
+    val original = CcScMidiMessage(0, ScMidiCc.SustainPedal, 64)
+
     // When
-    val mapped = ccSample.mapChannel(_ => 9)
+    val mapped = original.mapChannel(_ => 9)
 
     // Then
     mapped shouldBe CcScMidiMessage(9, ScMidiCc.SustainPedal, 64)
   }
 
   it should "rewrite the channel of a ProgramChangeScMidiMessage" in {
+    // Given
+    val original = ProgramChangeScMidiMessage(4, 42)
+
     // When
-    val mapped = programChangeSample.mapChannel(_ => 0)
+    val mapped = original.mapChannel(_ => 0)
 
     // Then
     mapped shouldBe ProgramChangeScMidiMessage(0, 42)
   }
 
   it should "rewrite the channel of a ChannelPressureScMidiMessage" in {
+    // Given
+    val original = ChannelPressureScMidiMessage(5, 110)
+
     // When
-    val mapped = channelPressureSample.mapChannel(_ => 1)
+    val mapped = original.mapChannel(_ => 1)
 
     // Then
     mapped shouldBe ChannelPressureScMidiMessage(1, 110)
   }
 
   it should "rewrite the channel of a PitchBendScMidiMessage" in {
+    // Given
+    val original = PitchBendScMidiMessage(6, -2048)
+
     // When
-    val mapped = pitchBendSample.mapChannel(_ => 11)
+    val mapped = original.mapChannel(_ => 11)
 
     // Then
     mapped shouldBe PitchBendScMidiMessage(11, -2048)
   }
 
   it should "preserve the concrete subtype in the return type" in {
-    // When
-    val mappedNoteOn: NoteOnScMidiMessage = noteOnSample.mapChannel(_ => 1)
-    val mappedNoteOff: NoteOffScMidiMessage = noteOffSample.mapChannel(_ => 1)
-    val mappedPolyPressure: PolyPressureScMidiMessage = polyPressureSample.mapChannel(_ => 1)
-    val mappedCc: CcScMidiMessage = ccSample.mapChannel(_ => 1)
-    val mappedProgramChange: ProgramChangeScMidiMessage = programChangeSample.mapChannel(_ => 1)
-    val mappedChannelPressure: ChannelPressureScMidiMessage = channelPressureSample.mapChannel(_ => 1)
-    val mappedPitchBend: PitchBendScMidiMessage = pitchBendSample.mapChannel(_ => 1)
+    // Given
+    val noteOn = NoteOnScMidiMessage(0, MidiNote(60))
+    val noteOff = NoteOffScMidiMessage(0, MidiNote(60))
+    val polyPressure = PolyPressureScMidiMessage(0, MidiNote(60), 80)
+    val cc = CcScMidiMessage(0, ScMidiCc.ModulationMsb, 32)
+    val programChange = ProgramChangeScMidiMessage(0, 5)
+    val channelPressure = ChannelPressureScMidiMessage(0, 64)
+    val pitchBend = PitchBendScMidiMessage(0, 0)
 
-    // Then
+    // When / Then
+    val mappedNoteOn: NoteOnScMidiMessage = noteOn.mapChannel(_ => 1)
     mappedNoteOn.channel shouldBe 1
+
+    val mappedNoteOff: NoteOffScMidiMessage = noteOff.mapChannel(_ => 1)
     mappedNoteOff.channel shouldBe 1
+
+    val mappedPolyPressure: PolyPressureScMidiMessage = polyPressure.mapChannel(_ => 1)
     mappedPolyPressure.channel shouldBe 1
+
+    val mappedCc: CcScMidiMessage = cc.mapChannel(_ => 1)
     mappedCc.channel shouldBe 1
+
+    val mappedProgramChange: ProgramChangeScMidiMessage = programChange.mapChannel(_ => 1)
     mappedProgramChange.channel shouldBe 1
+
+    val mappedChannelPressure: ChannelPressureScMidiMessage = channelPressure.mapChannel(_ => 1)
     mappedChannelPressure.channel shouldBe 1
+
+    val mappedPitchBend: PitchBendScMidiMessage = pitchBend.mapChannel(_ => 1)
     mappedPitchBend.channel shouldBe 1
   }
 }

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
@@ -139,13 +139,7 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     }
 
     val normalized = scMessage match {
-      case m: NoteOnScMidiMessage => m.copy(channel = trackedChannel)
-      case m: NoteOffScMidiMessage => m.copy(channel = trackedChannel)
-      case m: PitchBendScMidiMessage => m.copy(channel = trackedChannel)
-      case m: CcScMidiMessage => m.copy(channel = trackedChannel)
-      case m: ChannelPressureScMidiMessage => m.copy(channel = trackedChannel)
-      case m: PolyPressureScMidiMessage => m.copy(channel = trackedChannel)
-      case m: ProgramChangeScMidiMessage => m.copy(channel = trackedChannel)
+      case m: ChannelScMidiMessage => m.mapChannel(_ => trackedChannel)
       case m => m
     }
     tracker.send(normalized)

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -329,13 +329,13 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
       // (MPE spec §2.6: CC #74 is both Note-Level and Zone-Level).
       case ScMidiCc.MpeSlide =>
         if (inputMode == MpeInputMode.Mpe) {
-          forwardToMemberChannel(buffer, inputChannel, CcScMidiMessage(_, ScMidiCc.MpeSlide, ccValue))
+          forwardToMemberChannel(buffer, msg)
         } else {
-          forwardOnZoneMasterChannel(buffer, inputChannel, CcScMidiMessage(_, ScMidiCc.MpeSlide, ccValue))
+          forwardOnZoneMasterChannel(buffer, msg)
         }
       // All other CCs are forwarded on the master channel of the zone the input belongs to
       case _ =>
-        forwardOnZoneMasterChannel(buffer, inputChannel, CcScMidiMessage(_, ccNumber, ccValue))
+        forwardOnZoneMasterChannel(buffer, msg)
     }
   }
 
@@ -476,12 +476,12 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
 
     if (inputMode == MpeInputMode.Mpe) {
       // Per-note pressure in MPE input: route to the allocated Member Channel.
-      forwardToMemberChannel(buffer, inputChannel, ChannelPressureScMidiMessage(_, pressure))
+      forwardToMemberChannel(buffer, msg)
     } else {
       // Non-MPE input: Channel Pressure applies to all notes on the input channel. Route to the
       // Zone's Master Channel as Zone-level pressure (MPE spec §2.5: CP is both Note-Level and
       // Zone-Level; receivers combine Master + Member data per sounding note).
-      forwardOnZoneMasterChannel(buffer, inputChannel, ChannelPressureScMidiMessage(_, pressure))
+      forwardOnZoneMasterChannel(buffer, msg)
     }
   }
 
@@ -508,27 +508,27 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
   }
 
   /**
-   * Forwards a per-note control message (Channel Pressure, CC #74) to the output Member Channel
-   * that currently holds the note originated on `inputChannel`. MPE input mode only: in non-MPE
-   * mode these controls are routed to the Master Channel by the callers.
+   * Forwards `msg` to the output Member Channel that currently holds the note originated on
+   * `msg.channel`, rewriting the channel via [[ChannelScMidiMessage.mapChannel]]. MPE input mode
+   * only: in non-MPE mode these controls are routed to the Master Channel by the callers.
    */
-  private def forwardToMemberChannel(buffer: mutable.Buffer[MidiMessage], inputChannel: Int,
-                                     makeMessage: Int => ScMidiMessage): Unit = {
-    mpeInputChannelMap.get(inputChannel).foreach { outChannel =>
-      buffer += makeMessage(outChannel).asJava
+  private def forwardToMemberChannel(buffer: mutable.Buffer[MidiMessage], msg: ChannelScMidiMessage): Unit = {
+    mpeInputChannelMap.get(msg.channel).foreach { outChannel =>
+      buffer += msg.mapChannel(_ => outChannel).asJava
     }
   }
 
   /**
-   * Forwards a message on the master channel of the zone that the `inputChannel` belongs to.
+   * Forwards `msg` on the master channel of the zone that `msg.channel` belongs to, rewriting the
+   * channel via [[ChannelScMidiMessage.mapChannel]].
    *
    * For non-MPE input, all messages are routed to the first enabled zone (lower preferred).
-   * For MPE input, the zone is determined by which zone's channel range contains `inputChannel`.
+   * For MPE input, the zone is determined by which zone's channel range contains `msg.channel`.
    */
-  private def forwardOnZoneMasterChannel(buffer: mutable.Buffer[MidiMessage], inputChannel: Int,
-                                         makeMessage: Int => ScMidiMessage): Unit = {
-    resolveZoneMasterChannel(inputChannel).foreach { masterCh =>
-      buffer += makeMessage(masterCh).asJava
+  private def forwardOnZoneMasterChannel(buffer: mutable.Buffer[MidiMessage],
+                                         msg: ChannelScMidiMessage): Unit = {
+    resolveZoneMasterChannel(msg.channel).foreach { masterCh =>
+      buffer += msg.mapChannel(_ => masterCh).asJava
     }
   }
 

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -177,7 +177,7 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
       case msg: ProgramChangeScMidiMessage =>
         // Forward on the zone's master channel
         resolveZoneMasterChannel(msg.channel).foreach { masterCh =>
-          buffer += msg.copy(channel = masterCh).asJava
+          buffer += msg.mapChannel(_ => masterCh).asJava
         }
       case _ =>
         buffer += message


### PR DESCRIPTION
Resolves #169

## Summary

- Add abstract `mapChannel(map: Int => Int): ChannelScMidiMessage` on `ChannelScMidiMessage`, implemented in each concrete subclass (`NoteOnScMidiMessage`, `NoteOffScMidiMessage`, `PolyPressureScMidiMessage`, `CcScMidiMessage`, `ProgramChangeScMidiMessage`, `ChannelPressureScMidiMessage`, `PitchBendScMidiMessage`) via the case-class `copy` method, with covariant return types preserving the concrete subtype.
- Replace the per-subclass match block that rewrote the channel in `MonophonicPitchBendTuner.sendToTracker` with a single `case m: ChannelScMidiMessage => m.mapChannel(_ => trackedChannel)`.
- Replace the `ProgramChange` channel rewrite in `MpeTuner.processShortMessage` with `msg.mapChannel(_ => masterCh)`.
- Add `ChannelScMidiMessageMapChannelTest` covering all subclasses and verifying the concrete return type.

## Test plan

- [x] `sbt scMidi/test` passes
- [x] `sbt tuner/test` passes (290 tests, including all `MonophonicPitchBendTunerTest` and `MpeTunerTest` cases)
- [x] Full project compiles
