### PR TITLE
[#194] Instruct the scoverage-inspector skill subagent to suffix build target subdirectories

### DIFF
--- a/.claude/skills/scoverage-inspector/SKILL.md
+++ b/.claude/skills/scoverage-inspector/SKILL.md
@@ -116,17 +116,21 @@ Create the log directory once before the first sbt invocation:
 mkdir -p logs/skills/scoverage-inspector
 ```
 
+All sbt coverage commands must be run with `-Dmicrotonalist.targetSuffix=-scoverage` which forces the target
+subdirectories to have `-scoverage` suffix, being named `target-scoverage` instead of `target`. This avoids clashes with
+concurrent builds that are not instrumented for coverage such as a build from an IDE.
+
 Initial run (`N=1`):
 
 ```bash
-sbt "coverageModules <m1> <m2> ..." 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-1.log
+sbt -Dmicrotonalist.targetSuffix=-scoverage "coverageModules <m1> <m2> ..." 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-1.log
 ```
 
 Retry run (`N=2`), only if the initial failure matches the TASTy/companion-class
 symptoms described in the failure-handling subsection below:
 
 ```bash
-sbt "coverageModules <m1> <m2> ..." 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-2.log
+sbt -Dmicrotonalist.targetSuffix=-scoverage "coverageModules <m1> <m2> ..." 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-2.log
 ```
 
 Use `coverageModules` (varargs) so the whole set runs in one
@@ -143,7 +147,7 @@ they want the **aggregate** report instead:
 - Run it the same way as `coverageModules`, using the numbered log scheme:
 
   ```bash
-  sbt coverageAll 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-1.log
+  sbt -Dmicrotonalist.targetSuffix=-scoverage coverageAll 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-1.log
   ```
 
   No `coverageModules` shortcut covers this case — the aggregate is built by
@@ -173,14 +177,14 @@ Without `--aggregate`, the freshness script intentionally ignores edits in
 dependent modules because re-running `coverageModules <m>` after such an edit
 would produce identical numbers.
 
-**Do not** run `sbt coverageClean` first — the `clean` at the start of
+**Do not** run `sbt -Dmicrotonalist.targetSuffix=-scoverage coverageClean` first — the `clean` at the start of
 `coverageModules` already wipes stale instrumentation under
 `target/scoverage-data`, and the trailing `clean` removes instrumented
 `.class`/`.tasty` files. `coverage-reports/` lives outside `target/` and
 is preserved on purpose. Forcing `coverageClean` would just invalidate
 unrelated modules' reports for no benefit.
 
-**Do not** use `sbt coverageAll` for a focused "check these classes"
+**Do not** use `sbt -Dmicrotonalist.targetSuffix=-scoverage coverageAll` for a focused "check these classes"
 question — that runs every module's tests and is exactly what
 `coverageModules` exists to avoid.
 
@@ -190,14 +194,14 @@ All three readers stream the XML with `xml.etree.iterparse` (constant
 memory, terse output). Run **only the script(s) that directly answer the
 question** — never run a script whose output the user did not ask for:
 
-| User asks for…                              | Script(s) to run                                    |
-|---------------------------------------------|-----------------------------------------------------|
-| Module-level percentage(s) only             | `module_summary.py … --overall-only`                |
-| Module overview with per-class breakdown    | `module_summary.py …`                               |
-| A class's percentage(s) only               | `class_summary.py … --overall-only`                 |
-| A class's percentages + method breakdown    | `class_summary.py …`                                |
-| Where are the gaps / uncovered lines        | `class_uncovered_lines.py …`                        |
-| Both percentages AND gaps for a class       | `class_summary.py …` **then** `class_uncovered_lines.py …` |
+| User asks for…                           | Script(s) to run                                           |
+|------------------------------------------|------------------------------------------------------------|
+| Module-level percentage(s) only          | `module_summary.py … --overall-only`                       |
+| Module overview with per-class breakdown | `module_summary.py …`                                      |
+| A class's percentage(s) only             | `class_summary.py … --overall-only`                        |
+| A class's percentages + method breakdown | `class_summary.py …`                                       |
+| Where are the gaps / uncovered lines     | `class_uncovered_lines.py …`                               |
+| Both percentages AND gaps for a class    | `class_summary.py …` **then** `class_uncovered_lines.py …` |
 
 Add `--aggregate` to any of these scripts when the user wants caller-test
 coverage (see the note in step 3). Without `--aggregate` the script reads
@@ -276,8 +280,8 @@ Main agent spawns a Haiku subagent with that question. Haiku:
    `org.calinburloiu.music.microtonalist.tuner.MtsTuner` → module `tuner`.
 3. `coverage_freshness.py intonation` → 0; `coverage_freshness.py tuner` → 1.
 4. `mkdir -p logs/skills/scoverage-inspector`, then
-   `sbt "coverageModules tuner" 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-1.log` (intonation skipped — already
-   fresh).
+   `sbt -Dmicrotonalist.targetSuffix=-scoverage "coverageModules tuner" 2>&1 | tee logs/skills/scoverage-inspector/sbt-run-1.log` (
+   intonation skipped — already fresh).
 5. `class_summary.py intonation org.calinburloiu.music.intonation.Scale`,
    then `class_uncovered_lines.py intonation ...Scale`.
 6. Same pair for `MtsTuner` in `tuner`.

--- a/.claude/skills/scoverage-inspector/SKILL.md
+++ b/.claude/skills/scoverage-inspector/SKILL.md
@@ -118,7 +118,7 @@ mkdir -p logs/skills/scoverage-inspector
 
 All sbt coverage commands must be run with `-Dmicrotonalist.targetSuffix=-scoverage` which forces the target
 subdirectories to have `-scoverage` suffix, being named `target-scoverage` instead of `target`. This avoids clashes with
-concurrent builds that are not instrumented for coverage such as a build from an IDE.
+concurrent builds that don't include code instrumented for coverage such as a build from an IDE.
 
 Initial run (`N=1`):
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ hs_err_pid*
 dist/*
 target/
 target-bsp/
+target-scoverage/
 coverage-reports/
 lib_managed/
 src_managed/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ documented in [`docs/development/scoverage-issue.md`](docs/development/scoverage
 modifying code.
 
 For the manual `sbt coverageAll` / `sbt coverageModules` workflow (running coverage outside the skill, CI's
-`coverageCheck`, post-run `clean` rules), see [`docs/development/coverage.md`](docs/development/coverage.md). Note that
+`coverageCheck`), see [`docs/development/coverage.md`](docs/development/coverage.md). Note that
 it is recommended to set a suffix for build target subdirectories to avoid clashes with concurrent builds that don't
 include code instrumented for coverage such as a build from an IDE.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,9 @@ documented in [`docs/development/scoverage-issue.md`](docs/development/scoverage
 modifying code.
 
 For the manual `sbt coverageAll` / `sbt coverageModules` workflow (running coverage outside the skill, CI's
-`coverageCheck`, post-run `clean` rules), see [`docs/development/coverage.md`](docs/development/coverage.md).
+`coverageCheck`, post-run `clean` rules), see [`docs/development/coverage.md`](docs/development/coverage.md). Note that
+it is recommended to set a suffix for build target subdirectories to avoid clashes with concurrent builds that don't
+include code instrumented for coverage such as a build from an IDE.
 
 ## Shared test utilities
 

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -23,6 +23,11 @@ needed to reach 80%.
 
 ## Running coverage
 
+The project introduces custom coverage commands. It is recommended to set a suffix for build target subdirectories to
+avoid clashes with concurrent builds that don't include code instrumented for coverage such as a build from an IDE.
+You can do that by adding `-Dmicrotonalist.targetSuffix=-scoverage` for example to every sbt CLI command used for
+coverage. There are known issues with IntelliJ IDEA while running scoverage without custom target subdirectories.
+
 **Run coverage as the final step of any code-changing task, before committing**, to verify that the module's
 configured threshold still holds and that any new files meet the 80% target. Pick the scope that matches your change:
 

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -42,35 +42,26 @@ configured threshold still holds and that any new files meet the 80% target. Pic
 Both commands are defined in `project/Coverage.scala`; see its ScalaDoc for the workflow's implementation details.
 There is also a `coverageCheck` command used by CI.
 
-The two-pass workflow exists to work around a known sbt-scoverage + Scala 3 multi-module compile bug. If a coverage
-command fails with TASTy/companion-class errors, `Not found: type X`, or `NoClassDefFoundError` at test runtime, see
-[`docs/development/scoverage-issue.md`](scoverage-issue.md) before assuming it is a code defect — the typical response
-is to retry the command, not to change source code.
+If a coverage command fails with TASTy/companion-class errors, `Not found: type X`, or `NoClassDefFoundError` at test
+runtime, see [`docs/development/scoverage-issue.md`](scoverage-issue.md) before assuming it is a code defect — the
+typical response is to retry the command, not to change source code.
 
 **Coverage commands do not work via `sbtn`** — run them through a fresh `sbt` JVM instead. This is the one
 exception to the "prefer `sbtn`" rule in `AGENTS.md`.
 
-After **every** coverage run, follow up with a `clean` to remove the instrumented `.class`/`.tasty` files that
-scoverage leaves in the active `target` tree. Leaving instrumented binaries around will make any subsequent
-`sbt run` / `sbt assembly` invocation fail at runtime with `NoClassDefFoundError: scoverage.Invoker$`. Use
-`sbt clean` after a coverage run.
-
 ```bash
 sbt coverageAll
-sbt clean
 ```
 
 ```bash
 sbt "coverageModules intonation"
-sbt "clean"
 ```
 
 ```bash
 sbt "coverageModules tuner intonation"
-sbt clean
 ```
 
 Coverage data and reports live at the repo root under `coverage-reports/<project-id>/scoverage-report/` (configured
 via `coverageDataDir` in `build.sbt`); the aggregate is at `coverage-reports/root/scoverage-report/`. The
 `coverage-reports/` directory lives outside `target/`, so `sbt clean` does **not** wipe it — reports remain
-browsable after the post-coverage cleanup. Run `sbt coverageClean` to discard the persisted reports explicitly.
+browsable after a subsequent clean. Run `sbt coverageClean` to discard the persisted reports explicitly.

--- a/docs/development/scoverage-issue.md
+++ b/docs/development/scoverage-issue.md
@@ -91,19 +91,14 @@ generally succeed.
 ## What's already done about it
 
 The `coverageAll` / `coverageModules` / `coverageCheck` commands in
-[`project/Coverage.scala`](../../project/Coverage.scala) implement a two-pass
-build that is meant to side-step the bug:
+[`project/Coverage.scala`](../../project/Coverage.scala) use a single-pass
+workflow: `clean; coverage; test; coverageReport[; coverageAggregate]`.
+The leading `clean` ensures a cold, non-instrumented cache is not carried over
+from a previous build, which reduces (but does not eliminate) the chance of
+hitting the race.
 
-1. `clean; compile` — populates `target/` with **non-instrumented**
-   `.class`/`.tasty` files so a fully valid TASTy set exists on disk.
-2. `set Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)` then
-   `coverage; test; coverageReport[; coverageAggregate]` — recompiles with
-   instrumentation, with compile-task parallelism serialized as
-   belt-and-braces protection against sbt#1673 / sbt-scoverage#108.
-
-This makes the failure rare in practice but does not fully eliminate it. When
-you do hit it, recognize it for what it is and retry rather than chasing it
-as a code defect.
+When you do hit it, recognize it for what it is and retry rather than chasing
+it as a code defect.
 
 ## What does *not* help
 
@@ -115,8 +110,8 @@ These were tried during the original investigation and did not fix the bug:
 - Disabling parallel test execution.
 - Lowering compile-task parallelism alone.
 
-The only reliable mitigations are the two-pass workflow encoded in the
-custom commands and, if it still fails, retrying.
+The only reliable mitigation is retrying — the bug is non-deterministic on cold caches; warm runs generally
+succeed.
 
 [#183]: https://github.com/calinburloiu/microtonalist/issues/183
 

--- a/project/Coverage.scala
+++ b/project/Coverage.scala
@@ -16,72 +16,41 @@
 
 import sbt.*
 import sbt.Keys.*
-import scoverage.ScoverageKeys.coverageEnabled
 
 /**
  * `coverageAll`, `coverageModules <module> [<module> ...]`, `coverageCheck`, and `coverageClean` sbt commands — run
- * the coverage workflow with a two-pass build (and clean up the reports directory).
+ * the coverage workflow and clean up the reports directory.
  *
- * Single-invocation `clean; coverage; test` reliably fails on this multi-project
- * Scala 3.6.3 + sbt-scoverage 2.x setup with TASTy/companion-class errors. See
- * `docs/development/scoverage-issue.md` for the symptom shapes, the working
- * theory of the root cause, and how to recognize a recurrence. The first pass
- * here compiles the project without instrumentation so the on-disk TASTy is
- * valid before `coverageEnabled := true` triggers an instrumented recompile in
- * the second pass.
+ * `coverageAll` runs `clean; coverage; test; coverageReport; coverageAggregate` across all modules.
  *
- * For `coverageAll`, the first pass compiles all modules in parallel; then
- * compile-task parallelism is serialized for the instrumented second pass as
- * belt-and-braces protection against the same family of bugs.
- *
- * `coverageModules <module> [<module> ...]` runs the same two-pass workflow but only the named modules' tests are
- * run, giving accurate per-module coverage that is not inflated by tests from other modules exercising the same
- * code. At least one module must be supplied. All listed modules' tests run inside a single `coverage` session,
- * then each produces its own `coverageReport`.
+ * `coverageModules <module> [<module> ...]` runs the same workflow but only the named modules' tests are run, giving
+ * accurate per-module coverage that is not inflated by tests from other modules exercising the same code. At least
+ * one module must be supplied. All listed modules' tests run inside a single `coverage` session, then each produces
+ * its own `coverageReport`.
  *
  * `coverageClean` deletes the `coverage-reports/` directory at the repo root. The reports directory is
- * configured via `coverageDataDir` in `build.sbt` to live outside `target/` so it survives `sbt clean`
- * (which is recommended after a coverage run to remove instrumented `.class`/`.tasty` files). Use
- * `coverageClean` when you want to discard the persisted reports themselves.
+ * configured via `coverageDataDir` in `build.sbt` to live outside `target/` so it survives `sbt clean`.
+ * Use `coverageClean` when you want to discard the persisted reports themselves.
  *
- * `coverageCheck` is intended for CI: it runs the same two-pass workflow as `coverageAll`
- * but disables HTML and Cobertura report output for speed. XML output is kept on because
- * `coverageAggregate` reads each subproject's XML to combine their coverage data. Per-module
- * thresholds are enforced by `coverageReport` (each subproject with `coverageFailOnMinimum`)
- * and the aggregate threshold by `coverageAggregate` against the root project's settings.
- *
- * All three commands snapshot the settings they modify — `Global / concurrentRestrictions`
- * and per-project `coverageEnabled` — on entry, and `coverageAllRestore` re-applies the
- * snapshot at the end. `coverageCheck` additionally toggles `coverageOutputHTML` /
- * `coverageOutputCobertura` for the duration of the run; those are not snapshotted because
- * CI invocations are one-shot, but a local user can `reload` to drop them.
+ * `coverageCheck` is intended for CI: it runs the same workflow as `coverageAll` but disables HTML and
+ * Cobertura report output for speed. XML output is kept on because `coverageAggregate` reads each subproject's
+ * XML to combine their coverage data. Per-module thresholds are enforced by `coverageReport` (each subproject
+ * with `coverageFailOnMinimum`) and the aggregate threshold by `coverageAggregate` against the root project's
+ * settings. The HTML/Cobertura toggles are restored at the end so a local invocation does not leave the session
+ * with reduced output enabled.
  */
 object Coverage {
 
   val commands: Seq[Command] =
-    Seq(coverageAll, coverageModules, coverageCheck, coverageClean, coverageAllRestore)
-
-  private val savedRestrictions = AttributeKey[Seq[Tags.Rule]](
-    "coverageAllSavedRestrictions",
-    "Snapshot of Global / concurrentRestrictions captured on coverageAll entry.",
-  )
-
-  private val savedCoverageEnabled = AttributeKey[Map[ProjectRef, Boolean]](
-    "coverageAllSavedCoverageEnabled",
-    "Snapshot of per-project coverageEnabled values captured on coverageAll entry.",
-  )
+    Seq(coverageAll, coverageModules, coverageCheck, coverageClean)
 
   private def coverageAll: Command = Command.command("coverageAll") { state =>
-    val saved = snapshotSettings(state)
     "clean" ::
-      "compile" ::
-      "set Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)" ::
       "coverage" ::
       "test" ::
       "coverageReport" ::
       "coverageAggregate" ::
-      "coverageAllRestore" ::
-      saved
+      state
   }
 
   private def coverageModules: Command = Command.args("coverageModules", "<module> [<module> ...]") {
@@ -90,33 +59,27 @@ object Coverage {
         state.globalLogging.full.error("Usage: coverageModules <module> [<module> ...]")
         state.fail
       } else {
-        val saved = snapshotSettings(state)
         val testTasks = args.map(m => s"$m/test").toList
         val reportTasks = args.map(m => s"$m/coverageReport").toList
         ("clean" ::
-          "compile" ::
-          "set Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)" ::
           "coverage" ::
           testTasks :::
           reportTasks :::
-          "coverageAllRestore" ::
-          Nil) ::: saved
+          Nil) ::: state
       }
   }
 
   private def coverageCheck: Command = Command.command("coverageCheck") { state =>
-    val saved = snapshotSettings(state)
     "clean" ::
-      "compile" ::
-      "set Global / concurrentRestrictions += Tags.limit(Tags.Compile, 1)" ::
       "set Global / coverageOutputHTML := false" ::
       "set Global / coverageOutputCobertura := false" ::
       "coverage" ::
       "test" ::
       "coverageReport" ::
       "coverageAggregate" ::
-      "coverageAllRestore" ::
-      saved
+      "set Global / coverageOutputHTML := true" ::
+      "set Global / coverageOutputCobertura := true" ::
+      state
   }
 
   private def coverageClean: Command = Command.command("coverageClean") { state =>
@@ -130,35 +93,5 @@ object Coverage {
       log.info(s"$reportsDir does not exist; nothing to delete")
     }
     state
-  }
-
-  private def snapshotSettings(state: State): State = {
-    val extracted = Project.extract(state)
-    val data = extracted.structure.data
-    val originalRestrictions = (Global / concurrentRestrictions).get(data).getOrElse(Seq.empty)
-    val originalCoverageEnabled = extracted.structure.allProjectRefs.flatMap { ref =>
-      (ref / coverageEnabled).get(data).map(ref -> _)
-    }.toMap
-    state
-      .put(savedRestrictions, originalRestrictions)
-      .put(savedCoverageEnabled, originalCoverageEnabled)
-  }
-
-  private def coverageAllRestore: Command = Command.command("coverageAllRestore") { state =>
-    val extracted = Project.extract(state)
-    val restrictionsSetting: Seq[Setting[?]] =
-      state.attributes.get(savedRestrictions)
-        .map(original => Seq(Global / concurrentRestrictions := original))
-        .getOrElse(Seq.empty)
-    val coverageEnabledSettings: Seq[Setting[?]] =
-      state.attributes.get(savedCoverageEnabled)
-        .map(_.toSeq.map { case (ref, value) => ref / coverageEnabled := value })
-        .getOrElse(Seq.empty)
-    val cleanState = state
-      .remove(savedRestrictions)
-      .remove(savedCoverageEnabled)
-    val toApply = restrictionsSetting ++ coverageEnabledSettings
-    if (toApply.isEmpty) cleanState
-    else extracted.appendWithSession(toApply, cleanState)
   }
 }


### PR DESCRIPTION
Resolves #194.

* Instruct the scoverage-inspector skill subagent to suffix build target subdirectories.
* Reattempt to remove coverage two-pass workaround from #189.
* Update documentation and agent rules.