### PR TITLE
[#189] Remove coverage two-pass workaround

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,30 +209,28 @@ needed to reach 80%.
 **Run coverage as the final step of any code-changing task, before committing**, to verify that the module's
 configured threshold still holds and that any new files meet the 80% target. Pick the scope that matches your change:
 
-- **Larger or multi-module changes** — run the full project-wide workflow with `sbtn coverageAll`. Per-module reports
+- **Larger or multi-module changes** — run the full project-wide workflow with `sbt coverageAll`. Per-module reports
   plus an aggregate report are produced. The aggregate combines each module's tests with the tests of dependent
   modules.
-- **Smaller changes scoped to a single module** — run `sbtn "coverageModule <module>"`, where `<module>` is the sbt
+- **Smaller changes scoped to a single module** — run `sbt "coverageModule <module>"`, where `<module>` is the sbt
   project ID (e.g. `intonation`, `tuner`, `appConfig`). Only the named module's tests run, so coverage is not
   inflated by tests from other modules exercising the same code.
 
-Both commands are defined in `project/Coverage.scala`; see its ScalaDoc for the workflow's implementation details
-and the bugs they work around. They are server-side commands, so `sbtn` relays them to the running BSP server
-exactly as a direct `sbt` invocation would. There is also a `coverageCheck` command used by CI.
+Both commands are defined in `project/Coverage.scala`; see its ScalaDoc for the workflow's implementation details.
+There is also a `coverageCheck` command used by CI.
 
-After **every** coverage run, follow up with a `clean` to remove the instrumented `.class`/`.tasty` files that
-scoverage leaves in the active `target` tree. Leaving instrumented binaries around will make any subsequent
-`sbtn run` / `sbtn assembly` invocation fail at runtime with `NoClassDefFoundError: scoverage.Invoker$`. Use
-`sbtn clean` after a project-wide coverage run, or `sbtn "<module>/clean"` after a single-module run.
+**Coverage commands currently do not work via `sbtn`** — run them through a fresh `sbt` JVM instead. This is
+the one exception to the "prefer `sbtn`" rule above.
+
+Each command ends with a `clean` that removes instrumented `.class`/`.tasty` files from `target/` automatically,
+so no manual clean is needed after a coverage run.
 
 ```bash
-sbtn coverageAll
-sbtn clean
+sbt coverageAll
 ```
 
 ```bash
-sbtn "coverageModule intonation"
-sbtn "intonation/clean"
+sbt "coverageModule intonation"
 ```
 
 Coverage data and reports live at the repo root under `coverage-reports/<project-id>/scoverage-report/` (configured

--- a/project/Coverage.scala
+++ b/project/Coverage.scala
@@ -16,85 +16,55 @@
 
 import sbt.*
 import sbt.Keys.*
-import scoverage.ScoverageKeys.coverageEnabled
 
 /**
  * `coverageAll`, `coverageModule <module>`, `coverageCheck`, and `coverageClean` sbt commands — run the coverage
- * workflow with a two-pass build (and clean up the reports directory).
+ * workflow and clean up the reports directory.
  *
- * Single-invocation `clean; coverage; test` reliably fails on this multi-project
- * Scala 3.6.3 + sbt-scoverage 2.x setup with TASTy/companion-class errors (see
- * https://github.com/scoverage/sbt-scoverage/issues/517 and
- * https://github.com/scoverage/sbt-scoverage/issues/511). The first pass compiles
- * the project without instrumentation so the on-disk TASTy is valid before
- * `coverageEnabled := true` triggers an instrumented recompile in the second pass.
+ * `coverageAll` runs `clean; coverage; test; coverageReport; coverageAggregate` across all modules, then cleans the
+ * active `target/` tree to remove instrumented `.class`/`.tasty` files left by scoverage. The `coverage-reports/`
+ * directory is configured via `coverageDataDir` to live outside `target/`, so it is not affected by the trailing
+ * `clean`.
  *
- * For `coverageAll`, the first pass compiles all modules in parallel; then
- * compile-task parallelism is serialized for the instrumented second pass as
- * belt-and-braces protection against https://github.com/sbt/sbt/issues/1673 /
- * sbt-scoverage#108.
+ * `coverageModule <module>` runs the same workflow but only the named module's tests are run, giving accurate
+ * per-module coverage that is not inflated by tests from other modules exercising the same code. Note that
+ * `coverageEnabled` is set globally by the `coverage` task, so even though only `<module>/test` runs, the module's
+ * upstream dependencies are recompiled with instrumentation too — hence the trailing `clean` is full, not module-scoped.
  *
- * For `coverageModule <module>`, the same two-pass strategy is used as `coverageAll`, but
- * only the named module's tests are run in the second pass. This gives accurate per-module
- * coverage that is not inflated by tests from other modules exercising the same code.
+ * `coverageClean` deletes the `coverage-reports/` directory at the repo root. Use it when you want to discard the
+ * persisted reports explicitly.
  *
- * `coverageClean` deletes the `coverage-reports/` directory at the repo root. The reports directory is
- * configured via `coverageDataDir` in `build.sbt` to live outside `target/` so it survives `sbt clean`
- * (which is recommended after a coverage run to remove instrumented `.class`/`.tasty` files). Use
- * `coverageClean` when you want to discard the persisted reports themselves.
- *
- * `coverageCheck` is intended for CI: it runs the same two-pass workflow as `coverageAll`
- * but disables HTML and Cobertura report output for speed. XML output is kept on because
- * `coverageAggregate` reads each subproject's XML to combine their coverage data. Per-module
- * thresholds are enforced by `coverageReport` (each subproject with `coverageFailOnMinimum`)
- * and the aggregate threshold by `coverageAggregate` against the root project's settings.
- *
- * All three commands snapshot the settings they modify — `Global / concurrentRestrictions`
- * and per-project `coverageEnabled` — on entry, and `coverageAllRestore` re-applies the
- * snapshot at the end. `coverageCheck` additionally toggles `coverageOutputHTML` /
- * `coverageOutputCobertura` for the duration of the run; those are not snapshotted because
- * CI invocations are one-shot, but a local user can `reload` to drop them.
+ * `coverageCheck` is intended for CI: it runs the same workflow as `coverageAll` but disables HTML and
+ * Cobertura report output for speed. XML output is kept on because `coverageAggregate` reads each subproject's
+ * XML to combine their coverage data. Per-module thresholds are enforced by `coverageReport` (each subproject
+ * with `coverageFailOnMinimum`) and the aggregate threshold by `coverageAggregate` against the root project's
+ * settings. The HTML/Cobertura toggles are restored at the end so a local invocation does not leave the session
+ * with reduced output enabled.
  */
 object Coverage {
 
   val commands: Seq[Command] =
-    Seq(coverageAll, coverageModule, coverageCheck, coverageClean, coverageAllRestore)
-
-  private val savedRestrictions = AttributeKey[Seq[Tags.Rule]](
-    "coverageAllSavedRestrictions",
-    "Snapshot of Global / concurrentRestrictions captured on coverageAll entry.",
-  )
-
-  private val savedCoverageEnabled = AttributeKey[Map[ProjectRef, Boolean]](
-    "coverageAllSavedCoverageEnabled",
-    "Snapshot of per-project coverageEnabled values captured on coverageAll entry.",
-  )
+    Seq(coverageAll, coverageModule, coverageCheck, coverageClean)
 
   private def coverageAll: Command = Command.command("coverageAll") { state =>
-    val saved = snapshotSettings(state)
     "clean" ::
-      "compile" ::
-      "set Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)" ::
       "coverage" ::
       "test" ::
       "coverageReport" ::
       "coverageAggregate" ::
-      "coverageAllRestore" ::
-      saved
+      "clean" ::
+      state
   }
 
   private def coverageModule: Command = Command.args("coverageModule", "<module>") { (state, args) =>
     args match {
       case Seq(module) =>
-        val saved = snapshotSettings(state)
         "clean" ::
-          "compile" ::
-          "set Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)" ::
           "coverage" ::
           s"$module/test" ::
           s"$module/coverageReport" ::
-          "coverageAllRestore" ::
-          saved
+          "clean" ::
+          state
       case _ =>
         state.globalLogging.full.error("Usage: coverageModule <module>")
         state.fail
@@ -102,18 +72,17 @@ object Coverage {
   }
 
   private def coverageCheck: Command = Command.command("coverageCheck") { state =>
-    val saved = snapshotSettings(state)
     "clean" ::
-      "compile" ::
-      "set Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)" ::
       "set Global / coverageOutputHTML := false" ::
       "set Global / coverageOutputCobertura := false" ::
       "coverage" ::
       "test" ::
       "coverageReport" ::
       "coverageAggregate" ::
-      "coverageAllRestore" ::
-      saved
+      "set Global / coverageOutputHTML := true" ::
+      "set Global / coverageOutputCobertura := true" ::
+      "clean" ::
+      state
   }
 
   private def coverageClean: Command = Command.command("coverageClean") { state =>
@@ -127,35 +96,5 @@ object Coverage {
       log.info(s"$reportsDir does not exist; nothing to delete")
     }
     state
-  }
-
-  private def snapshotSettings(state: State): State = {
-    val extracted = Project.extract(state)
-    val data = extracted.structure.data
-    val originalRestrictions = (Global / concurrentRestrictions).get(data).getOrElse(Seq.empty)
-    val originalCoverageEnabled = extracted.structure.allProjectRefs.flatMap { ref =>
-      (ref / coverageEnabled).get(data).map(ref -> _)
-    }.toMap
-    state
-      .put(savedRestrictions, originalRestrictions)
-      .put(savedCoverageEnabled, originalCoverageEnabled)
-  }
-
-  private def coverageAllRestore: Command = Command.command("coverageAllRestore") { state =>
-    val extracted = Project.extract(state)
-    val restrictionsSetting: Seq[Setting[?]] =
-      state.attributes.get(savedRestrictions)
-        .map(original => Seq(Global / concurrentRestrictions := original))
-        .getOrElse(Seq.empty)
-    val coverageEnabledSettings: Seq[Setting[?]] =
-      state.attributes.get(savedCoverageEnabled)
-        .map(_.toSeq.map { case (ref, value) => ref / coverageEnabled := value })
-        .getOrElse(Seq.empty)
-    val cleanState = state
-      .remove(savedRestrictions)
-      .remove(savedCoverageEnabled)
-    val toApply = restrictionsSetting ++ coverageEnabledSettings
-    if (toApply.isEmpty) cleanState
-    else extracted.appendWithSession(toApply, cleanState)
   }
 }


### PR DESCRIPTION
Resolves #189.

## Summary

- Drop the two-pass build workaround from `project/Coverage.scala` (initial `compile` warm-up, `Tags.limit(Tags.Compile, 1)` serialization, and the snapshot/restore mechanism for `concurrentRestrictions` and per-project `coverageEnabled`). #186 isolated BSP and CLI sbt onto separate `target` trees, removing the race that the workaround was guarding against.
- For `coverageCheck`, simplify the HTML/Cobertura toggle by just flipping them back to `true` at the end instead of snapshotting.
- Append a full `clean` to each coverage command so callers no longer have to remember it. `coverageModule` uses a full `clean` (not `<module>/clean`) because `coverageEnabled` is set globally, so upstream dependency modules' `target/` trees also accumulate instrumented classes — verified empirically (`businessync/target/...Businessync.class` references `scala.runtime.coverage.Invoker$.invoked` and the module's scoverage-data path after a `coverageModule tuner` run with the trailing `tuner/clean`).
- `AGENTS.md`: drop the manual post-coverage `sbt clean` / `sbt "<module>/clean"` instructions.

## Test plan

- [x] `sbt coverageAll` runs cleanly on a cold target (verified twice).
- [x] `sbt "coverageModule intonation"`, `sbt "coverageModule tuner"`, `sbt "coverageModule businessync"` all succeed.
- [x] `sbt coverageCheck` succeeds and ends with `coverageOutputHTML`/`coverageOutputCobertura` restored to `true`.
- [x] After `sbt "coverageModule tuner"`, every dependency module's `target/` is empty (`tuner`, `scMidi`, `businessync`, `common` all 0 .class files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)