### PR TITLE
[#154] Reorganize MpeTunerTest into operation/input-mode categories

### DIFF
--- a/issues/00154-mpe-tuner-poly-expr/tests-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/tests-reorg-plan.md
@@ -1,0 +1,336 @@
+# MpeTunerTest reorganization plan
+
+## Context
+
+`tuner/src/test/scala/.../MpeTunerTest.scala` has grown to 2127 lines across 21
+`behavior of` sections that mix several axes: the operation under test
+(`reset()`, `tune()`, `process()`), the kind of MIDI behavior (basic note
+allocation, expression, dropping, zone-level messages, MCM, PBS), and the input
+mode (MPE vs Non-MPE). The current layout has duplicated category names, some
+sections (e.g. "MPE Input Master Channel Notes", "Note Off Behavior", "Worked
+Examples") that span multiple concerns, and 9 `ignore`d future-work tests
+floating in three early sections that don't fit the rest of the file.
+
+This reorganization splits the suite into 8 well-defined categories, each
+sub-divided by input mode (MPE / Non-MPE), so:
+
+1. The structure matches the production semantics under test.
+2. The side-by-side CSV (`tests-reorg.csv`) makes it obvious which MPE/Non-MPE
+   pairs exist and which are missing — coverage gaps to drive future tests.
+3. Future contributors know where a new test belongs.
+
+User decisions captured up front:
+
+- Worked Examples → distributed into the 8 categories.
+- Drop redundant ` in MPE input mode` / ` in non-MPE mode` suffixes from test
+  names — the new `behavior of` heading carries the mode.
+- `ignore`d tests are listed as if they were live tests (their ignored state is
+  temporary).
+
+## New `behavior of` headings
+
+Each category gets two headings, one per input mode (omitted if no tests exist
+on that side — currently only "MCM Processing — MPE Input" is empty):
+
+```
+MpeTuner - reset() - Non-MPE Input
+MpeTuner - reset() - MPE Input
+MpeTuner - tune() - Non-MPE Input
+MpeTuner - tune() - MPE Input
+MpeTuner - process() - Basic - Non-MPE Input
+MpeTuner - process() - Basic - MPE Input
+MpeTuner - process() - Expression - Non-MPE Input
+MpeTuner - process() - Expression - MPE Input
+MpeTuner - process() - Note Dropping - Non-MPE Input
+MpeTuner - process() - Note Dropping - MPE Input
+MpeTuner - process() - Zone-level Messages - Non-MPE Input
+MpeTuner - process() - Zone-level Messages - MPE Input
+MpeTuner - MCM Processing - Non-MPE Input
+MpeTuner - PBS Processing - Non-MPE Input
+MpeTuner - PBS Processing - MPE Input
+```
+
+## Test-by-test mapping
+
+Source line numbers refer to the pre-reorganization file. "→" indicates the
+new `behavior of` heading. Renames shown in *italics*; if no rename is needed,
+the title is in plain text.
+
+### reset()
+
+Tie-breaker rule: when a test overlaps two categories and one is `MCM Processing`
+or `PBS Processing`, the MCM/PBS category wins. The three reset-output tests
+that emit MCM or PBS messages are routed accordingly (see MCM/PBS Processing
+sections below).
+
+Non-MPE Input:
+- L509 `clear internal state after reset`
+- L522 `emit Note Off for every active Member Channel note before resetting state`
+- L550 `not emit Note Off messages on reset when no notes are active`
+
+MPE Input:
+- L537 `emit Note Off for active Master Channel notes before resetting state`
+
+### tune()
+
+Non-MPE Input:
+- L559 `store tuning but output no messages when no active notes`
+- L567 `output updated Pitch Bend on each occupied member channel`
+- L581 `correctly retune notes of different pitch classes on different channels`
+- L1559 `not update released channel's pitch bend on tuning changes` (moved from "Note Off Behavior")
+- L1700 `reproduce paper section "Tuning change during performance"` (moved from "Worked Examples")
+
+MPE Input:
+- L595 *`output updated Pitch Bend on each occupied member channel`* (suffix dropped)
+- L612 `recompute pitch bend = new tuning offset + current expressive pitch bend on each occupied channel`
+- L1431 `not retune Master Channel notes on tune() call` (moved from "MPE Input Master Channel Notes")
+- L1601 *`not update released channel's pitch bend on tuning changes`* (suffix dropped; moved from "Note Off Behavior")
+
+### process() - Basic
+
+Non-MPE Input:
+- L641 `output Pitch Bend, CC #74, Channel Pressure, then Note On for single Note On`
+- L658 `output Note Off on the correct member channel`
+- L669 `allocate multiple notes with distinct pitch classes to separate member channels`
+- L679 `preserve Note On velocity`
+- L686 `preserve Note Off velocity`
+- L706 `treat Note On with velocity 0 as Note Off`
+- L716 `correctly allocate notes from any input channel`
+- L821 *`initialize member channel CC #74 to default 64 even after sending CC #74`* (suffix dropped; moved from "Non-MPE to MPE Conversion")
+- L835 *`initialize member channel Channel Pressure to default 0 even after sending CP`* (suffix dropped; moved from "Non-MPE to MPE Conversion")
+- L846 `initialize control dimensions before Note On even when input omits them` (moved from "Non-MPE to MPE Conversion")
+- L955 `compute output pitch bend = tuning offset for single note on channel` (moved from "Pitch Bend Computation")
+- L974 `clamp pitch bend to valid range when tuning offset exceeds PBS` (moved from "Pitch Bend Computation")
+- L1068 `allocate second note with same pitch class to Expression Group with independent pitch bends` (moved from "Dual-Group Allocation")
+- L1583 `make channel available for reuse after Note Off` (moved from "Note Off Behavior")
+
+MPE Input:
+- L696 *`preserve Note Off velocity`* (suffix dropped; moved from "Non-MPE Basic")
+- L1000 *`compute output pitch bend = tuning offset for single note on channel`* (suffix dropped; moved from "Pitch Bend Computation")
+- L1019 *`clamp pitch bend to valid range when tuning offset exceeds PBS`* (suffix dropped; moved from "Pitch Bend Computation")
+- L1044 `leave Pitch Class Group channel unaffected when bending Expression Group channel of same pitch class` (moved from "Dual-Group Allocation")
+- L1247 `process MPE input notes with tuning offsets applied` (moved from "MPE Input")
+- L1279 `split notes with different pitch classes from the same MPE input channel onto different output channels` (moved from "MPE Input")
+- L1356 `forward Note On received on Lower Master Channel on the same Master Channel` (from "MPE Input Master Channel Notes")
+- L1366 `not emit Pitch Bend, CC #74, or Channel Pressure setup for Master Channel Note On`
+- L1376 `forward Note Off received on Lower Master Channel on the same Master Channel`
+- L1386 `forward Note On/Off received on Upper Master Channel on the same Master Channel`
+- L1401 *`route member channel notes to their own zone in dual-zone`* (suffix dropped)
+- L1417 `not consume Member Channel slots for Master Channel notes`
+- L1441 `allow multiple active notes on the Master Channel concurrently`
+- L1532 *`seed Member Channel CC #74 from the per-input-channel value at Note On`* (suffix dropped)
+- L1546 *`seed Member Channel Channel Pressure from the per-input-channel value at Note On`* (suffix dropped)
+- L1625 *`make channel available for reuse after Note Off`* (suffix dropped; moved from "Note Off Behavior")
+- L1666 `reproduce paper section "Basic allocation in quarter-comma meantone"` (moved from "Worked Examples")
+
+### process() - Expression
+
+Non-MPE Input:
+- L727 `redirect input Pitch Bend to Master Channel as Zone-level Pitch Bend` (moved from "Non-MPE Pitch Bend")
+- L742 `not bleed master channel pitch bend into member channel tuning on retune` (moved from "Non-MPE Pitch Bend")
+- L765 `redirect input Channel Pressure to Master Channel as Zone-level Pitch Bend` (moved from "Non-MPE Channel Pressure") — *current name says "as Zone-level Pitch Bend" but it asserts Channel Pressure; the suspected typo is preserved as-is, flagged for separate fix.*
+- L782 `redirect input Slide CC #74 to Master Channel as Zone-level Pitch Bend` (moved from "Non-MPE Slide CC #74") — *same typo preserved as-is.*
+- L799 `convert Polyphonic Key Pressure to Channel Pressure on member channel` (moved from "Non-MPE to MPE Conversion")
+- L810 `ignore Polyphonic Key Pressure for non-active notes` (moved from "Non-MPE to MPE Conversion")
+
+MPE Input:
+- L1255 `treat per-note pitch bend as expressive pitch bend combined with tuning offset` (from "MPE Input")
+- L1272 `forward Master Channel pitch bend without modification`
+- L1298 `fan out expressive Pitch Bend to all output channels for split notes from same MPE input channel`
+- L1320 `fan out CC #74 to all output channels for split notes from same MPE input channel`
+- L1337 `fan out Channel Pressure to all output channels for split notes from same MPE input channel`
+- L1461 `forward Polyphonic Key Pressure as-is for Master Channel notes` (from "MPE Input Master Channel Notes")
+- L1472 *`drop Polyphonic Key Pressure received on a Member Channel`* (suffix dropped)
+- L1483 `not forward CC #74 on an MPE input channel with no active note`
+- L1492 `not forward Channel Pressure on an MPE input channel with no active note`
+- L1501 `not forward Pitch Bend on an MPE input member channel with no active note`
+- L1510 `forward CC #74 to the allocated Member Channel when an active note exists on MPE input channel`
+- L1521 `forward Channel Pressure to allocated Member Channel when active note exists on MPE input channel`
+- L1643 `not forward expressive controls from an input channel after its notes have been released` (from "Note Off Behavior")
+- L322 `average the expression pitch bend value of all active notes on a member channel` *(ignored; from "Averaging expression parameters")*
+- L346 `average the channel pressure value of all active notes on a member channel` *(ignored)*
+- L371 `average the MPE slide (CC #74) value of all active notes on a member channel` *(ignored)*
+- L415 `distribute the pitch bend values of the input channel` *(ignored; from "distributing expression parameters")*
+- L431 `distribute the channel pressure values of the input channel` *(ignored)*
+- L448 `distribute the slide values of the input channel` *(ignored)*
+
+### process() - Note Dropping
+
+Non-MPE Input:
+- L1093 `trigger note dropping with Note Off output for dropped notes on channel exhaustion`
+- L1108 `preserve the lowest note during channel exhaustion dropping`
+- L1120 `preserve the highest note during channel exhaustion dropping`
+- L1133 `preserve the highest and drop the lowest note during channel exhaustion dropping when there are only 2 candidate channels` *(ignored)*
+- L1145 `free a single channel during exhaustion dropping when there is a single member channel`
+- L1726 `reproduce paper section "Note dropping under channel exhaustion"` (moved from "Worked Examples")
+
+MPE Input:
+- L1156 *`trigger note dropping with Note Off output for dropped notes on channel exhaustion`* (suffix dropped)
+- L1171 *`preserve the lowest note during channel exhaustion dropping`* (suffix dropped)
+- L1184 *`preserve the highest note during channel exhaustion dropping`* (suffix dropped)
+- L1198 *`preserve the highest and drop the lowest note during channel exhaustion dropping when there are only 2 candidate channels`* (suffix dropped) *(ignored)*
+- L1210 *`free a single channel during exhaustion dropping when there is a single member channel`* (suffix dropped)
+- L209 `drop a channel with high expressive PB to make room for an incoming note with low expression PB` *(ignored; moved from "Dropping on high expressive pitch bend")*
+- L226 `drop a channel with high expressive PB to make room for an incoming note with high expression PB` *(ignored)*
+- L243 `drop a channel with low expressive PB to make room for an incoming note with high expression PB` *(ignored)*
+- L260 `prefer to drop a channel with low expressive PB to make room for an incoming note with high expression PB` *(ignored)*
+- L278 `drop other notes on a shared channel when one note develops a high expressive pitch bend` *(ignored)*
+- L300 `not drop other notes on a shared channel when one note develops a low expressive pitch bend`
+- L1222 `drop all notes on a shared channel with a common input channel when a high expressive pitch bend is received on it` *(ignored)*
+
+### process() - Zone-level Messages
+
+Non-MPE Input:
+- L862 `forward Sustain Pedal (CC #64) on Master Channel`
+- L870 `forward Program Change on Master Channel`
+- L878 `forward zone-level CCs on Master Channel`
+
+MPE Input:
+- L898 `forward Sustain Pedal (CC #64) received on member channel to zone Master Channel`
+- L907 `forward Program Change received on member channel to zone Master Channel`
+- L916 `forward zone-level CCs received on member channel to zone Master Channel`
+- L935 `route zone-level CC to upper zone Master Channel when received on upper member channel`
+- L944 `route Program Change to upper zone Master Channel when received on upper member channel`
+
+### MCM Processing
+
+Non-MPE Input (all current MCM tests start in Non-MPE input mode; MCM itself
+switches the tuner into MPE during the test):
+- L469 `output MPE Configuration Message (MCM) for the configured zone` (moved from `reset()` per tie-breaker rule)
+- L1754 `reconfigure lower zone on MCM received on channel 0`
+- L1769 `reconfigure upper zone on MCM received on channel 15`
+- L1784 `stop all active notes when MCM is received`
+- L1795 `shrink other zone when MCM causes overlap`
+- L1811 `disable zone when MCM with memberCount=0 is received`
+- L1822 `not trigger MCM on incomplete RPN sequence`
+- L1836 `not trigger MCM for non-MCM RPN (e.g. PBS RPN)`
+- L1847 `ignore MCM on non-master channel`
+- L1854 `revert to initialZones on reset() after MCM`
+- L1875 `not output PBS messages after MCM`
+- L1886 `switch input mode to MPE automatically when an MCM is received`
+- L1895 `reset PBS to defaults when MCM is received`
+
+MPE Input: *no current tests*.
+
+### PBS Processing
+
+Non-MPE Input:
+- L482 `output RPN 0 (Pitch Bend Sensitivity) on all member channels` (moved from `reset()` per tie-breaker rule)
+- L497 `output RPN 0 on master channel with configured master pitch bend sensitivity` (moved from `reset()` per tie-breaker rule)
+- L1922 `update master PBS on master channel`
+- L1936 `update member PBS and forward only on the received channel`
+- L1954 `forward PBS on each channel when received on all member channels`
+- L1968 `recompute pitch bends on occupied channels after member PBS change`
+- L1983 `not affect other zone's PBS`
+- L1994 `handle PBS LSB (cents) update`
+- L2037 `preserve intonation of active note without expressive pitch bend after PBS change`
+- L2050 `revert PBS to initial values on reset()`
+
+MPE Input:
+- L2011 `preserve intonation of active note with expressive pitch bend after PBS change` (uses inline MPE-mode tuner)
+- L2066 *`update master PBS on master channel`* (suffix dropped)
+- L2079 *`update member PBS and forward only on the received channel`* (suffix dropped)
+- L2098 *`recompute pitch bends on occupied channels after member PBS change`* (suffix dropped)
+- L2112 *`revert PBS to initial values on reset()`* (suffix dropped)
+
+## Sections being dissolved
+
+These existing `behavior of` headings disappear; every test is moved to one of
+the new categories above:
+
+- `MpeTuner - Dropping on high expressive pitch bend` → process() - Note Dropping - MPE Input
+- `MpeTuner - Averaging expression parameters` → process() - Expression - MPE Input
+- `MpeTuner - distributing expression parameters` → process() - Expression - MPE Input
+- `MpeTuner - process() Non-MPE Basic` → process() - Basic - Non-MPE Input (+ one to Basic - MPE Input)
+- `MpeTuner - process() Non-MPE Pitch Bend` → process() - Expression - Non-MPE Input
+- `MpeTuner - process() Non-MPE Channel Pressure` → process() - Expression - Non-MPE Input
+- `MpeTuner - process() Non-MPE Slide CC #74` → process() - Expression - Non-MPE Input
+- `MpeTuner - process() Non-MPE to MPE Conversion` → process() - Basic (init/seed tests) & process() - Expression (Poly Pressure tests)
+- `MpeTuner - process() Zone-Level Messages` → process() - Zone-level Messages - Non-MPE Input
+- `MpeTuner - process() Zone-Level Messages MPE Input` → process() - Zone-level Messages - MPE Input
+- `MpeTuner - process() Pitch Bend Computation` → process() - Basic (both modes)
+- `MpeTuner - process() Dual-Group Allocation` → process() - Basic (split across modes)
+- `MpeTuner - process() Note Dropping` → process() - Note Dropping (split across modes)
+- `MpeTuner - process() MPE Input` → process() - Basic - MPE Input + process() - Expression - MPE Input
+- `MpeTuner - process() MPE Input Master Channel Notes` → process() - Basic - MPE Input + process() - Expression - MPE Input + tune() - MPE Input
+- `MpeTuner - process() Note Off Behavior` → tune() (when assertion is on tune output) / process() - Basic (channel-reuse) / process() - Expression (forward-after-release)
+- `MpeTuner - Worked Examples` → distributed (Basic - MPE Input, tune() - Non-MPE, Note Dropping - Non-MPE)
+- `MpeTuner - MCM Processing` → MCM Processing - Non-MPE Input (kept)
+- `MpeTuner - PBS Processing` → PBS Processing (split across modes)
+
+## CSV layout
+
+The side-by-side table lives in [`tests-reorg.csv`](tests-reorg.csv) with two
+columns (`Non-MPE Input`, `MPE Input`). Each category starts with a separator
+row whose left cell is `== <category> ==` and right cell is empty. Test names
+that have a near-match across modes share a row; orphans get an empty cell on
+the opposite side. Renamed test cases use the post-rename text. Ignored tests
+appear with no extra marker.
+
+## Coverage gaps surfaced by the table
+
+The CSV makes the asymmetry visible at a glance:
+
+- **MPE Input is much richer for `process() - Expression`** (per-note PB, fan-out
+  of expression to all split-mapped output channels, gating expression by
+  active-note presence) — Non-MPE has only zone-level redirection tests. Likely
+  fine: this asymmetry is inherent to MPE.
+- **Note Dropping**: every "high expression PB → drop" case (6 ignored tests) is
+  MPE-only. Non-MPE has only channel-exhaustion dropping (5 tests, all live).
+- **`reset()` (after re-routing per the MCM/PBS tie-breaker rule) is essentially
+  Non-MPE only** — only one MPE-specific test (master-channel notes). Possible
+  additions: "clear internal state" and "no-op when empty" in MPE mode.
+- **Zone-level Messages** is symmetric for the three forwarding tests; only MPE
+  has upper-zone routing variants.
+- **MCM Processing - MPE Input has zero tests.** Worth asking whether
+  re-receiving an MCM while already in MPE mode should be tested separately.
+- Several MPE-only tests in `process() - Basic` could plausibly have Non-MPE
+  counterparts (preserve Note On velocity in both modes, treat Note On with
+  velocity 0 as Note Off in both modes, etc.) — listed as gaps on the MPE side
+  with empty Non-MPE cells where parity would be cheap to add.
+
+These gaps are intentionally surfaced rather than fixed in this change.
+
+## Reorganization steps for MpeTunerTest.scala
+
+1. Keep the file header (imports, class declaration line 31) and the entire
+   private fixture/helper block (lines 33–202) verbatim.
+2. Delete the existing `behavior of` headings and re-emit them in the order
+   listed in "New behavior of headings".
+3. For each new heading, append the test blocks in the order given in
+   "Test-by-test mapping". Move the entire block (`it should "…" in
+   new Fixture(…) { … }` or `ignore should "…"`); preserve all code,
+   comments, and `ignore` modifiers verbatim.
+4. Apply the renames noted with *italics* by editing just the string between
+   `should "` and `" in` (no logic changes).
+5. Delete the two `// TODO #154 Move new tests for their own category` /
+   `////////////////////////////////` / `///////////////////////` marker
+   comments at lines 204–206 and 465–466, since their reason for existing is
+   resolved.
+6. Re-run the suite to confirm nothing broke during the cut/paste:
+   `sbtn "tuner/testOnly org.calinburloiu.music.microtonalist.tuner.MpeTunerTest"`.
+
+The tests themselves are pure-Scala unit tests; no production code changes,
+no fixture changes, no helper changes. Diff should be 100% reordering + a
+handful of string edits on test names.
+
+## Verification
+
+After applying the reorganization:
+
+1. `sbtn "tuner/testOnly org.calinburloiu.music.microtonalist.tuner.MpeTunerTest"`
+   — every test must still pass / stay ignored. Counts should match
+   (currently 88 live + 14 ignored = 102 tests; the moves don't add or remove
+   any).
+2. Spot-check the new file structure: `grep -nE '^\s*(behavior of|it should|ignore should)'`
+   on the reorganized file should yield the headings in the order listed in
+   "New behavior of headings" and the right count under each.
+3. Open [`tests-reorg.csv`](tests-reorg.csv) in a spreadsheet viewer and
+   confirm the gap pattern matches "Coverage gaps surfaced by the table".
+
+## Critical files
+
+- `tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala`
+  — only file modified.
+- [`tests-reorg-plan.md`](tests-reorg-plan.md) — this file.
+- [`tests-reorg.csv`](tests-reorg.csv) — side-by-side category table.

--- a/issues/00154-mpe-tuner-poly-expr/tests-reorg.csv
+++ b/issues/00154-mpe-tuner-poly-expr/tests-reorg.csv
@@ -1,0 +1,104 @@
+Non-MPE Input,MPE Input
+== reset() ==,
+clear internal state after reset,
+emit Note Off for every active Member Channel note before resetting state,emit Note Off for active Master Channel notes before resetting state
+not emit Note Off messages on reset when no notes are active,
+== tune() ==,
+store tuning but output no messages when no active notes,
+output updated Pitch Bend on each occupied member channel,output updated Pitch Bend on each occupied member channel
+correctly retune notes of different pitch classes on different channels,
+,recompute pitch bend = new tuning offset + current expressive pitch bend on each occupied channel
+,not retune Master Channel notes on tune() call
+not update released channel's pitch bend on tuning changes,not update released channel's pitch bend on tuning changes
+"reproduce paper section ""Tuning change during performance""",
+== process() - Basic ==,
+"output Pitch Bend, CC #74, Channel Pressure, then Note On for single Note On",
+output Note Off on the correct member channel,forward Note Off received on Lower Master Channel on the same Master Channel
+allocate multiple notes with distinct pitch classes to separate member channels,split notes with different pitch classes from the same MPE input channel onto different output channels
+preserve Note On velocity,
+preserve Note Off velocity,preserve Note Off velocity
+treat Note On with velocity 0 as Note Off,
+correctly allocate notes from any input channel,
+initialize member channel CC #74 to default 64 even after sending CC #74,seed Member Channel CC #74 from the per-input-channel value at Note On
+initialize member channel Channel Pressure to default 0 even after sending CP,seed Member Channel Channel Pressure from the per-input-channel value at Note On
+initialize control dimensions before Note On even when input omits them,
+compute output pitch bend = tuning offset for single note on channel,compute output pitch bend = tuning offset for single note on channel
+clamp pitch bend to valid range when tuning offset exceeds PBS,clamp pitch bend to valid range when tuning offset exceeds PBS
+allocate second note with same pitch class to Expression Group with independent pitch bends,leave Pitch Class Group channel unaffected when bending Expression Group channel of same pitch class
+make channel available for reuse after Note Off,make channel available for reuse after Note Off
+,process MPE input notes with tuning offsets applied
+,forward Note On received on Lower Master Channel on the same Master Channel
+,"not emit Pitch Bend, CC #74, or Channel Pressure setup for Master Channel Note On"
+,forward Note On/Off received on Upper Master Channel on the same Master Channel
+,route member channel notes to their own zone in dual-zone
+,not consume Member Channel slots for Master Channel notes
+,allow multiple active notes on the Master Channel concurrently
+,"reproduce paper section ""Basic allocation in quarter-comma meantone"""
+== process() - Expression ==,
+redirect input Pitch Bend to Master Channel as Zone-level Pitch Bend,forward Master Channel pitch bend without modification
+not bleed master channel pitch bend into member channel tuning on retune,
+redirect input Channel Pressure to Master Channel as Zone-level Pitch Bend,
+redirect input Slide CC #74 to Master Channel as Zone-level Pitch Bend,
+convert Polyphonic Key Pressure to Channel Pressure on member channel,drop Polyphonic Key Pressure received on a Member Channel
+ignore Polyphonic Key Pressure for non-active notes,forward Polyphonic Key Pressure as-is for Master Channel notes
+,treat per-note pitch bend as expressive pitch bend combined with tuning offset
+,fan out expressive Pitch Bend to all output channels for split notes from same MPE input channel
+,fan out CC #74 to all output channels for split notes from same MPE input channel
+,fan out Channel Pressure to all output channels for split notes from same MPE input channel
+,not forward CC #74 on an MPE input channel with no active note
+,not forward Channel Pressure on an MPE input channel with no active note
+,not forward Pitch Bend on an MPE input member channel with no active note
+,forward CC #74 to the allocated Member Channel when an active note exists on MPE input channel
+,forward Channel Pressure to allocated Member Channel when active note exists on MPE input channel
+,not forward expressive controls from an input channel after its notes have been released
+,average the expression pitch bend value of all active notes on a member channel
+,average the channel pressure value of all active notes on a member channel
+,average the MPE slide (CC #74) value of all active notes on a member channel
+,distribute the pitch bend values of the input channel
+,distribute the channel pressure values of the input channel
+,distribute the slide values of the input channel
+== process() - Note Dropping ==,
+trigger note dropping with Note Off output for dropped notes on channel exhaustion,trigger note dropping with Note Off output for dropped notes on channel exhaustion
+preserve the lowest note during channel exhaustion dropping,preserve the lowest note during channel exhaustion dropping
+preserve the highest note during channel exhaustion dropping,preserve the highest note during channel exhaustion dropping
+preserve the highest and drop the lowest note during channel exhaustion dropping when there are only 2 candidate channels,preserve the highest and drop the lowest note during channel exhaustion dropping when there are only 2 candidate channels
+free a single channel during exhaustion dropping when there is a single member channel,free a single channel during exhaustion dropping when there is a single member channel
+"reproduce paper section ""Note dropping under channel exhaustion""",
+,drop a channel with high expressive PB to make room for an incoming note with low expression PB
+,drop a channel with high expressive PB to make room for an incoming note with high expression PB
+,drop a channel with low expressive PB to make room for an incoming note with high expression PB
+,prefer to drop a channel with low expressive PB to make room for an incoming note with high expression PB
+,drop other notes on a shared channel when one note develops a high expressive pitch bend
+,not drop other notes on a shared channel when one note develops a low expressive pitch bend
+,drop all notes on a shared channel with a common input channel when a high expressive pitch bend is received on it
+== process() - Zone-level Messages ==,
+forward Sustain Pedal (CC #64) on Master Channel,forward Sustain Pedal (CC #64) received on member channel to zone Master Channel
+forward Program Change on Master Channel,forward Program Change received on member channel to zone Master Channel
+forward zone-level CCs on Master Channel,forward zone-level CCs received on member channel to zone Master Channel
+,route zone-level CC to upper zone Master Channel when received on upper member channel
+,route Program Change to upper zone Master Channel when received on upper member channel
+== MCM Processing ==,
+output MPE Configuration Message (MCM) for the configured zone,
+reconfigure lower zone on MCM received on channel 0,
+reconfigure upper zone on MCM received on channel 15,
+stop all active notes when MCM is received,
+shrink other zone when MCM causes overlap,
+disable zone when MCM with memberCount=0 is received,
+not trigger MCM on incomplete RPN sequence,
+not trigger MCM for non-MCM RPN (e.g. PBS RPN),
+ignore MCM on non-master channel,
+revert to initialZones on reset() after MCM,
+not output PBS messages after MCM,
+switch input mode to MPE automatically when an MCM is received,
+reset PBS to defaults when MCM is received,
+== PBS Processing ==,
+output RPN 0 (Pitch Bend Sensitivity) on all member channels,
+output RPN 0 on master channel with configured master pitch bend sensitivity,
+update master PBS on master channel,update master PBS on master channel
+update member PBS and forward only on the received channel,update member PBS and forward only on the received channel
+forward PBS on each channel when received on all member channels,
+recompute pitch bends on occupied channels after member PBS change,recompute pitch bends on occupied channels after member PBS change
+not affect other zone's PBS,
+handle PBS LSB (cents) update,
+preserve intonation of active note without expressive pitch bend after PBS change,preserve intonation of active note with expressive pitch bend after PBS change
+revert PBS to initial values on reset(),revert PBS to initial values on reset()

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
@@ -200,11 +200,1279 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
     }
   }
 
+  private abstract class DistributeFixture extends Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
+    private val output1: Seq[MidiMessage] = noteOn(1, D4)
+    private val output2: Seq[MidiMessage] = noteOn(1, E4)
 
-  // TODO #154 Move new tests for their own category
-  ////////////////////////////////
+    private val output3: Seq[MidiMessage] = noteOn(3, F4)
+    private val output4: Seq[MidiMessage] = noteOn(3, G4)
+    private val output1bis: Seq[MidiMessage] = noteOn(3, D4)
 
-  behavior of "MpeTuner - Dropping on high expressive pitch bend"
+    protected val output1Channel: Int = extractNoteOns(output1).head.channel
+    protected val output2Channel: Int = extractNoteOns(output2).head.channel
+    protected val output3Channel: Int = extractNoteOns(output3).head.channel
+    protected val output4Channel: Int = extractNoteOns(output4).head.channel
+    private val output1bisChannel: Int = extractNoteOns(output1bis).head.channel
+
+    output1bisChannel shouldEqual output1Channel
+  }
+
+  /** Sends a complete MCM RPN sequence: CC#100=6, CC#101=0, CC#6=memberCount on the given channel. */
+  private def sendMcm(tuner: MpeTuner, channel: Int, memberCount: Int): Seq[MidiMessage] = {
+    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnLsb, ScMidiRpn.MpeConfigurationMessageLsb).asJava)
+    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnMsb, ScMidiRpn.MpeConfigurationMessageMsb).asJava)
+    tuner.process(CcScMidiMessage(channel, ScMidiCc.DataEntryMsb, memberCount).asJava)
+  }
+
+  /** Sends a complete PBS RPN MSB sequence: CC#100=0, CC#101=0, CC#6=semitones on the given channel. */
+  private def sendPbsMsb(tuner: MpeTuner, channel: Int, semitones: Int): Seq[MidiMessage] = {
+    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb).asJava)
+    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb).asJava)
+    tuner.process(CcScMidiMessage(channel, ScMidiCc.DataEntryMsb, semitones).asJava)
+  }
+
+  /** Sends a PBS RPN LSB (cents) on the given channel, assuming RPN is already set to PBS. */
+  private def sendPbsLsb(tuner: MpeTuner, channel: Int, cents: Int): Seq[MidiMessage] = {
+    tuner.process(CcScMidiMessage(channel, ScMidiCc.DataEntryLsb, cents).asJava)
+  }
+
+  behavior of "MpeTuner - reset() - Non-MPE Input"
+
+  it should "clear internal state after reset" in new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+    // Given
+    // Play a note
+    noteOn(nonMpeInputChannel, C4)
+    // When
+    // Reset should clear everything
+    tuner.reset()
+    // Then
+    // tune() with no active notes should produce no pitch bend messages
+    private val output = tuner.tune(pythagoreanTuning)
+    extractPitchBends(output) shouldBe empty
+  }
+
+  it should "emit Note Off for every active Member Channel note before resetting state" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // Given
+      private val out1 = noteOn(nonMpeInputChannel, C4)
+      private val out2 = noteOn(nonMpeInputChannel, E4)
+      private val ch1 = extractNoteOns(out1).head.channel
+      private val ch2 = extractNoteOns(out2).head.channel
+      // When
+      private val resetOutput = tuner.reset()
+      // Then
+      private val noteOffs = extractNoteOffs(resetOutput)
+      noteOffs should contain(NoteOffScMidiMessage(ch1, C4))
+      noteOffs should contain(NoteOffScMidiMessage(ch2, E4))
+    }
+
+  it should "not emit Note Off messages on reset when no notes are active" in new Fixture {
+    // When
+    private val resetOutput = tuner.reset()
+    // Then
+    extractNoteOffs(resetOutput) shouldBe empty
+  }
+
+  behavior of "MpeTuner - reset() - MPE Input"
+
+  it should "emit Note Off for active Master Channel notes before resetting state" in
+    new Fixture(mpeTunerMpeInput) {
+      // Given
+      noteOn(0, C4)
+      noteOn(0, E4)
+      // When
+      private val resetOutput = tuner.reset()
+      // Then
+      private val noteOffs = extractNoteOffs(resetOutput)
+      noteOffs should contain(NoteOffScMidiMessage(0, C4))
+      noteOffs should contain(NoteOffScMidiMessage(0, E4))
+    }
+
+  behavior of "MpeTuner - tune() - Non-MPE Input"
+
+  it should "store tuning but output no messages when no active notes" in new Fixture {
+    // When
+    private val output = tuner.tune(quarterCommaMeantone)
+    // Then
+    tuner.tuning shouldEqual quarterCommaMeantone
+    extractPitchBends(output) shouldBe empty
+  }
+
+  it should "output updated Pitch Bend on each occupied member channel" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // Given
+      private val out1 = noteOn(nonMpeInputChannel, C4)
+      private val noteOnChannel = extractNoteOns(out1).head.channel
+      private val out2 = noteOn(nonMpeInputChannel, E4)
+      private val noteOnChannel2 = extractNoteOns(out2).head.channel
+      // When
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val pitchBends = extractPitchBends(tuneOutput)
+      pitchBends.map(_.channel).toSet should contain allOf(noteOnChannel, noteOnChannel2)
+    }
+
+  it should "correctly retune notes of different pitch classes on different channels" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // Given
+      noteOn(nonMpeInputChannel, C4)
+      noteOn(nonMpeInputChannel, E4)
+      // When
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val pitchBends = extractPitchBends(tuneOutput)
+      // C and E should have different pitch bends (different tuning offsets)
+      pitchBends.size shouldEqual 2
+      pitchBends.map(_.cents.round.toInt) should contain theSameElementsInOrderAs Seq(0, 8)
+    }
+
+  it should "not update released channel's pitch bend on tuning changes" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // Given
+      // E has -14.0 cents offset; pythagorean E has 8.0 cents — non-zero in both tunings
+      private val noteOutputE = noteOn(nonMpeInputChannel, E4)
+      private val releasedChannel = extractNoteOns(noteOutputE).head.channel
+
+      // G stays active as a control
+      private val noteOutputG = noteOn(nonMpeInputChannel, G4)
+      private val activeChannel = extractNoteOns(noteOutputG).head.channel
+
+      // Release E4
+      noteOff(nonMpeInputChannel, E4)
+
+      // When
+      // Retune — only the active channel (G) should get a pitch bend update
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val pitchBends = extractPitchBends(tuneOutput)
+      pitchBends should have size 1
+      pitchBends.head.channel shouldBe activeChannel
+      pitchBends.head.cents.round.toInt shouldBe 2 // pythagorean G offset
+    }
+
+  it should "reproduce paper section \"Tuning change during performance\"" in
+    new Fixture(tuner7, Some(quarterCommaMeantone)) {
+      // Given
+      private val chC = extractNoteOns(noteOn(nonMpeInputChannel, C4)).head.channel
+      private val chE = extractNoteOns(noteOn(nonMpeInputChannel, E4)).head.channel
+      private val chG = extractNoteOns(noteOn(nonMpeInputChannel, G4)).head.channel
+      private val chC5 = extractNoteOns(noteOn(nonMpeInputChannel, C5)).head.channel
+
+      // When
+      // Switch to Pythagorean tuning
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val pitchBends = extractPitchBends(tuneOutput)
+
+      // Should have pitch bend updates for all 4 occupied channels
+      pitchBends should have size 4
+
+      // Pythagorean offsets: C = 0.0, E = 8.0, G = 2.0
+      private val pbByChannel = pitchBends.map(pb => pb.channel -> pb.cents.round.toInt).toMap
+      pbByChannel(chC) shouldBe 0
+      pbByChannel(chE) shouldBe 8
+      pbByChannel(chG) shouldBe 2
+      // C5 shares pitch class C, so same offset
+      pbByChannel(chC5) shouldBe 0
+    }
+
+  behavior of "MpeTuner - tune() - MPE Input"
+
+  it should "output updated Pitch Bend on each occupied member channel" in
+    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      private val out1 = noteOn(1, C4)
+      private val noteOnChannel = extractNoteOns(out1).head.channel
+      private val out2 = noteOn(2, E4)
+      private val noteOnChannel2 = extractNoteOns(out2).head.channel
+      // When
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val pitchBends = extractPitchBends(tuneOutput)
+      pitchBends.map(_.channel).toSet should contain allOf(noteOnChannel, noteOnChannel2)
+      // C and E should reflect pythagorean tuning offsets (0.0, 8.0)
+      pitchBends.size shouldEqual 2
+      pitchBends.map(_.cents.round.toInt) should contain theSameElementsInOrderAs Seq(0, 8)
+    }
+
+  it should "recompute pitch bend = new tuning offset + current expressive pitch bend on each occupied channel" in
+    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      // E has -14.0 in quarter-comma meantone, +8.0 in pythagorean
+      private val noteOutE = noteOn(1, E4)
+      private val chE = extractNoteOns(noteOutE).head.channel
+      private val noteOutG = noteOn(2, G4)
+      private val chG = extractNoteOns(noteOutG).head.channel
+
+      // Apply small expressive pitch bends (under the high-bend threshold) per note in MPE mode
+      private val eExprCents = 20.0
+      private val gExprCents = -30.0
+      pitchBend(1, eExprCents)
+      pitchBend(2, gExprCents)
+
+      // When
+      // Switch tuning — output PB on each channel must combine new tuning offset + expressive bend.
+      // Compare on MIDI values (not cents) to avoid resolution noise from the cents↔value roundtrip.
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val pbByChannel = extractPitchBends(tuneOutput).map(pb => pb.channel -> pb.value).toMap
+      private val expectedE = PitchBendScMidiMessage.convertCentsToValue(8.0 + eExprCents, defaultPbs)
+      private val expectedG = PitchBendScMidiMessage.convertCentsToValue(2.0 + gExprCents, defaultPbs)
+      pbByChannel(chE) shouldBe expectedE
+      pbByChannel(chG) shouldBe expectedG
+    }
+
+  it should "not retune Master Channel notes on tune() call" in
+    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      noteOn(0, C4)
+      // When
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      extractPitchBends(tuneOutput).filter(_.channel == 0) shouldBe empty
+    }
+
+  it should "not update released channel's pitch bend on tuning changes" in
+    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      // E has -14.0 cents offset; pythagorean E has 8.0 cents — non-zero in both tunings
+      private val noteOutputE = noteOn(1, E4)
+      private val releasedChannel = extractNoteOns(noteOutputE).head.channel
+
+      // G stays active as a control
+      private val noteOutputG = noteOn(2, G4)
+      private val activeChannel = extractNoteOns(noteOutputG).head.channel
+
+      // Release E4
+      noteOff(1, E4)
+
+      // When
+      // Retune — only the active channel (G) should get a pitch bend update
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val pitchBends = extractPitchBends(tuneOutput)
+      pitchBends should have size 1
+      pitchBends.head.channel shouldBe activeChannel
+      pitchBends.head.cents.round.toInt shouldBe 2 // pythagorean G offset
+    }
+
+  behavior of "MpeTuner - process() - Basic - Non-MPE Input"
+
+  it should "output Pitch Bend, CC #74, Channel Pressure, then Note On for single Note On" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // When
+      private val output = noteOn(nonMpeInputChannel, C4, 100)
+      // Then
+      private val msgs = extractScMidiMessages(output)
+      private val noteChannel = extractNoteOns(output).head.channel
+
+      // Should have: PitchBend, CC#74, ChannelPressure, NoteOn
+      msgs should contain inOrder(
+        PitchBendScMidiMessage(noteChannel, 0),
+        CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 64),
+        ChannelPressureScMidiMessage(noteChannel, 0),
+        NoteOnScMidiMessage(noteChannel, C4, 100)
+      )
+    }
+
+  it should "output Note Off on the correct member channel" in new Fixture {
+    // Given
+    private val noteOnOutput = noteOn(nonMpeInputChannel, C4)
+    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
+    // When
+    private val noteOffOutput = noteOff(nonMpeInputChannel, C4)
+    // Then
+    private val noteOffs = extractNoteOffs(noteOffOutput)
+    noteOffs should contain(NoteOffScMidiMessage(noteOnChannel, C4))
+  }
+
+  it should "allocate multiple notes with distinct pitch classes to separate member channels" in new Fixture {
+    // When
+    private val out1 = noteOn(nonMpeInputChannel, C4)
+    private val out2 = noteOn(nonMpeInputChannel, E4)
+    private val out3 = noteOn(nonMpeInputChannel, G4)
+    // Then
+    private val channels = Seq(out1, out2, out3).flatMap(extractNoteOns).map(_.channel)
+    channels.distinct.size shouldBe 3
+  }
+
+  it should "preserve Note On velocity" in new Fixture {
+    // When
+    private val output = noteOn(nonMpeInputChannel, C4, 87)
+    // Then
+    extractNoteOns(output).head.velocity shouldBe 87
+  }
+
+  it should "preserve Note Off velocity" in new Fixture {
+    // Given
+    private val noteOnOutput = noteOn(nonMpeInputChannel, C4, 100)
+    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
+    // When
+    private val noteOffOutput = noteOff(nonMpeInputChannel, C4, 73)
+    // Then
+    extractNoteOffs(noteOffOutput) should contain(NoteOffScMidiMessage(noteOnChannel, C4, 73))
+  }
+
+  it should "treat Note On with velocity 0 as Note Off" in new Fixture {
+    // Given
+    private val noteOnOutput = noteOn(nonMpeInputChannel, C4, 100)
+    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
+    // When
+    private val noteOffOutput = noteOn(nonMpeInputChannel, C4, 0)
+    // Then
+    extractNoteOffs(noteOffOutput) should contain(NoteOffScMidiMessage(noteOnChannel, C4))
+  }
+
+  it should "correctly allocate notes from any input channel" in new Fixture {
+    // When
+    private val out1 = noteOn(0, C4)
+    private val out2 = noteOn(5, E4)
+    // Then
+    extractNoteOns(out1).map(_.channel) should contain(1)
+    extractNoteOns(out2).map(_.channel) should contain(2)
+  }
+
+  it should "initialize member channel CC #74 to default 64 even after sending CC #74" in
+    new Fixture {
+      // Given
+      // Sender sends CC #74 before Note On; value goes to Master Channel only
+      slide(nonMpeInputChannel, 120)
+      // When
+      private val output = noteOn(nonMpeInputChannel, C4)
+      // Then
+      private val noteChannel = extractNoteOns(output).head.channel
+      // Member channel must be initialized with neutral default (64), not the sender's value,
+      // to avoid double-counting with the Master Channel value.
+      extractCc(output) should contain(CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 64))
+    }
+
+  it should "initialize member channel Channel Pressure to default 0 even after sending CP" in
+    new Fixture {
+      // Given
+      pressure(nonMpeInputChannel, 100)
+      // When
+      private val output = noteOn(nonMpeInputChannel, C4)
+      // Then
+      private val noteChannel = extractNoteOns(output).head.channel
+      extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 0))
+    }
+
+  it should "initialize control dimensions before Note On even when input omits them" in new Fixture {
+    // When
+    private val output = noteOn(nonMpeInputChannel, C4)
+    // Then
+    private val msgs = extractScMidiMessages(output)
+
+    private val noteChannel = 1
+    // CC #74 should be 64 (default), Channel Pressure should be 0 (default)
+    msgs should contain allOf(
+      CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 64),
+      ChannelPressureScMidiMessage(noteChannel, 0)
+    )
+  }
+
+  it should "compute output pitch bend = tuning offset for single note on channel" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // C has 0.0 cents offset
+      private val outC = noteOn(nonMpeInputChannel, C4)
+      extractPitchBends(outC).head.cents shouldEqual 0.0
+
+      // E has -14.0 cents offset
+      private val outE = noteOn(nonMpeInputChannel, E4)
+      extractPitchBends(outE).head.cents shouldEqual -14.0
+
+      // D has -7.0 cents offset
+      private val outD = noteOn(nonMpeInputChannel, D4)
+      extractPitchBends(outD).head.cents shouldEqual -7.0
+
+      // G has -3.0 cents offset
+      private val outG = noteOn(nonMpeInputChannel, G4)
+      extractPitchBends(outG).head.cents shouldEqual -3.0
+    }
+
+  it should "clamp pitch bend to valid range when tuning offset exceeds PBS" in {
+    // Use a small PBS (2 semitones = 200 cents) so that a large tuning offset exceeds the range
+    val smallPbs = PitchBendSensitivity(2)
+    val smallPbsTuner = MpeTuner(
+      initialZones = MpeZones(
+        MpeZone(MpeZoneType.Lower, 15, memberPitchBendSensitivity = smallPbs),
+        MpeZone(MpeZoneType.Upper, 0)
+      )
+    )
+    new Fixture(smallPbsTuner) {
+      // B: exceeds ±200 cents PBS range
+      private val extremeTuning = Tuning("extreme", b = Some(500.0))
+      tuner.tune(extremeTuning)
+
+      // B should be clamped to max pitch bend value
+      private val outB = noteOn(nonMpeInputChannel, MidiNote.B4)
+      private val pbB = extractPitchBends(outB).head
+      pbB.value shouldBe PitchBendScMidiMessage.MaxValue
+      pbB.centsFor(smallPbs) shouldEqual smallPbs.totalCents.toDouble
+
+      // C has 0.0 offset, should not be clamped
+      private val outC = noteOn(nonMpeInputChannel, C4)
+      extractPitchBends(outC).head.value shouldBe 0
+    }
+  }
+
+  it should "allocate second note with same pitch class to Expression Group with independent pitch bends" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // When
+      // E has -14.0 cents offset in quarter-comma meantone
+      private val out1 = noteOn(nonMpeInputChannel, E4)
+      private val ch1 = extractNoteOns(out1).head.channel
+      private val pb1 = extractPitchBends(out1).head
+
+      private val out2 = noteOn(nonMpeInputChannel, E5)
+      private val ch2 = extractNoteOns(out2).head.channel
+      private val pb2 = extractPitchBends(out2).head
+
+      // Then
+      // Notes should be on different channels
+      ch1 should not equal ch2
+
+      // Both should have pitch bends reflecting the -14.0 cents tuning offset for E
+      pb1.channel shouldBe ch1
+      pb1.cents shouldEqual -14.0
+      pb2.channel shouldBe ch2
+      pb2.cents shouldEqual -14.0
+    }
+
+  it should "make channel available for reuse after Note Off" in new Fixture(tuner3) {
+    // Given
+    // Fill all 3 member channels
+    noteOn(nonMpeInputChannel, C4)
+    private val out = noteOn(nonMpeInputChannel, E4)
+    private val ch = extractNoteOns(out).head.channel
+    noteOn(nonMpeInputChannel, G4)
+
+    // When
+    // Release the second note
+    noteOff(nonMpeInputChannel, E4)
+
+    // Then
+    // New note should reuse the released channel
+    private val output = noteOn(nonMpeInputChannel, D4)
+    extractNoteOns(output).head.channel shouldBe ch
+  }
+
+  behavior of "MpeTuner - process() - Basic - MPE Input"
+
+  it should "preserve Note Off velocity" in new Fixture(tuner7MpeInput) {
+    // Given
+    private val noteOnOutput = noteOn(1, C4, 100)
+    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
+    // When
+    private val noteOffOutput = noteOff(1, C4, 73)
+    // Then
+    extractNoteOffs(noteOffOutput) should contain(NoteOffScMidiMessage(noteOnChannel, C4, 73))
+  }
+
+  it should "compute output pitch bend = tuning offset for single note on channel" in
+    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
+      // C has 0.0 cents offset
+      private val outC = noteOn(1, C4)
+      extractPitchBends(outC).head.cents shouldEqual 0.0
+
+      // E has -14.0 cents offset
+      private val outE = noteOn(2, E4)
+      extractPitchBends(outE).head.cents shouldEqual -14.0
+
+      // D has -7.0 cents offset
+      private val outD = noteOn(3, D4)
+      extractPitchBends(outD).head.cents shouldEqual -7.0
+
+      // G has -3.0 cents offset
+      private val outG = noteOn(4, G4)
+      extractPitchBends(outG).head.cents shouldEqual -3.0
+    }
+
+  it should "clamp pitch bend to valid range when tuning offset exceeds PBS" in {
+    val smallPbs = PitchBendSensitivity(2)
+    val smallPbsTuner = MpeTuner(
+      initialZones = MpeZones(
+        MpeZone(MpeZoneType.Lower, 15, memberPitchBendSensitivity = smallPbs),
+        MpeZone(MpeZoneType.Upper, 0)
+      ),
+      initialInputMode = MpeInputMode.Mpe
+    )
+    new Fixture(smallPbsTuner) {
+      private val extremeTuning = Tuning("extreme", b = Some(500.0))
+      tuner.tune(extremeTuning)
+
+      private val outB = noteOn(1, MidiNote.B4)
+      private val pbB = extractPitchBends(outB).head
+      pbB.value shouldBe PitchBendScMidiMessage.MaxValue
+      pbB.centsFor(smallPbs) shouldEqual smallPbs.totalCents.toDouble
+
+      private val outC = noteOn(2, C4)
+      extractPitchBends(outC).head.value shouldBe 0
+    }
+  }
+
+  it should "leave Pitch Class Group channel unaffected when bending Expression Group channel of same pitch class" in
+    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      // E4 -> PCG channel (E enters Pitch Class Group)
+      private val outE4 = noteOn(1, E4)
+      private val pcgChannel = extractNoteOns(outE4).head.channel
+
+      // E5 (same pitch class) -> Expression Group channel (PCG slot for E is already taken)
+      private val outE5 = noteOn(2, E5)
+      private val egChannel = extractNoteOns(outE5).head.channel
+      egChannel should not equal pcgChannel
+
+      // When
+      // Send a non-high expressive pitch bend on the EG input channel
+      private val eExprCents = 30.0
+      private val bendOutput = pitchBend(2, eExprCents)
+      // Then
+      private val pitchBends = extractPitchBends(bendOutput)
+
+      // Only the EG channel should receive an updated pitch bend; the PCG channel must not.
+      pitchBends.map(_.channel) should contain(egChannel)
+      pitchBends.map(_.channel) should not contain pcgChannel
+      pitchBends.filter(_.channel == egChannel).head.cents shouldEqual (-14.0 + eExprCents)
+    }
+
+  it should "process MPE input notes with tuning offsets applied" in
+    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
+      // When
+      private val output = noteOn(1, E4, 100)
+      // Then
+      extractPitchBends(output).head.cents shouldEqual -14.0
+    }
+
+  it should "split notes with different pitch classes from the same MPE input channel onto different output channels" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      // C4 on input ch 2 — allocator honors the input channel hint, places C4 on output ch 2.
+      private val out1 = noteOn(2, C4)
+      private val ch1 = extractNoteOns(out1).head.channel
+
+      // When
+      // E4 on the same input ch 2 — different pitch class, so the pitch-class invariant prevents
+      // sharing output ch 2 with C4. The allocator must split E4 onto a different output channel.
+      private val out2 = noteOn(2, E4)
+      private val ch2 = extractNoteOns(out2).head.channel
+
+      // Then
+      ch1 shouldBe 2
+      ch2 should not be ch1
+      ch2 should (be >= 1 and be <= 7)
+    }
+
+  it should "forward Note On received on Lower Master Channel on the same Master Channel" in
+    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
+      // When
+      private val output = noteOn(0, C4, 100)
+      // Then
+      private val noteOns = extractNoteOns(output)
+      noteOns should have size 1
+      noteOns.head shouldEqual NoteOnScMidiMessage(0, C4, 100)
+    }
+
+  it should "not emit Pitch Bend, CC #74, or Channel Pressure setup for Master Channel Note On" in
+    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
+      // When
+      private val output = noteOn(0, C4, 100)
+      // Then
+      extractPitchBends(output) shouldBe empty
+      extractCc(output).filter(_.number == ScMidiCc.MpeSlide) shouldBe empty
+      extractChannelPressures(output) shouldBe empty
+    }
+
+  it should "forward Note Off received on Lower Master Channel on the same Master Channel" in
+    new Fixture(mpeTunerMpeInput) {
+      // Given
+      noteOn(0, C4, 100)
+      // When
+      private val output = noteOff(0, C4)
+      // Then
+      extractNoteOffs(output) should contain(NoteOffScMidiMessage(0, C4))
+    }
+
+  it should "forward Note On/Off received on Upper Master Channel on the same Master Channel" in
+    new Fixture(dualZoneTunerMpeInput) {
+      // When
+      private val onOutput = noteOn(15, C4, 90)
+      // Then
+      private val noteOns = extractNoteOns(onOutput)
+      noteOns should have size 1
+      noteOns.head shouldEqual NoteOnScMidiMessage(15, C4, 90)
+
+      // When
+      private val offOutput = noteOff(15, C4)
+      // Then
+      extractNoteOffs(offOutput) should contain(NoteOffScMidiMessage(15, C4))
+    }
+
+  it should "route member channel notes to their own zone in dual-zone" in
+    new Fixture(dualZoneTunerMpeInput) {
+      // When
+      // Lower zone: master 0, members 1..7. Upper zone: master 15, members 8..14.
+      private val lowerOut = noteOn(1, C4)
+      private val lowerChannel = extractNoteOns(lowerOut).head.channel
+      // Then
+      lowerChannel should (be >= 1 and be <= 7)
+
+      // When
+      private val upperOut = noteOn(8, C4)
+      private val upperChannel = extractNoteOns(upperOut).head.channel
+      // Then
+      upperChannel should (be >= 8 and be <= 14)
+    }
+
+  it should "not consume Member Channel slots for Master Channel notes" in
+    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      // Master Channel note should not occupy a Member Channel
+      noteOn(0, C4)
+      // When
+      // Subsequent Member Channel note gets the first Member Channel
+      private val out = noteOn(mpeInputChannel, E4)
+      // Then
+      private val noteOns = extractNoteOns(out)
+      noteOns should have size 1
+      noteOns.head.channel shouldBe 1
+    }
+
+  it should "allow multiple active notes on the Master Channel concurrently" in
+    new Fixture(mpeTunerMpeInput) {
+      // When
+      private val out1 = noteOn(0, C4, 100)
+      private val out2 = noteOn(0, E4, 100)
+      // Then
+      extractNoteOns(out1).map(n => (n.channel, n.midiNote)) should contain((0, C4))
+      extractNoteOns(out2).map(n => (n.channel, n.midiNote)) should contain((0, E4))
+
+      // When
+      private val offOutput = noteOff(0, C4)
+      // Then
+      extractNoteOffs(offOutput) should contain(NoteOffScMidiMessage(0, C4))
+      // E4 should still be tracked as active
+      // When
+      private val offOutput2 = noteOff(0, E4)
+      // Then
+      extractNoteOffs(offOutput2) should contain(NoteOffScMidiMessage(0, E4))
+    }
+
+  it should "seed Member Channel CC #74 from the per-input-channel value at Note On" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      // Send CC #74 first (no active note, so forwarding is dropped) — but the per-input-channel value is recorded
+      slide(mpeInputChannel, 100)
+      // When
+      // Note On should seed the Member Channel CC #74 with the recorded value (not the neutral default 64)
+      private val output = noteOn(mpeInputChannel, C4)
+      // Then
+      private val noteChannel = extractNoteOns(output).head.channel
+      extractCc(output) should contain(CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 100))
+    }
+
+  // TODO #154 Do we have a similar test for PB?
+  it should "seed Member Channel Channel Pressure from the per-input-channel value at Note On" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      pressure(mpeInputChannel, 90)
+      // When
+      private val output = noteOn(mpeInputChannel, C4)
+      // Then
+      private val noteChannel = extractNoteOns(output).head.channel
+      extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 90))
+    }
+
+  it should "make channel available for reuse after Note Off" in
+    new Fixture(tuner3MpeInput) {
+      // Given
+      noteOn(1, C4)
+      private val out = noteOn(2, E4)
+      private val ch = extractNoteOns(out).head.channel
+      noteOn(3, G4)
+
+      // When
+      // Release the second note
+      noteOff(2, E4)
+
+      // Then
+      // New note arriving on a different input channel should reuse the released channel
+      private val output = noteOn(1, D4)
+      extractNoteOns(output).head.channel shouldBe ch
+    }
+
+  it should "reproduce paper section \"Basic allocation in quarter-comma meantone\"" in
+    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
+      // 1. Note C4 arrives on input ch 1 -> Pitch Class Group; C has 0.0 cents offset
+      private val out1 = noteOn(1, C4)
+      private val ch1 = extractNoteOns(out1).head.channel
+      extractPitchBends(out1).head.cents shouldEqual 0.0
+
+      // 2. Note E4 arrives on input ch 2 -> Pitch Class Group; E has -14.0 cents offset
+      private val out2 = noteOn(2, E4)
+      private val ch2 = extractNoteOns(out2).head.channel
+      ch2 should not equal ch1
+      extractPitchBends(out2).head.cents shouldEqual -14.0
+
+      // 3. Note G4 arrives on input ch 3 -> Pitch Class Group; G has -3.0 cents offset
+      private val out3 = noteOn(3, G4)
+      private val ch3 = extractNoteOns(out3).head.channel
+      ch3 should not equal ch2
+      extractPitchBends(out3).head.cents shouldEqual -3.0
+
+      // 4. Second C (C5) arrives on input ch 4 -> Expression Group; C has 0.0 cents offset
+      private val out4 = noteOn(4, C5)
+      private val ch4 = extractNoteOns(out4).head.channel
+      ch4 should not equal ch1
+      extractPitchBends(out4).head.cents shouldEqual 0.0
+
+      // 5. Performer bends C5 on input ch 4 — only ch4's pitch bend is affected
+      private val cExprCents = 586.0
+      private val bendOut = pitchBend(4, cExprCents)
+      private val pitchBends = extractPitchBends(bendOut)
+      pitchBends should have size 1
+      pitchBends.head.channel shouldBe ch4
+      pitchBends.head.cents shouldEqual (0.0 + cExprCents)
+    }
+
+  behavior of "MpeTuner - process() - Expression - Non-MPE Input"
+
+  it should "redirect input Pitch Bend to Master Channel as Zone-level Pitch Bend" in new Fixture {
+    // When
+    private var output = pitchBend(nonMpeInputChannel, 50.0)
+    // Then
+    private var pitchBends = extractPitchBendsWithCents(output)
+    pitchBends should contain theSameElementsAs Seq((0, 50))
+
+    // When
+    noteOn(nonMpeInputChannel, E4)
+    output = pitchBend(nonMpeInputChannel, 25.0)
+    // Then
+    pitchBends = extractPitchBendsWithCents(output)
+    pitchBends should contain theSameElementsAs Seq((0, 25))
+  }
+
+  it should "not bleed master channel pitch bend into member channel tuning on retune" in
+    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
+      // Given
+      // E has -14.0 cents offset in quarter-comma meantone
+      private val noteOutput = noteOn(nonMpeInputChannel, E4)
+      private val noteChannel = extractNoteOns(noteOutput).head.channel
+      extractPitchBends(noteOutput).head.cents shouldEqual -14.0
+
+      // In NonMpe mode, pitch bend goes to the master channel as zone-level expression
+      tuner.process(PitchBendScMidiMessage(nonMpeInputChannel, 500).asJava)
+
+      // When
+      // Retune — member channel pitch bend should only reflect tuning, not master expression
+      private val tuneOutput = tuner.tune(pythagoreanTuning)
+      // Then
+      private val memberPb = extractPitchBends(tuneOutput).filter(_.channel == noteChannel)
+      memberPb should have size 1
+      // Pythagorean E offset is 8.0 cents — no contamination from the master pitch bend
+      memberPb.head.cents.round.toInt shouldBe 8
+    }
+
+  it should "redirect input Channel Pressure to Master Channel as Zone-level Pitch Bend" in new Fixture {
+    // When
+    private var output = pressure(nonMpeInputChannel, 32)
+    // Then
+    private var channelPressures = extractChannelPressures(output)
+    channelPressures should contain theSameElementsAs Seq(ChannelPressureScMidiMessage(0, 32))
+
+    // When
+    noteOn(nonMpeInputChannel, E4)
+    output = pressure(nonMpeInputChannel, 25)
+    // Then
+    channelPressures = extractChannelPressures(output)
+    channelPressures should contain theSameElementsAs Seq(ChannelPressureScMidiMessage(0, 25))
+  }
+
+  it should "redirect input Slide CC #74 to Master Channel as Zone-level Pitch Bend" in new Fixture {
+    // When
+    private var output = slide(nonMpeInputChannel, 72)
+    // Then
+    private var slides = extractSlides(output)
+    slides should contain theSameElementsAs Seq(CcScMidiMessage(0, ScMidiCc.MpeSlide, 72))
+
+    // When
+    noteOn(nonMpeInputChannel, E4)
+    output = slide(nonMpeInputChannel, 96)
+    // Then
+    slides = extractSlides(output)
+    slides should contain theSameElementsAs Seq(CcScMidiMessage(0, ScMidiCc.MpeSlide, 96))
+  }
+
+  it should "convert Polyphonic Key Pressure to Channel Pressure on member channel" in new Fixture {
+    // Given
+    private val noteOutput = noteOn(nonMpeInputChannel, C4)
+    private val noteChannel = extractNoteOns(noteOutput).head.channel
+    // When
+    private val output = tuner.process(PolyPressureScMidiMessage(nonMpeInputChannel, C4, 80).asJava)
+    // Then
+    extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 80))
+    output.map(_.asScala).collect { case m: PolyPressureScMidiMessage => m } shouldBe empty
+  }
+
+  it should "ignore Polyphonic Key Pressure for non-active notes" in new Fixture {
+    // Given
+    private val noteOutput = noteOn(nonMpeInputChannel, C4)
+    private val noteChannel = extractNoteOns(noteOutput).head.channel
+    // When
+    private val output = tuner.process(PolyPressureScMidiMessage(nonMpeInputChannel, D4, 80).asJava)
+    // Then
+    extractChannelPressures(output) shouldBe empty
+    output.map(_.asScala).collect { case m: PolyPressureScMidiMessage => m } shouldBe empty
+  }
+
+  behavior of "MpeTuner - process() - Expression - MPE Input"
+
+  it should "treat per-note pitch bend as expressive pitch bend combined with tuning offset" in
+    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      // E has -14.0 cents offset in quarter-comma meantone
+      private val noteOutput = noteOn(1, E4, 100)
+      private val noteChannel = extractNoteOns(noteOutput).head.channel
+
+      private val eExprCents = 290.0
+      // When
+      private val output = pitchBend(1, eExprCents)
+      // Then
+      private val pitchBendMsg = extractPitchBends(output).filter(_.channel == noteChannel).head
+
+      // Output pitch bend should combine tuning offset for E (-14.0) + expressive bend
+      pitchBendMsg.cents shouldEqual (-14.0 + eExprCents)
+    }
+
+  it should "forward Master Channel pitch bend without modification" in new Fixture(mpeTunerMpeInput) {
+    // When
+    private val output = tuner.process(PitchBendScMidiMessage(0, 1000).asJava)
+    // Then
+    extractPitchBends(output) should contain(PitchBendScMidiMessage(0, 1000))
+  }
+
+  it should "fan out expressive Pitch Bend to all output channels for split notes from same MPE input channel" in
+    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      private val out1 = noteOn(2, C4)
+      private val ch1 = extractNoteOns(out1).head.channel
+      private val out2 = noteOn(2, E4)
+      private val ch2 = extractNoteOns(out2).head.channel
+
+      private val exprCents = 30.0
+      // When
+      private val output = pitchBend(2, exprCents)
+
+      // Then
+      // Both output channels must receive the expressive bend on top of their tuning offset.
+      // C: 0.0 cents, E: -14.0 cents in quarter-comma meantone.
+      private val pbs = extractPitchBends(output)
+      private val ch1Pb = pbs.find(_.channel == ch1).value
+      private val ch2Pb = pbs.find(_.channel == ch2).value
+      ch1Pb.cents shouldEqual (0.0 + exprCents)
+      ch2Pb.cents shouldEqual (-14.0 + exprCents)
+    }
+
+  it should "fan out CC #74 to all output channels for split notes from same MPE input channel" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      private val out1 = noteOn(2, C4)
+      private val ch1 = extractNoteOns(out1).head.channel
+      private val out2 = noteOn(2, E4)
+      private val ch2 = extractNoteOns(out2).head.channel
+
+      // When
+      private val output = slide(2, 100)
+
+      // Then
+      private val slides = extractSlides(output).map(cc => (cc.channel, cc.value)).toSet
+      slides should contain((ch1, 100))
+      slides should contain((ch2, 100))
+    }
+
+  it should "fan out Channel Pressure to all output channels for split notes from same MPE input channel" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      private val out1 = noteOn(2, C4)
+      private val ch1 = extractNoteOns(out1).head.channel
+      private val out2 = noteOn(2, E4)
+      private val ch2 = extractNoteOns(out2).head.channel
+
+      // When
+      private val output = pressure(2, 90)
+
+      // Then
+      private val cps = extractChannelPressures(output).map(cp => (cp.channel, cp.value)).toSet
+      cps should contain((ch1, 90))
+      cps should contain((ch2, 90))
+    }
+
+  it should "forward Polyphonic Key Pressure as-is for Master Channel notes" in
+    new Fixture(mpeTunerMpeInput) {
+      // Given
+      noteOn(0, C4, 100)
+      // When
+      private val output = tuner.process(PolyPressureScMidiMessage(0, C4, 80).asJava)
+      // Then
+      extractPolyPressure(output) should contain(PolyPressureScMidiMessage(0, C4, 80))
+      extractChannelPressures(output) shouldBe empty
+    }
+
+  it should "drop Polyphonic Key Pressure received on a Member Channel" in
+    new Fixture(mpeTunerMpeInput) {
+      // Given
+      noteOn(mpeInputChannel, C4, 100)
+      // When
+      private val output = tuner.process(PolyPressureScMidiMessage(mpeInputChannel, C4, 80).asJava)
+      // Then
+      extractPolyPressure(output) shouldBe empty
+      extractChannelPressures(output) shouldBe empty
+    }
+
+  it should "not forward CC #74 on an MPE input channel with no active note" in
+    new Fixture(tuner7MpeInput) {
+      // When
+      // Send CC #74 on a member channel that has no active note
+      private val output = slide(mpeInputChannel, 100)
+      // Then
+      extractCc(output) shouldBe empty
+    }
+
+  it should "not forward Channel Pressure on an MPE input channel with no active note" in
+    new Fixture(tuner7MpeInput) {
+      // When
+      // Send Channel Pressure on a member channel that has no active note
+      private val output = pressure(mpeInputChannel, 90)
+      // Then
+      extractChannelPressures(output) shouldBe empty
+    }
+
+  it should "not forward Pitch Bend on an MPE input member channel with no active note" in
+    new Fixture(tuner7MpeInput) {
+      // When
+      // Send Pitch Bend on a member channel that has no active note
+      private val output = tuner.process(PitchBendScMidiMessage(mpeInputChannel, 4000).asJava)
+      // Then
+      extractPitchBends(output) shouldBe empty
+    }
+
+  it should "forward CC #74 to the allocated Member Channel when an active note exists on MPE input channel" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      private val noteOutput = noteOn(mpeInputChannel, C4)
+      private val noteChannel = extractNoteOns(noteOutput).head.channel
+      // When
+      private val output = slide(mpeInputChannel, 100)
+      // Then
+      extractCc(output) should contain(CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 100))
+    }
+
+  it should "forward Channel Pressure to allocated Member Channel when active note exists on MPE input channel" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      private val noteOutput = noteOn(mpeInputChannel, C4)
+      private val noteChannel = extractNoteOns(noteOutput).head.channel
+      // When
+      private val output = pressure(mpeInputChannel, 90)
+      // Then
+      extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 90))
+    }
+
+  it should "not forward expressive controls from an input channel after its notes have been released" in
+    new Fixture(tuner7MpeInput) {
+      // Given
+      // Note On routes mpeInputChannel -> some output channel
+      noteOn(mpeInputChannel, C4)
+      noteOff(mpeInputChannel, C4)
+
+      // When / Then
+      // After Note Off, no input->output mapping should exist for mpeInputChannel — expressive
+      // CC #74 / Channel Pressure / Pitch Bend on this input channel must NOT be forwarded to a
+      // (now stale) member channel.
+      private val ccOutput = slide(mpeInputChannel, 100)
+      extractCc(ccOutput) shouldBe empty
+
+      private val cpOutput = pressure(mpeInputChannel, 90)
+      extractChannelPressures(cpOutput) shouldBe empty
+
+      private val pbOutput = tuner.process(PitchBendScMidiMessage(mpeInputChannel, 4000).asJava)
+      extractPitchBends(pbOutput) shouldBe empty
+    }
+
+  ignore should "average the expression pitch bend value of all active notes on a member channel" in
+    new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      private val e1Output = noteOn(1, E1, pbCents = Some(10.0))
+      private val e1OutputChannel = extractNoteOns(e1Output).head.channel
+      noteOn(3, E3)
+      noteOn(4, E4)
+
+      // When
+      private var output = noteOn(2, E2, pbCents = Some(-20.0))
+      // Then
+      private var outputPitchBends = extractPitchBends(output)
+      outputPitchBends should have size 1
+      outputPitchBends.head.channel shouldEqual e1OutputChannel
+      outputPitchBends.head.cents shouldEqual (quarterCommaMeantone.e - 5.0)
+
+      // When
+      output = pitchBend(2, 30.0)
+      // Then
+      outputPitchBends = extractPitchBends(output)
+      outputPitchBends.head.channel shouldEqual e1OutputChannel
+      outputPitchBends.head.cents shouldEqual (quarterCommaMeantone.e + 20.0)
+    }
+
+  ignore should "average the channel pressure value of all active notes on a member channel" in
+    new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      private val e1Output = noteOn(1, E1, pressure = Some(32))
+      private val e1OutputChannel = extractNoteOns(e1Output).head.channel
+      noteOn(3, E3)
+      noteOn(4, E4)
+
+      // When
+      private var output = noteOn(2, E2, pressure = Some(96))
+      // Then
+      private var outputPressures = extractChannelPressures(output)
+      outputPressures should have size 1
+      outputPressures.head.channel shouldEqual e1OutputChannel
+      outputPressures.head.value shouldEqual 64
+
+      // When
+      output = pressure(2, 16)
+      // Then
+      outputPressures = extractChannelPressures(output)
+      outputPressures should have size 1
+      outputPressures.head.channel shouldEqual e1OutputChannel
+      outputPressures.head.value shouldEqual 24
+    }
+
+  ignore should "average the MPE slide (CC #74) value of all active notes on a member channel" in
+    new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      private val e1Output = noteOn(1, E1, slide = Some(48))
+      private val e1OutputChannel = extractNoteOns(e1Output).head.channel
+      noteOn(3, E3)
+      noteOn(4, E4)
+
+      // When
+      private var output = noteOn(2, E2, pressure = Some(16))
+      // Then
+      private var outputSlides = extractSlides(output)
+      outputSlides should have size 1
+      outputSlides.head.channel shouldEqual e1OutputChannel
+      outputSlides.head.value shouldEqual 32
+
+      // When
+      output = slide(2, 96)
+      // Then
+      outputSlides = extractSlides(output)
+      outputSlides should have size 1
+      outputSlides.head.channel shouldEqual e1OutputChannel
+      outputSlides.head.value shouldEqual 72
+    }
+
+  ignore should "distribute the pitch bend values of the input channel" in new DistributeFixture {
+    // When
+    private val pitchBends1 = extractPitchBends(pitchBend(1, 10.0))
+    private val pitchBends3 = extractPitchBends(pitchBend(3, 30.0))
+
+    // Then
+    pitchBends1.map(_.channel) shouldEqual Seq(output1Channel, output2Channel)
+    pitchBends1.head.cents shouldEqual (quarterCommaMeantone.d + 10.0)
+    pitchBends1(1).cents shouldEqual (quarterCommaMeantone.e + 10.0)
+
+    pitchBends3.map(_.channel) shouldEqual Seq(output3Channel, output4Channel, output1Channel)
+    pitchBends3.head.cents shouldEqual (quarterCommaMeantone.f + 30.0)
+    pitchBends3(1).cents shouldEqual (quarterCommaMeantone.g + 30.0)
+    pitchBends3(2).cents shouldEqual (quarterCommaMeantone.d + 20.0)
+  }
+
+  ignore should "distribute the channel pressure values of the input channel" in new DistributeFixture {
+    // When
+    private val channelPressures1 = extractChannelPressures(pressure(1, 10))
+    private val channelPressures3 = extractChannelPressures(pressure(3, 30))
+
+    // Then
+    channelPressures1 should contain theSameElementsAs Seq(
+      ChannelPressureScMidiMessage(output1Channel, 10),
+      ChannelPressureScMidiMessage(output2Channel, 10)
+    )
+    channelPressures3 should contain theSameElementsAs Seq(
+      ChannelPressureScMidiMessage(output3Channel, 30),
+      ChannelPressureScMidiMessage(output4Channel, 30),
+      ChannelPressureScMidiMessage(output1Channel, 20)
+    )
+  }
+
+  ignore should "distribute the slide values of the input channel" in new DistributeFixture {
+    // When
+    private val slides1 = extractSlides(slide(1, 10))
+    private val slides3 = extractSlides(slide(3, 30))
+
+    // Then
+    slides1 should contain theSameElementsAs Seq(
+      CcScMidiMessage(output1Channel, ScMidiCc.MpeSlide, 10),
+      CcScMidiMessage(output2Channel, ScMidiCc.MpeSlide, 10)
+    )
+    slides3 should contain theSameElementsAs Seq(
+      CcScMidiMessage(output3Channel, ScMidiCc.MpeSlide, 30),
+      CcScMidiMessage(output4Channel, ScMidiCc.MpeSlide, 30),
+      CcScMidiMessage(output1Channel, ScMidiCc.MpeSlide, 20)
+    )
+  }
+
+  behavior of "MpeTuner - process() - Note Dropping - Non-MPE Input"
+
+  it should "trigger note dropping with Note Off output for dropped notes on channel exhaustion" in
+    new Fixture(tuner3) {
+      // Given
+      noteOn(nonMpeInputChannel, C4)
+      noteOn(nonMpeInputChannel, E4)
+      noteOn(nonMpeInputChannel, G4)
+      // When
+      private val output = noteOn(nonMpeInputChannel, A4)
+      // Then
+      private val noteOffs = extractNoteOffs(output)
+      noteOffs should have size 1
+      // Dropped E4, not C4. The latter, although older, is the bass note which is excluded.
+      noteOffs.head.midiNote shouldEqual E4
+    }
+
+  it should "preserve the lowest note during channel exhaustion dropping" in new Fixture(tuner3) {
+    // Given
+    noteOn(nonMpeInputChannel, C4) // lowest
+    noteOn(nonMpeInputChannel, E4) // middle
+    noteOn(nonMpeInputChannel, G4) // highest
+    // When
+    private val output = noteOn(nonMpeInputChannel, A4)
+    // Then
+    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+    droppedNotes should not contain C4
+  }
+
+  it should "preserve the highest note during channel exhaustion dropping" in new Fixture(tuner3) {
+    // Given
+    // Oldest not, but will not be dropped since it's the highest.
+    noteOn(nonMpeInputChannel, G4) // highest
+    noteOn(nonMpeInputChannel, C4) // lowest
+    noteOn(nonMpeInputChannel, E4) // middle
+    // When
+    private val output = noteOn(nonMpeInputChannel, A4)
+    // Then
+    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+    droppedNotes should not contain G4
+  }
+
+  ignore should "preserve the highest and drop the lowest note during channel exhaustion dropping when there are only" +
+    " 2 candidate channels" in new Fixture(tuner2) {
+    // Given
+    noteOn(nonMpeInputChannel, G4) // highest
+    noteOn(nonMpeInputChannel, C4) // lowest
+    // When
+    private val output = noteOn(nonMpeInputChannel, E4)
+    // Then
+    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+    droppedNotes should contain(C4)
+  }
+
+  it should "free a single channel during exhaustion dropping when there is a single member channel" in
+    new Fixture(tuner1) {
+      // Given
+      noteOn(nonMpeInputChannel, C4)
+      // When
+      private val output = noteOn(nonMpeInputChannel, E4)
+      // Then
+      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+      droppedNotes should contain(C4)
+    }
+
+  it should "reproduce paper section \"Note dropping under channel exhaustion\"" in
+    new Fixture(tuner3, Some(quarterCommaMeantone)) {
+      // Given
+      // C, E, G on 3 channels
+      noteOn(nonMpeInputChannel, C4)
+      noteOn(nonMpeInputChannel, E4)
+      noteOn(nonMpeInputChannel, G4)
+
+      // When
+      // A arrives - must drop a note
+      private val output = noteOn(nonMpeInputChannel, A4)
+      // Then
+      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+      // E should be dropped (C is lowest, G is highest)
+      droppedNotes should contain(E4)
+      // A should be allocated
+      extractNoteOns(output).map(_.midiNote) should contain(A4)
+    }
+
+  behavior of "MpeTuner - process() - Note Dropping - MPE Input"
+
+  it should "trigger note dropping with Note Off output for dropped notes on channel exhaustion" in
+    new Fixture(tuner3MpeInput) {
+      // Given
+      noteOn(1, C4)
+      noteOn(2, E4)
+      noteOn(3, G4)
+      // When
+      private val output = noteOn(1, A4)
+      // Then
+      private val noteOffs = extractNoteOffs(output)
+      noteOffs should have size 1
+      // Dropped E4, not C4. The latter, although older, is the bass note which is excluded.
+      noteOffs.head.midiNote shouldEqual E4
+    }
+
+  it should "preserve the lowest note during channel exhaustion dropping" in
+    new Fixture(tuner3MpeInput) {
+      // Given
+      noteOn(1, C4) // lowest
+      noteOn(2, E4) // middle
+      noteOn(3, G4) // highest
+      // When
+      private val output = noteOn(1, A4)
+      // Then
+      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+      droppedNotes should not contain C4
+    }
+
+  it should "preserve the highest note during channel exhaustion dropping" in
+    new Fixture(tuner3MpeInput) {
+      // Given
+      // Oldest not, but will not be dropped since it's the highest.
+      noteOn(3, G4) // highest
+      noteOn(1, C4) // lowest
+      noteOn(2, E4) // middle
+      // When
+      private val output = noteOn(1, A4)
+      // Then
+      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+      droppedNotes should not contain G4
+    }
+
+  ignore should "preserve the highest and drop the lowest note during channel exhaustion dropping when there are only" +
+    " 2 candidate channels" in new Fixture(tuner2MpeInput) {
+    // Given
+    noteOn(2, G4) // highest
+    noteOn(1, C4) // lowest
+    // When
+    private val output = noteOn(1, E4)
+    // Then
+    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+    droppedNotes should contain(C4)
+  }
+
+  it should "free a single channel during exhaustion dropping when there is a single member channel" in
+    new Fixture(tuner1MpeInput) {
+      // Given
+      noteOn(1, C4)
+      // When
+      private val output = noteOn(1, E4)
+      // Then
+      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
+      droppedNotes should contain(C4)
+    }
 
   ignore should "drop a channel with high expressive PB to make room for an incoming note with low expression PB" in
     new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
@@ -317,547 +1585,30 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       extractNoteOffs(output) shouldBe empty
     }
 
-  behavior of "MpeTuner - Averaging expression parameters"
-
-  ignore should "average the expression pitch bend value of all active notes on a member channel" in
-    new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
+  ignore should "drop all notes on a shared channel with a common input channel when a high expressive pitch bend is " +
+    "received on it" in
+    new Fixture(tuner3MpeInput) {
       // Given
-      private val e1Output = noteOn(1, E1, pbCents = Some(10.0))
-      private val e1OutputChannel = extractNoteOns(e1Output).head.channel
-      noteOn(3, E3)
-      noteOn(4, E4)
+      // tuner3 in MPE input: PCG=1, EG=2. Input channels are 1..3.
+      // Share E4 + E5 on the same output channel by sending E5 on E4's input channel.
+      private val outE4 = noteOn(1, E4)
+      private val sharedChannel = extractNoteOns(outE4).head.channel
+      noteOn(2, G4)
+      noteOn(3, C4)
+      noteOn(1, E5)
 
       // When
-      private var output = noteOn(2, E2, pbCents = Some(-20.0))
+      // High expressive pitch bend (> 50 cents threshold) on input ch 1 -> drops co-resident E4.
+      private val output = pitchBend(1, 100.0)
       // Then
-      private var outputPitchBends = extractPitchBends(output)
-      outputPitchBends should have size 1
-      outputPitchBends.head.channel shouldEqual e1OutputChannel
-      outputPitchBends.head.cents shouldEqual (quarterCommaMeantone.e - 5.0)
-
-      // When
-      output = pitchBend(2, 30.0)
-      // Then
-      outputPitchBends = extractPitchBends(output)
-      outputPitchBends.head.channel shouldEqual e1OutputChannel
-      outputPitchBends.head.cents shouldEqual (quarterCommaMeantone.e + 20.0)
-    }
-
-  ignore should "average the channel pressure value of all active notes on a member channel" in
-    new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      private val e1Output = noteOn(1, E1, pressure = Some(32))
-      private val e1OutputChannel = extractNoteOns(e1Output).head.channel
-      noteOn(3, E3)
-      noteOn(4, E4)
-
-      // When
-      private var output = noteOn(2, E2, pressure = Some(96))
-      // Then
-      private var outputPressures = extractChannelPressures(output)
-      outputPressures should have size 1
-      outputPressures.head.channel shouldEqual e1OutputChannel
-      outputPressures.head.value shouldEqual 64
-
-      // When
-      output = pressure(2, 16)
-      // Then
-      outputPressures = extractChannelPressures(output)
-      outputPressures should have size 1
-      outputPressures.head.channel shouldEqual e1OutputChannel
-      outputPressures.head.value shouldEqual 24
-    }
-
-  ignore should "average the MPE slide (CC #74) value of all active notes on a member channel" in
-    new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      private val e1Output = noteOn(1, E1, slide = Some(48))
-      private val e1OutputChannel = extractNoteOns(e1Output).head.channel
-      noteOn(3, E3)
-      noteOn(4, E4)
-
-      // When
-      private var output = noteOn(2, E2, pressure = Some(16))
-      // Then
-      private var outputSlides = extractSlides(output)
-      outputSlides should have size 1
-      outputSlides.head.channel shouldEqual e1OutputChannel
-      outputSlides.head.value shouldEqual 32
-
-      // When
-      output = slide(2, 96)
-      // Then
-      outputSlides = extractSlides(output)
-      outputSlides should have size 1
-      outputSlides.head.channel shouldEqual e1OutputChannel
-      outputSlides.head.value shouldEqual 72
-    }
-
-  behavior of "MpeTuner - distributing expression parameters"
-
-  private abstract class DistributeFixture extends Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
-    private val output1: Seq[MidiMessage] = noteOn(1, D4)
-    private val output2: Seq[MidiMessage] = noteOn(1, E4)
-
-    private val output3: Seq[MidiMessage] = noteOn(3, F4)
-    private val output4: Seq[MidiMessage] = noteOn(3, G4)
-    private val output1bis: Seq[MidiMessage] = noteOn(3, D4)
-
-    protected val output1Channel: Int = extractNoteOns(output1).head.channel
-    protected val output2Channel: Int = extractNoteOns(output2).head.channel
-    protected val output3Channel: Int = extractNoteOns(output3).head.channel
-    protected val output4Channel: Int = extractNoteOns(output4).head.channel
-    private val output1bisChannel: Int = extractNoteOns(output1bis).head.channel
-
-    output1bisChannel shouldEqual output1Channel
-  }
-
-  ignore should "distribute the pitch bend values of the input channel" in new DistributeFixture {
-    // When
-    private val pitchBends1 = extractPitchBends(pitchBend(1, 10.0))
-    private val pitchBends3 = extractPitchBends(pitchBend(3, 30.0))
-
-    // Then
-    pitchBends1.map(_.channel) shouldEqual Seq(output1Channel, output2Channel)
-    pitchBends1.head.cents shouldEqual (quarterCommaMeantone.d + 10.0)
-    pitchBends1(1).cents shouldEqual (quarterCommaMeantone.e + 10.0)
-
-    pitchBends3.map(_.channel) shouldEqual Seq(output3Channel, output4Channel, output1Channel)
-    pitchBends3.head.cents shouldEqual (quarterCommaMeantone.f + 30.0)
-    pitchBends3(1).cents shouldEqual (quarterCommaMeantone.g + 30.0)
-    pitchBends3(2).cents shouldEqual (quarterCommaMeantone.d + 20.0)
-  }
-
-  ignore should "distribute the channel pressure values of the input channel" in new DistributeFixture {
-    // When
-    private val channelPressures1 = extractChannelPressures(pressure(1, 10))
-    private val channelPressures3 = extractChannelPressures(pressure(3, 30))
-
-    // Then
-    channelPressures1 should contain theSameElementsAs Seq(
-      ChannelPressureScMidiMessage(output1Channel, 10),
-      ChannelPressureScMidiMessage(output2Channel, 10)
-    )
-    channelPressures3 should contain theSameElementsAs Seq(
-      ChannelPressureScMidiMessage(output3Channel, 30),
-      ChannelPressureScMidiMessage(output4Channel, 30),
-      ChannelPressureScMidiMessage(output1Channel, 20)
-    )
-  }
-
-  ignore should "distribute the slide values of the input channel" in new DistributeFixture {
-    // When
-    private val slides1 = extractSlides(slide(1, 10))
-    private val slides3 = extractSlides(slide(3, 30))
-
-    // Then
-    slides1 should contain theSameElementsAs Seq(
-      CcScMidiMessage(output1Channel, ScMidiCc.MpeSlide, 10),
-      CcScMidiMessage(output2Channel, ScMidiCc.MpeSlide, 10)
-    )
-    slides3 should contain theSameElementsAs Seq(
-      CcScMidiMessage(output3Channel, ScMidiCc.MpeSlide, 30),
-      CcScMidiMessage(output4Channel, ScMidiCc.MpeSlide, 30),
-      CcScMidiMessage(output1Channel, ScMidiCc.MpeSlide, 20)
-    )
-  }
-
-  ///////////////////////
-
-  behavior of "MpeTuner - reset()"
-
-  it should "output MPE Configuration Message (MCM) for the configured zone" in new Fixture(defaultTuner) {
-    // When
-    private val output = tuner.reset()
-    // Then
-    private val ccs = extractCc(output)
-    // MCM: RPN LSB=6, RPN MSB=0, Data Entry MSB=memberCount on master channel 0
-    ccs should contain inOrder(
-      CcScMidiMessage(0, ScMidiCc.RpnLsb, ScMidiRpn.MpeConfigurationMessageLsb),
-      CcScMidiMessage(0, ScMidiCc.RpnMsb, ScMidiRpn.MpeConfigurationMessageMsb),
-      CcScMidiMessage(0, ScMidiCc.DataEntryMsb, 15)
-    )
-  }
-
-  it should "output RPN 0 (Pitch Bend Sensitivity) on all member channels" in new Fixture(tuner7) {
-    // When
-    private val output = tuner.reset()
-    // Then
-    private val ccs = extractCc(output)
-    // Check that PBS is set on member channels 1..7
-    (1 to 7).foreach { ch =>
-      ccs should contain inOrder(
-        CcScMidiMessage(ch, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
-        CcScMidiMessage(ch, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
-        CcScMidiMessage(ch, ScMidiCc.DataEntryMsb, 48)
-      )
-    }
-  }
-
-  it should "output RPN 0 on master channel with configured master pitch bend sensitivity" in new Fixture {
-    // When
-    private val output = tuner.reset()
-    // Then
-    private val ccs = extractCc(output)
-    ccs should contain inOrder(
-      CcScMidiMessage(0, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
-      CcScMidiMessage(0, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
-      CcScMidiMessage(0, ScMidiCc.DataEntryMsb, 2)
-    )
-  }
-
-  it should "clear internal state after reset" in new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-    // Given
-    // Play a note
-    noteOn(nonMpeInputChannel, C4)
-    // When
-    // Reset should clear everything
-    tuner.reset()
-    // Then
-    // tune() with no active notes should produce no pitch bend messages
-    private val output = tuner.tune(pythagoreanTuning)
-    extractPitchBends(output) shouldBe empty
-  }
-
-  it should "emit Note Off for every active Member Channel note before resetting state" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // Given
-      private val out1 = noteOn(nonMpeInputChannel, C4)
-      private val out2 = noteOn(nonMpeInputChannel, E4)
-      private val ch1 = extractNoteOns(out1).head.channel
-      private val ch2 = extractNoteOns(out2).head.channel
-      // When
-      private val resetOutput = tuner.reset()
-      // Then
-      private val noteOffs = extractNoteOffs(resetOutput)
-      noteOffs should contain(NoteOffScMidiMessage(ch1, C4))
-      noteOffs should contain(NoteOffScMidiMessage(ch2, E4))
-    }
-
-  it should "emit Note Off for active Master Channel notes before resetting state" in
-    new Fixture(mpeTunerMpeInput) {
-      // Given
-      noteOn(0, C4)
-      noteOn(0, E4)
-      // When
-      private val resetOutput = tuner.reset()
-      // Then
-      private val noteOffs = extractNoteOffs(resetOutput)
-      noteOffs should contain(NoteOffScMidiMessage(0, C4))
-      noteOffs should contain(NoteOffScMidiMessage(0, E4))
-    }
-
-  it should "not emit Note Off messages on reset when no notes are active" in new Fixture {
-    // When
-    private val resetOutput = tuner.reset()
-    // Then
-    extractNoteOffs(resetOutput) shouldBe empty
-  }
-
-  behavior of "MpeTuner - tune()"
-
-  it should "store tuning but output no messages when no active notes" in new Fixture {
-    // When
-    private val output = tuner.tune(quarterCommaMeantone)
-    // Then
-    tuner.tuning shouldEqual quarterCommaMeantone
-    extractPitchBends(output) shouldBe empty
-  }
-
-  it should "output updated Pitch Bend on each occupied member channel" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // Given
-      private val out1 = noteOn(nonMpeInputChannel, C4)
-      private val noteOnChannel = extractNoteOns(out1).head.channel
-      private val out2 = noteOn(nonMpeInputChannel, E4)
-      private val noteOnChannel2 = extractNoteOns(out2).head.channel
-      // When
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val pitchBends = extractPitchBends(tuneOutput)
-      pitchBends.map(_.channel).toSet should contain allOf(noteOnChannel, noteOnChannel2)
-    }
-
-  it should "correctly retune notes of different pitch classes on different channels" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // Given
-      noteOn(nonMpeInputChannel, C4)
-      noteOn(nonMpeInputChannel, E4)
-      // When
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val pitchBends = extractPitchBends(tuneOutput)
-      // C and E should have different pitch bends (different tuning offsets)
-      pitchBends.size shouldEqual 2
-      pitchBends.map(_.cents.round.toInt) should contain theSameElementsInOrderAs Seq(0, 8)
-    }
-
-  it should "output updated Pitch Bend on each occupied member channel in MPE input mode" in
-    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      private val out1 = noteOn(1, C4)
-      private val noteOnChannel = extractNoteOns(out1).head.channel
-      private val out2 = noteOn(2, E4)
-      private val noteOnChannel2 = extractNoteOns(out2).head.channel
-      // When
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val pitchBends = extractPitchBends(tuneOutput)
-      pitchBends.map(_.channel).toSet should contain allOf(noteOnChannel, noteOnChannel2)
-      // C and E should reflect pythagorean tuning offsets (0.0, 8.0)
-      pitchBends.size shouldEqual 2
-      pitchBends.map(_.cents.round.toInt) should contain theSameElementsInOrderAs Seq(0, 8)
-    }
-
-  it should "recompute pitch bend = new tuning offset + current expressive pitch bend on each occupied channel" in
-    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      // E has -14.0 in quarter-comma meantone, +8.0 in pythagorean
-      private val noteOutE = noteOn(1, E4)
-      private val chE = extractNoteOns(noteOutE).head.channel
-      private val noteOutG = noteOn(2, G4)
-      private val chG = extractNoteOns(noteOutG).head.channel
-
-      // Apply small expressive pitch bends (under the high-bend threshold) per note in MPE mode
-      private val eExprCents = 20.0
-      private val gExprCents = -30.0
-      pitchBend(1, eExprCents)
-      pitchBend(2, gExprCents)
-
-      // When
-      // Switch tuning — output PB on each channel must combine new tuning offset + expressive bend.
-      // Compare on MIDI values (not cents) to avoid resolution noise from the cents↔value roundtrip.
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val pbByChannel = extractPitchBends(tuneOutput).map(pb => pb.channel -> pb.value).toMap
-      private val expectedE = PitchBendScMidiMessage.convertCentsToValue(8.0 + eExprCents, defaultPbs)
-      private val expectedG = PitchBendScMidiMessage.convertCentsToValue(2.0 + gExprCents, defaultPbs)
-      pbByChannel(chE) shouldBe expectedE
-      pbByChannel(chG) shouldBe expectedG
-    }
-
-  behavior of "MpeTuner - process() Non-MPE Basic"
-
-  it should "output Pitch Bend, CC #74, Channel Pressure, then Note On for single Note On" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // When
-      private val output = noteOn(nonMpeInputChannel, C4, 100)
-      // Then
-      private val msgs = extractScMidiMessages(output)
-      private val noteChannel = extractNoteOns(output).head.channel
-
-      // Should have: PitchBend, CC#74, ChannelPressure, NoteOn
-      msgs should contain inOrder(
-        PitchBendScMidiMessage(noteChannel, 0),
-        CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 64),
-        ChannelPressureScMidiMessage(noteChannel, 0),
-        NoteOnScMidiMessage(noteChannel, C4, 100)
+      private val noteOffs = extractNoteOffs(output).map(n => (n.channel, n.midiNote))
+      noteOffs should contain theSameElementsAs Seq(
+        (sharedChannel, E4),
+        (sharedChannel, E5)
       )
     }
 
-  it should "output Note Off on the correct member channel" in new Fixture {
-    // Given
-    private val noteOnOutput = noteOn(nonMpeInputChannel, C4)
-    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
-    // When
-    private val noteOffOutput = noteOff(nonMpeInputChannel, C4)
-    // Then
-    private val noteOffs = extractNoteOffs(noteOffOutput)
-    noteOffs should contain(NoteOffScMidiMessage(noteOnChannel, C4))
-  }
-
-  it should "allocate multiple notes with distinct pitch classes to separate member channels" in new Fixture {
-    // When
-    private val out1 = noteOn(nonMpeInputChannel, C4)
-    private val out2 = noteOn(nonMpeInputChannel, E4)
-    private val out3 = noteOn(nonMpeInputChannel, G4)
-    // Then
-    private val channels = Seq(out1, out2, out3).flatMap(extractNoteOns).map(_.channel)
-    channels.distinct.size shouldBe 3
-  }
-
-  it should "preserve Note On velocity" in new Fixture {
-    // When
-    private val output = noteOn(nonMpeInputChannel, C4, 87)
-    // Then
-    extractNoteOns(output).head.velocity shouldBe 87
-  }
-
-  it should "preserve Note Off velocity" in new Fixture {
-    // Given
-    private val noteOnOutput = noteOn(nonMpeInputChannel, C4, 100)
-    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
-    // When
-    private val noteOffOutput = noteOff(nonMpeInputChannel, C4, 73)
-    // Then
-    extractNoteOffs(noteOffOutput) should contain(NoteOffScMidiMessage(noteOnChannel, C4, 73))
-  }
-
-  it should "preserve Note Off velocity in MPE input mode" in new Fixture(tuner7MpeInput) {
-    // Given
-    private val noteOnOutput = noteOn(1, C4, 100)
-    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
-    // When
-    private val noteOffOutput = noteOff(1, C4, 73)
-    // Then
-    extractNoteOffs(noteOffOutput) should contain(NoteOffScMidiMessage(noteOnChannel, C4, 73))
-  }
-
-  it should "treat Note On with velocity 0 as Note Off" in new Fixture {
-    // Given
-    private val noteOnOutput = noteOn(nonMpeInputChannel, C4, 100)
-    private val noteOnChannel = extractNoteOns(noteOnOutput).head.channel
-    // When
-    private val noteOffOutput = noteOn(nonMpeInputChannel, C4, 0)
-    // Then
-    extractNoteOffs(noteOffOutput) should contain(NoteOffScMidiMessage(noteOnChannel, C4))
-  }
-
-  it should "correctly allocate notes from any input channel" in new Fixture {
-    // When
-    private val out1 = noteOn(0, C4)
-    private val out2 = noteOn(5, E4)
-    // Then
-    extractNoteOns(out1).map(_.channel) should contain(1)
-    extractNoteOns(out2).map(_.channel) should contain(2)
-  }
-
-  behavior of "MpeTuner - process() Non-MPE Pitch Bend"
-
-  it should "redirect input Pitch Bend to Master Channel as Zone-level Pitch Bend" in new Fixture {
-    // When
-    private var output = pitchBend(nonMpeInputChannel, 50.0)
-    // Then
-    private var pitchBends = extractPitchBendsWithCents(output)
-    pitchBends should contain theSameElementsAs Seq((0, 50))
-
-    // When
-    noteOn(nonMpeInputChannel, E4)
-    output = pitchBend(nonMpeInputChannel, 25.0)
-    // Then
-    pitchBends = extractPitchBendsWithCents(output)
-    pitchBends should contain theSameElementsAs Seq((0, 25))
-  }
-
-  it should "not bleed master channel pitch bend into member channel tuning on retune" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // Given
-      // E has -14.0 cents offset in quarter-comma meantone
-      private val noteOutput = noteOn(nonMpeInputChannel, E4)
-      private val noteChannel = extractNoteOns(noteOutput).head.channel
-      extractPitchBends(noteOutput).head.cents shouldEqual -14.0
-
-      // In NonMpe mode, pitch bend goes to the master channel as zone-level expression
-      tuner.process(PitchBendScMidiMessage(nonMpeInputChannel, 500).asJava)
-
-      // When
-      // Retune — member channel pitch bend should only reflect tuning, not master expression
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val memberPb = extractPitchBends(tuneOutput).filter(_.channel == noteChannel)
-      memberPb should have size 1
-      // Pythagorean E offset is 8.0 cents — no contamination from the master pitch bend
-      memberPb.head.cents.round.toInt shouldBe 8
-    }
-
-  behavior of "MpeTuner - process() Non-MPE Channel Pressure"
-
-  it should "redirect input Channel Pressure to Master Channel as Zone-level Pitch Bend" in new Fixture {
-    // When
-    private var output = pressure(nonMpeInputChannel, 32)
-    // Then
-    private var channelPressures = extractChannelPressures(output)
-    channelPressures should contain theSameElementsAs Seq(ChannelPressureScMidiMessage(0, 32))
-
-    // When
-    noteOn(nonMpeInputChannel, E4)
-    output = pressure(nonMpeInputChannel, 25)
-    // Then
-    channelPressures = extractChannelPressures(output)
-    channelPressures should contain theSameElementsAs Seq(ChannelPressureScMidiMessage(0, 25))
-  }
-
-  behavior of "MpeTuner - process() Non-MPE Slide CC #74"
-
-  it should "redirect input Slide CC #74 to Master Channel as Zone-level Pitch Bend" in new Fixture {
-    // When
-    private var output = slide(nonMpeInputChannel, 72)
-    // Then
-    private var slides = extractSlides(output)
-    slides should contain theSameElementsAs Seq(CcScMidiMessage(0, ScMidiCc.MpeSlide, 72))
-
-    // When
-    noteOn(nonMpeInputChannel, E4)
-    output = slide(nonMpeInputChannel, 96)
-    // Then
-    slides = extractSlides(output)
-    slides should contain theSameElementsAs Seq(CcScMidiMessage(0, ScMidiCc.MpeSlide, 96))
-  }
-
-  behavior of "MpeTuner - process() Non-MPE to MPE Conversion"
-
-  it should "convert Polyphonic Key Pressure to Channel Pressure on member channel" in new Fixture {
-    // Given
-    private val noteOutput = noteOn(nonMpeInputChannel, C4)
-    private val noteChannel = extractNoteOns(noteOutput).head.channel
-    // When
-    private val output = tuner.process(PolyPressureScMidiMessage(nonMpeInputChannel, C4, 80).asJava)
-    // Then
-    extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 80))
-    output.map(_.asScala).collect { case m: PolyPressureScMidiMessage => m } shouldBe empty
-  }
-
-  it should "ignore Polyphonic Key Pressure for non-active notes" in new Fixture {
-    // Given
-    private val noteOutput = noteOn(nonMpeInputChannel, C4)
-    private val noteChannel = extractNoteOns(noteOutput).head.channel
-    // When
-    private val output = tuner.process(PolyPressureScMidiMessage(nonMpeInputChannel, D4, 80).asJava)
-    // Then
-    extractChannelPressures(output) shouldBe empty
-    output.map(_.asScala).collect { case m: PolyPressureScMidiMessage => m } shouldBe empty
-  }
-
-  it should "initialize member channel CC #74 to default 64 even after sending CC #74 in non-MPE mode" in
-    new Fixture {
-      // Given
-      // Sender sends CC #74 before Note On; value goes to Master Channel only
-      slide(nonMpeInputChannel, 120)
-      // When
-      private val output = noteOn(nonMpeInputChannel, C4)
-      // Then
-      private val noteChannel = extractNoteOns(output).head.channel
-      // Member channel must be initialized with neutral default (64), not the sender's value,
-      // to avoid double-counting with the Master Channel value.
-      extractCc(output) should contain(CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 64))
-    }
-
-  it should "initialize member channel Channel Pressure to default 0 even after sending CP in non-MPE mode" in
-    new Fixture {
-      // Given
-      pressure(nonMpeInputChannel, 100)
-      // When
-      private val output = noteOn(nonMpeInputChannel, C4)
-      // Then
-      private val noteChannel = extractNoteOns(output).head.channel
-      extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 0))
-    }
-
-  it should "initialize control dimensions before Note On even when input omits them" in new Fixture {
-    // When
-    private val output = noteOn(nonMpeInputChannel, C4)
-    // Then
-    private val msgs = extractScMidiMessages(output)
-
-    private val noteChannel = 1
-    // CC #74 should be 64 (default), Channel Pressure should be 0 (default)
-    msgs should contain allOf(
-      CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 64),
-      ChannelPressureScMidiMessage(noteChannel, 0)
-    )
-  }
-
-  behavior of "MpeTuner - process() Zone-Level Messages"
+  behavior of "MpeTuner - process() - Zone-level Messages - Non-MPE Input"
 
   it should "forward Sustain Pedal (CC #64) on Master Channel" in new Fixture {
     // When
@@ -893,7 +1644,7 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
     }
   }
 
-  behavior of "MpeTuner - process() Zone-Level Messages MPE Input"
+  behavior of "MpeTuner - process() - Zone-level Messages - MPE Input"
 
   it should "forward Sustain Pedal (CC #64) received on member channel to zone Master Channel" in
     new Fixture(tuner7MpeInput) {
@@ -950,805 +1701,19 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       programChanges should contain(ProgramChangeScMidiMessage(15, 5))
     }
 
-  behavior of "MpeTuner - process() Pitch Bend Computation"
+  behavior of "MpeTuner - MCM Processing - Non-MPE Input"
 
-  it should "compute output pitch bend = tuning offset for single note on channel" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // C has 0.0 cents offset
-      private val outC = noteOn(nonMpeInputChannel, C4)
-      extractPitchBends(outC).head.cents shouldEqual 0.0
-
-      // E has -14.0 cents offset
-      private val outE = noteOn(nonMpeInputChannel, E4)
-      extractPitchBends(outE).head.cents shouldEqual -14.0
-
-      // D has -7.0 cents offset
-      private val outD = noteOn(nonMpeInputChannel, D4)
-      extractPitchBends(outD).head.cents shouldEqual -7.0
-
-      // G has -3.0 cents offset
-      private val outG = noteOn(nonMpeInputChannel, G4)
-      extractPitchBends(outG).head.cents shouldEqual -3.0
-    }
-
-  it should "clamp pitch bend to valid range when tuning offset exceeds PBS" in {
-    // Use a small PBS (2 semitones = 200 cents) so that a large tuning offset exceeds the range
-    val smallPbs = PitchBendSensitivity(2)
-    val smallPbsTuner = MpeTuner(
-      initialZones = MpeZones(
-        MpeZone(MpeZoneType.Lower, 15, memberPitchBendSensitivity = smallPbs),
-        MpeZone(MpeZoneType.Upper, 0)
-      )
+  it should "output MPE Configuration Message (MCM) for the configured zone" in new Fixture(defaultTuner) {
+    // When
+    private val output = tuner.reset()
+    // Then
+    private val ccs = extractCc(output)
+    // MCM: RPN LSB=6, RPN MSB=0, Data Entry MSB=memberCount on master channel 0
+    ccs should contain inOrder(
+      CcScMidiMessage(0, ScMidiCc.RpnLsb, ScMidiRpn.MpeConfigurationMessageLsb),
+      CcScMidiMessage(0, ScMidiCc.RpnMsb, ScMidiRpn.MpeConfigurationMessageMsb),
+      CcScMidiMessage(0, ScMidiCc.DataEntryMsb, 15)
     )
-    new Fixture(smallPbsTuner) {
-      // B: exceeds ±200 cents PBS range
-      private val extremeTuning = Tuning("extreme", b = Some(500.0))
-      tuner.tune(extremeTuning)
-
-      // B should be clamped to max pitch bend value
-      private val outB = noteOn(nonMpeInputChannel, MidiNote.B4)
-      private val pbB = extractPitchBends(outB).head
-      pbB.value shouldBe PitchBendScMidiMessage.MaxValue
-      pbB.centsFor(smallPbs) shouldEqual smallPbs.totalCents.toDouble
-
-      // C has 0.0 offset, should not be clamped
-      private val outC = noteOn(nonMpeInputChannel, C4)
-      extractPitchBends(outC).head.value shouldBe 0
-    }
-  }
-
-  it should "compute output pitch bend = tuning offset for single note on channel in MPE input mode" in
-    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
-      // C has 0.0 cents offset
-      private val outC = noteOn(1, C4)
-      extractPitchBends(outC).head.cents shouldEqual 0.0
-
-      // E has -14.0 cents offset
-      private val outE = noteOn(2, E4)
-      extractPitchBends(outE).head.cents shouldEqual -14.0
-
-      // D has -7.0 cents offset
-      private val outD = noteOn(3, D4)
-      extractPitchBends(outD).head.cents shouldEqual -7.0
-
-      // G has -3.0 cents offset
-      private val outG = noteOn(4, G4)
-      extractPitchBends(outG).head.cents shouldEqual -3.0
-    }
-
-  it should "clamp pitch bend to valid range when tuning offset exceeds PBS in MPE input mode" in {
-    val smallPbs = PitchBendSensitivity(2)
-    val smallPbsTuner = MpeTuner(
-      initialZones = MpeZones(
-        MpeZone(MpeZoneType.Lower, 15, memberPitchBendSensitivity = smallPbs),
-        MpeZone(MpeZoneType.Upper, 0)
-      ),
-      initialInputMode = MpeInputMode.Mpe
-    )
-    new Fixture(smallPbsTuner) {
-      private val extremeTuning = Tuning("extreme", b = Some(500.0))
-      tuner.tune(extremeTuning)
-
-      private val outB = noteOn(1, MidiNote.B4)
-      private val pbB = extractPitchBends(outB).head
-      pbB.value shouldBe PitchBendScMidiMessage.MaxValue
-      pbB.centsFor(smallPbs) shouldEqual smallPbs.totalCents.toDouble
-
-      private val outC = noteOn(2, C4)
-      extractPitchBends(outC).head.value shouldBe 0
-    }
-  }
-
-  behavior of "MpeTuner - process() Dual-Group Allocation"
-
-  it should "leave Pitch Class Group channel unaffected when bending Expression Group channel of same pitch class" in
-    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      // E4 -> PCG channel (E enters Pitch Class Group)
-      private val outE4 = noteOn(1, E4)
-      private val pcgChannel = extractNoteOns(outE4).head.channel
-
-      // E5 (same pitch class) -> Expression Group channel (PCG slot for E is already taken)
-      private val outE5 = noteOn(2, E5)
-      private val egChannel = extractNoteOns(outE5).head.channel
-      egChannel should not equal pcgChannel
-
-      // When
-      // Send a non-high expressive pitch bend on the EG input channel
-      private val eExprCents = 30.0
-      private val bendOutput = pitchBend(2, eExprCents)
-      // Then
-      private val pitchBends = extractPitchBends(bendOutput)
-
-      // Only the EG channel should receive an updated pitch bend; the PCG channel must not.
-      pitchBends.map(_.channel) should contain(egChannel)
-      pitchBends.map(_.channel) should not contain pcgChannel
-      pitchBends.filter(_.channel == egChannel).head.cents shouldEqual (-14.0 + eExprCents)
-    }
-  it should "allocate second note with same pitch class to Expression Group with independent pitch bends" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // When
-      // E has -14.0 cents offset in quarter-comma meantone
-      private val out1 = noteOn(nonMpeInputChannel, E4)
-      private val ch1 = extractNoteOns(out1).head.channel
-      private val pb1 = extractPitchBends(out1).head
-
-      private val out2 = noteOn(nonMpeInputChannel, E5)
-      private val ch2 = extractNoteOns(out2).head.channel
-      private val pb2 = extractPitchBends(out2).head
-
-      // Then
-      // Notes should be on different channels
-      ch1 should not equal ch2
-
-      // Both should have pitch bends reflecting the -14.0 cents tuning offset for E
-      pb1.channel shouldBe ch1
-      pb1.cents shouldEqual -14.0
-      pb2.channel shouldBe ch2
-      pb2.cents shouldEqual -14.0
-    }
-
-  behavior of "MpeTuner - process() Note Dropping"
-
-  it should "trigger note dropping with Note Off output for dropped notes on channel exhaustion" in
-    new Fixture(tuner3) {
-      // Given
-      noteOn(nonMpeInputChannel, C4)
-      noteOn(nonMpeInputChannel, E4)
-      noteOn(nonMpeInputChannel, G4)
-      // When
-      private val output = noteOn(nonMpeInputChannel, A4)
-      // Then
-      private val noteOffs = extractNoteOffs(output)
-      noteOffs should have size 1
-      // Dropped E4, not C4. The latter, although older, is the bass note which is excluded.
-      noteOffs.head.midiNote shouldEqual E4
-    }
-
-  it should "preserve the lowest note during channel exhaustion dropping" in new Fixture(tuner3) {
-    // Given
-    noteOn(nonMpeInputChannel, C4) // lowest
-    noteOn(nonMpeInputChannel, E4) // middle
-    noteOn(nonMpeInputChannel, G4) // highest
-    // When
-    private val output = noteOn(nonMpeInputChannel, A4)
-    // Then
-    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-    droppedNotes should not contain C4
-  }
-
-  it should "preserve the highest note during channel exhaustion dropping" in new Fixture(tuner3) {
-    // Given
-    // Oldest not, but will not be dropped since it's the highest.
-    noteOn(nonMpeInputChannel, G4) // highest
-    noteOn(nonMpeInputChannel, C4) // lowest
-    noteOn(nonMpeInputChannel, E4) // middle
-    // When
-    private val output = noteOn(nonMpeInputChannel, A4)
-    // Then
-    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-    droppedNotes should not contain G4
-  }
-
-  ignore should "preserve the highest and drop the lowest note during channel exhaustion dropping when there are only" +
-    " 2 candidate channels" in new Fixture(tuner2) {
-    // Given
-    noteOn(nonMpeInputChannel, G4) // highest
-    noteOn(nonMpeInputChannel, C4) // lowest
-    // When
-    private val output = noteOn(nonMpeInputChannel, E4)
-    // Then
-    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-    droppedNotes should contain(C4)
-  }
-
-  it should "free a single channel during exhaustion dropping when there is a single member channel" in
-    new Fixture(tuner1) {
-      // Given
-      noteOn(nonMpeInputChannel, C4)
-      // When
-      private val output = noteOn(nonMpeInputChannel, E4)
-      // Then
-      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-      droppedNotes should contain(C4)
-    }
-
-  it should "trigger note dropping with Note Off output for dropped notes on channel exhaustion in MPE input mode" in
-    new Fixture(tuner3MpeInput) {
-      // Given
-      noteOn(1, C4)
-      noteOn(2, E4)
-      noteOn(3, G4)
-      // When
-      private val output = noteOn(1, A4)
-      // Then
-      private val noteOffs = extractNoteOffs(output)
-      noteOffs should have size 1
-      // Dropped E4, not C4. The latter, although older, is the bass note which is excluded.
-      noteOffs.head.midiNote shouldEqual E4
-    }
-
-  it should "preserve the lowest note during channel exhaustion dropping in MPE input mode" in
-    new Fixture(tuner3MpeInput) {
-      // Given
-      noteOn(1, C4) // lowest
-      noteOn(2, E4) // middle
-      noteOn(3, G4) // highest
-      // When
-      private val output = noteOn(1, A4)
-      // Then
-      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-      droppedNotes should not contain C4
-    }
-
-  it should "preserve the highest note during channel exhaustion dropping in MPE input mode" in
-    new Fixture(tuner3MpeInput) {
-      // Given
-      // Oldest not, but will not be dropped since it's the highest.
-      noteOn(3, G4) // highest
-      noteOn(1, C4) // lowest
-      noteOn(2, E4) // middle
-      // When
-      private val output = noteOn(1, A4)
-      // Then
-      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-      droppedNotes should not contain G4
-    }
-
-  ignore should "preserve the highest and drop the lowest note during channel exhaustion dropping when there are only" +
-    " 2 candidate channels in MPE input mode" in new Fixture(tuner2MpeInput) {
-    // Given
-    noteOn(2, G4) // highest
-    noteOn(1, C4) // lowest
-    // When
-    private val output = noteOn(1, E4)
-    // Then
-    private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-    droppedNotes should contain(C4)
-  }
-
-  it should "free a single channel during exhaustion dropping when there is a single member channel in MPE input " +
-    "mode" in
-    new Fixture(tuner1MpeInput) {
-      // Given
-      noteOn(1, C4)
-      // When
-      private val output = noteOn(1, E4)
-      // Then
-      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-      droppedNotes should contain(C4)
-    }
-
-  ignore should "drop all notes on a shared channel with a common input channel when a high expressive pitch bend is " +
-    "received on it" in
-    new Fixture(tuner3MpeInput) {
-      // Given
-      // tuner3 in MPE input: PCG=1, EG=2. Input channels are 1..3.
-      // Share E4 + E5 on the same output channel by sending E5 on E4's input channel.
-      private val outE4 = noteOn(1, E4)
-      private val sharedChannel = extractNoteOns(outE4).head.channel
-      noteOn(2, G4)
-      noteOn(3, C4)
-      noteOn(1, E5)
-
-      // When
-      // High expressive pitch bend (> 50 cents threshold) on input ch 1 -> drops co-resident E4.
-      private val output = pitchBend(1, 100.0)
-      // Then
-      private val noteOffs = extractNoteOffs(output).map(n => (n.channel, n.midiNote))
-      noteOffs should contain theSameElementsAs Seq(
-        (sharedChannel, E4),
-        (sharedChannel, E5)
-      )
-    }
-
-  behavior of "MpeTuner - process() MPE Input"
-
-  it should "process MPE input notes with tuning offsets applied" in
-    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
-      // When
-      private val output = noteOn(1, E4, 100)
-      // Then
-      extractPitchBends(output).head.cents shouldEqual -14.0
-    }
-
-  it should "treat per-note pitch bend as expressive pitch bend combined with tuning offset" in
-    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      // E has -14.0 cents offset in quarter-comma meantone
-      private val noteOutput = noteOn(1, E4, 100)
-      private val noteChannel = extractNoteOns(noteOutput).head.channel
-
-      private val eExprCents = 290.0
-      // When
-      private val output = pitchBend(1, eExprCents)
-      // Then
-      private val pitchBendMsg = extractPitchBends(output).filter(_.channel == noteChannel).head
-
-      // Output pitch bend should combine tuning offset for E (-14.0) + expressive bend
-      pitchBendMsg.cents shouldEqual (-14.0 + eExprCents)
-    }
-
-  it should "forward Master Channel pitch bend without modification" in new Fixture(mpeTunerMpeInput) {
-    // When
-    private val output = tuner.process(PitchBendScMidiMessage(0, 1000).asJava)
-    // Then
-    extractPitchBends(output) should contain(PitchBendScMidiMessage(0, 1000))
-  }
-
-  it should "split notes with different pitch classes from the same MPE input channel onto different output channels" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      // C4 on input ch 2 — allocator honors the input channel hint, places C4 on output ch 2.
-      private val out1 = noteOn(2, C4)
-      private val ch1 = extractNoteOns(out1).head.channel
-
-      // When
-      // E4 on the same input ch 2 — different pitch class, so the pitch-class invariant prevents
-      // sharing output ch 2 with C4. The allocator must split E4 onto a different output channel.
-      private val out2 = noteOn(2, E4)
-      private val ch2 = extractNoteOns(out2).head.channel
-
-      // Then
-      ch1 shouldBe 2
-      ch2 should not be ch1
-      ch2 should (be >= 1 and be <= 7)
-    }
-
-  it should "fan out expressive Pitch Bend to all output channels for split notes from same MPE input channel" in
-    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      private val out1 = noteOn(2, C4)
-      private val ch1 = extractNoteOns(out1).head.channel
-      private val out2 = noteOn(2, E4)
-      private val ch2 = extractNoteOns(out2).head.channel
-
-      private val exprCents = 30.0
-      // When
-      private val output = pitchBend(2, exprCents)
-
-      // Then
-      // Both output channels must receive the expressive bend on top of their tuning offset.
-      // C: 0.0 cents, E: -14.0 cents in quarter-comma meantone.
-      private val pbs = extractPitchBends(output)
-      private val ch1Pb = pbs.find(_.channel == ch1).value
-      private val ch2Pb = pbs.find(_.channel == ch2).value
-      ch1Pb.cents shouldEqual (0.0 + exprCents)
-      ch2Pb.cents shouldEqual (-14.0 + exprCents)
-    }
-
-  it should "fan out CC #74 to all output channels for split notes from same MPE input channel" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      private val out1 = noteOn(2, C4)
-      private val ch1 = extractNoteOns(out1).head.channel
-      private val out2 = noteOn(2, E4)
-      private val ch2 = extractNoteOns(out2).head.channel
-
-      // When
-      private val output = slide(2, 100)
-
-      // Then
-      private val slides = extractSlides(output).map(cc => (cc.channel, cc.value)).toSet
-      slides should contain((ch1, 100))
-      slides should contain((ch2, 100))
-    }
-
-  it should "fan out Channel Pressure to all output channels for split notes from same MPE input channel" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      private val out1 = noteOn(2, C4)
-      private val ch1 = extractNoteOns(out1).head.channel
-      private val out2 = noteOn(2, E4)
-      private val ch2 = extractNoteOns(out2).head.channel
-
-      // When
-      private val output = pressure(2, 90)
-
-      // Then
-      private val cps = extractChannelPressures(output).map(cp => (cp.channel, cp.value)).toSet
-      cps should contain((ch1, 90))
-      cps should contain((ch2, 90))
-    }
-
-  behavior of "MpeTuner - process() MPE Input Master Channel Notes"
-
-  it should "forward Note On received on Lower Master Channel on the same Master Channel" in
-    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
-      // When
-      private val output = noteOn(0, C4, 100)
-      // Then
-      private val noteOns = extractNoteOns(output)
-      noteOns should have size 1
-      noteOns.head shouldEqual NoteOnScMidiMessage(0, C4, 100)
-    }
-
-  it should "not emit Pitch Bend, CC #74, or Channel Pressure setup for Master Channel Note On" in
-    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
-      // When
-      private val output = noteOn(0, C4, 100)
-      // Then
-      extractPitchBends(output) shouldBe empty
-      extractCc(output).filter(_.number == ScMidiCc.MpeSlide) shouldBe empty
-      extractChannelPressures(output) shouldBe empty
-    }
-
-  it should "forward Note Off received on Lower Master Channel on the same Master Channel" in
-    new Fixture(mpeTunerMpeInput) {
-      // Given
-      noteOn(0, C4, 100)
-      // When
-      private val output = noteOff(0, C4)
-      // Then
-      extractNoteOffs(output) should contain(NoteOffScMidiMessage(0, C4))
-    }
-
-  it should "forward Note On/Off received on Upper Master Channel on the same Master Channel" in
-    new Fixture(dualZoneTunerMpeInput) {
-      // When
-      private val onOutput = noteOn(15, C4, 90)
-      // Then
-      private val noteOns = extractNoteOns(onOutput)
-      noteOns should have size 1
-      noteOns.head shouldEqual NoteOnScMidiMessage(15, C4, 90)
-
-      // When
-      private val offOutput = noteOff(15, C4)
-      // Then
-      extractNoteOffs(offOutput) should contain(NoteOffScMidiMessage(15, C4))
-    }
-
-  it should "route member channel notes to their own zone in dual-zone MPE input mode" in
-    new Fixture(dualZoneTunerMpeInput) {
-      // When
-      // Lower zone: master 0, members 1..7. Upper zone: master 15, members 8..14.
-      private val lowerOut = noteOn(1, C4)
-      private val lowerChannel = extractNoteOns(lowerOut).head.channel
-      // Then
-      lowerChannel should (be >= 1 and be <= 7)
-
-      // When
-      private val upperOut = noteOn(8, C4)
-      private val upperChannel = extractNoteOns(upperOut).head.channel
-      // Then
-      upperChannel should (be >= 8 and be <= 14)
-    }
-
-  it should "not consume Member Channel slots for Master Channel notes" in
-    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      // Master Channel note should not occupy a Member Channel
-      noteOn(0, C4)
-      // When
-      // Subsequent Member Channel note gets the first Member Channel
-      private val out = noteOn(mpeInputChannel, E4)
-      // Then
-      private val noteOns = extractNoteOns(out)
-      noteOns should have size 1
-      noteOns.head.channel shouldBe 1
-    }
-
-  it should "not retune Master Channel notes on tune() call" in
-    new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      noteOn(0, C4)
-      // When
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      extractPitchBends(tuneOutput).filter(_.channel == 0) shouldBe empty
-    }
-
-  it should "allow multiple active notes on the Master Channel concurrently" in
-    new Fixture(mpeTunerMpeInput) {
-      // When
-      private val out1 = noteOn(0, C4, 100)
-      private val out2 = noteOn(0, E4, 100)
-      // Then
-      extractNoteOns(out1).map(n => (n.channel, n.midiNote)) should contain((0, C4))
-      extractNoteOns(out2).map(n => (n.channel, n.midiNote)) should contain((0, E4))
-
-      // When
-      private val offOutput = noteOff(0, C4)
-      // Then
-      extractNoteOffs(offOutput) should contain(NoteOffScMidiMessage(0, C4))
-      // E4 should still be tracked as active
-      // When
-      private val offOutput2 = noteOff(0, E4)
-      // Then
-      extractNoteOffs(offOutput2) should contain(NoteOffScMidiMessage(0, E4))
-    }
-
-  it should "forward Polyphonic Key Pressure as-is for Master Channel notes" in
-    new Fixture(mpeTunerMpeInput) {
-      // Given
-      noteOn(0, C4, 100)
-      // When
-      private val output = tuner.process(PolyPressureScMidiMessage(0, C4, 80).asJava)
-      // Then
-      extractPolyPressure(output) should contain(PolyPressureScMidiMessage(0, C4, 80))
-      extractChannelPressures(output) shouldBe empty
-    }
-
-  it should "drop Polyphonic Key Pressure received on a Member Channel in MPE input mode" in
-    new Fixture(mpeTunerMpeInput) {
-      // Given
-      noteOn(mpeInputChannel, C4, 100)
-      // When
-      private val output = tuner.process(PolyPressureScMidiMessage(mpeInputChannel, C4, 80).asJava)
-      // Then
-      extractPolyPressure(output) shouldBe empty
-      extractChannelPressures(output) shouldBe empty
-    }
-
-  it should "not forward CC #74 on an MPE input channel with no active note" in
-    new Fixture(tuner7MpeInput) {
-      // When
-      // Send CC #74 on a member channel that has no active note
-      private val output = slide(mpeInputChannel, 100)
-      // Then
-      extractCc(output) shouldBe empty
-    }
-
-  it should "not forward Channel Pressure on an MPE input channel with no active note" in
-    new Fixture(tuner7MpeInput) {
-      // When
-      // Send Channel Pressure on a member channel that has no active note
-      private val output = pressure(mpeInputChannel, 90)
-      // Then
-      extractChannelPressures(output) shouldBe empty
-    }
-
-  it should "not forward Pitch Bend on an MPE input member channel with no active note" in
-    new Fixture(tuner7MpeInput) {
-      // When
-      // Send Pitch Bend on a member channel that has no active note
-      private val output = tuner.process(PitchBendScMidiMessage(mpeInputChannel, 4000).asJava)
-      // Then
-      extractPitchBends(output) shouldBe empty
-    }
-
-  it should "forward CC #74 to the allocated Member Channel when an active note exists on MPE input channel" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      private val noteOutput = noteOn(mpeInputChannel, C4)
-      private val noteChannel = extractNoteOns(noteOutput).head.channel
-      // When
-      private val output = slide(mpeInputChannel, 100)
-      // Then
-      extractCc(output) should contain(CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 100))
-    }
-
-  it should "forward Channel Pressure to allocated Member Channel when active note exists on MPE input channel" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      private val noteOutput = noteOn(mpeInputChannel, C4)
-      private val noteChannel = extractNoteOns(noteOutput).head.channel
-      // When
-      private val output = pressure(mpeInputChannel, 90)
-      // Then
-      extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 90))
-    }
-
-  it should "seed Member Channel CC #74 from the per-input-channel value at Note On in MPE mode" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      // Send CC #74 first (no active note, so forwarding is dropped) — but the per-input-channel value is recorded
-      slide(mpeInputChannel, 100)
-      // When
-      // Note On should seed the Member Channel CC #74 with the recorded value (not the neutral default 64)
-      private val output = noteOn(mpeInputChannel, C4)
-      // Then
-      private val noteChannel = extractNoteOns(output).head.channel
-      extractCc(output) should contain(CcScMidiMessage(noteChannel, ScMidiCc.MpeSlide, 100))
-    }
-
-  // TODO #154 Do we have a similar test for PB?
-  it should "seed Member Channel Channel Pressure from the per-input-channel value at Note On in MPE mode" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      pressure(mpeInputChannel, 90)
-      // When
-      private val output = noteOn(mpeInputChannel, C4)
-      // Then
-      private val noteChannel = extractNoteOns(output).head.channel
-      extractChannelPressures(output) should contain(ChannelPressureScMidiMessage(noteChannel, 90))
-    }
-
-  behavior of "MpeTuner - process() Note Off Behavior"
-
-  it should "not update released channel's pitch bend on tuning changes" in
-    new Fixture(initialTuning = Some(quarterCommaMeantone)) {
-      // Given
-      // E has -14.0 cents offset; pythagorean E has 8.0 cents — non-zero in both tunings
-      private val noteOutputE = noteOn(nonMpeInputChannel, E4)
-      private val releasedChannel = extractNoteOns(noteOutputE).head.channel
-
-      // G stays active as a control
-      private val noteOutputG = noteOn(nonMpeInputChannel, G4)
-      private val activeChannel = extractNoteOns(noteOutputG).head.channel
-
-      // Release E4
-      noteOff(nonMpeInputChannel, E4)
-
-      // When
-      // Retune — only the active channel (G) should get a pitch bend update
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val pitchBends = extractPitchBends(tuneOutput)
-      pitchBends should have size 1
-      pitchBends.head.channel shouldBe activeChannel
-      pitchBends.head.cents.round.toInt shouldBe 2 // pythagorean G offset
-    }
-
-  it should "make channel available for reuse after Note Off" in new Fixture(tuner3) {
-    // Given
-    // Fill all 3 member channels
-    noteOn(nonMpeInputChannel, C4)
-    private val out = noteOn(nonMpeInputChannel, E4)
-    private val ch = extractNoteOns(out).head.channel
-    noteOn(nonMpeInputChannel, G4)
-
-    // When
-    // Release the second note
-    noteOff(nonMpeInputChannel, E4)
-
-    // Then
-    // New note should reuse the released channel
-    private val output = noteOn(nonMpeInputChannel, D4)
-    extractNoteOns(output).head.channel shouldBe ch
-  }
-
-  it should "not update released channel's pitch bend on tuning changes in MPE input mode" in
-    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
-      // Given
-      // E has -14.0 cents offset; pythagorean E has 8.0 cents — non-zero in both tunings
-      private val noteOutputE = noteOn(1, E4)
-      private val releasedChannel = extractNoteOns(noteOutputE).head.channel
-
-      // G stays active as a control
-      private val noteOutputG = noteOn(2, G4)
-      private val activeChannel = extractNoteOns(noteOutputG).head.channel
-
-      // Release E4
-      noteOff(1, E4)
-
-      // When
-      // Retune — only the active channel (G) should get a pitch bend update
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val pitchBends = extractPitchBends(tuneOutput)
-      pitchBends should have size 1
-      pitchBends.head.channel shouldBe activeChannel
-      pitchBends.head.cents.round.toInt shouldBe 2 // pythagorean G offset
-    }
-
-  it should "make channel available for reuse after Note Off in MPE input mode" in
-    new Fixture(tuner3MpeInput) {
-      // Given
-      noteOn(1, C4)
-      private val out = noteOn(2, E4)
-      private val ch = extractNoteOns(out).head.channel
-      noteOn(3, G4)
-
-      // When
-      // Release the second note
-      noteOff(2, E4)
-
-      // Then
-      // New note arriving on a different input channel should reuse the released channel
-      private val output = noteOn(1, D4)
-      extractNoteOns(output).head.channel shouldBe ch
-    }
-
-  it should "not forward expressive controls from an input channel after its notes have been released" in
-    new Fixture(tuner7MpeInput) {
-      // Given
-      // Note On routes mpeInputChannel -> some output channel
-      noteOn(mpeInputChannel, C4)
-      noteOff(mpeInputChannel, C4)
-
-      // When / Then
-      // After Note Off, no input->output mapping should exist for mpeInputChannel — expressive
-      // CC #74 / Channel Pressure / Pitch Bend on this input channel must NOT be forwarded to a
-      // (now stale) member channel.
-      private val ccOutput = slide(mpeInputChannel, 100)
-      extractCc(ccOutput) shouldBe empty
-
-      private val cpOutput = pressure(mpeInputChannel, 90)
-      extractChannelPressures(cpOutput) shouldBe empty
-
-      private val pbOutput = tuner.process(PitchBendScMidiMessage(mpeInputChannel, 4000).asJava)
-      extractPitchBends(pbOutput) shouldBe empty
-    }
-
-  behavior of "MpeTuner - Worked Examples"
-
-  it should "reproduce paper section \"Basic allocation in quarter-comma meantone\"" in
-    new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
-      // 1. Note C4 arrives on input ch 1 -> Pitch Class Group; C has 0.0 cents offset
-      private val out1 = noteOn(1, C4)
-      private val ch1 = extractNoteOns(out1).head.channel
-      extractPitchBends(out1).head.cents shouldEqual 0.0
-
-      // 2. Note E4 arrives on input ch 2 -> Pitch Class Group; E has -14.0 cents offset
-      private val out2 = noteOn(2, E4)
-      private val ch2 = extractNoteOns(out2).head.channel
-      ch2 should not equal ch1
-      extractPitchBends(out2).head.cents shouldEqual -14.0
-
-      // 3. Note G4 arrives on input ch 3 -> Pitch Class Group; G has -3.0 cents offset
-      private val out3 = noteOn(3, G4)
-      private val ch3 = extractNoteOns(out3).head.channel
-      ch3 should not equal ch2
-      extractPitchBends(out3).head.cents shouldEqual -3.0
-
-      // 4. Second C (C5) arrives on input ch 4 -> Expression Group; C has 0.0 cents offset
-      private val out4 = noteOn(4, C5)
-      private val ch4 = extractNoteOns(out4).head.channel
-      ch4 should not equal ch1
-      extractPitchBends(out4).head.cents shouldEqual 0.0
-
-      // 5. Performer bends C5 on input ch 4 — only ch4's pitch bend is affected
-      private val cExprCents = 586.0
-      private val bendOut = pitchBend(4, cExprCents)
-      private val pitchBends = extractPitchBends(bendOut)
-      pitchBends should have size 1
-      pitchBends.head.channel shouldBe ch4
-      pitchBends.head.cents shouldEqual (0.0 + cExprCents)
-    }
-
-  it should "reproduce paper section \"Tuning change during performance\"" in
-    new Fixture(tuner7, Some(quarterCommaMeantone)) {
-      // Given
-      private val chC = extractNoteOns(noteOn(nonMpeInputChannel, C4)).head.channel
-      private val chE = extractNoteOns(noteOn(nonMpeInputChannel, E4)).head.channel
-      private val chG = extractNoteOns(noteOn(nonMpeInputChannel, G4)).head.channel
-      private val chC5 = extractNoteOns(noteOn(nonMpeInputChannel, C5)).head.channel
-
-      // When
-      // Switch to Pythagorean tuning
-      private val tuneOutput = tuner.tune(pythagoreanTuning)
-      // Then
-      private val pitchBends = extractPitchBends(tuneOutput)
-
-      // Should have pitch bend updates for all 4 occupied channels
-      pitchBends should have size 4
-
-      // Pythagorean offsets: C = 0.0, E = 8.0, G = 2.0
-      private val pbByChannel = pitchBends.map(pb => pb.channel -> pb.cents.round.toInt).toMap
-      pbByChannel(chC) shouldBe 0
-      pbByChannel(chE) shouldBe 8
-      pbByChannel(chG) shouldBe 2
-      // C5 shares pitch class C, so same offset
-      pbByChannel(chC5) shouldBe 0
-    }
-
-  it should "reproduce paper section \"Note dropping under channel exhaustion\"" in
-    new Fixture(tuner3, Some(quarterCommaMeantone)) {
-      // Given
-      // C, E, G on 3 channels
-      noteOn(nonMpeInputChannel, C4)
-      noteOn(nonMpeInputChannel, E4)
-      noteOn(nonMpeInputChannel, G4)
-
-      // When
-      // A arrives - must drop a note
-      private val output = noteOn(nonMpeInputChannel, A4)
-      // Then
-      private val droppedNotes = extractNoteOffs(output).map(_.midiNote)
-      // E should be dropped (C is lowest, G is highest)
-      droppedNotes should contain(E4)
-      // A should be allocated
-      extractNoteOns(output).map(_.midiNote) should contain(A4)
-    }
-
-  behavior of "MpeTuner - MCM Processing"
-
-  /** Sends a complete MCM RPN sequence: CC#100=6, CC#101=0, CC#6=memberCount on the given channel. */
-  private def sendMcm(tuner: MpeTuner, channel: Int, memberCount: Int): Seq[MidiMessage] = {
-    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnLsb, ScMidiRpn.MpeConfigurationMessageLsb).asJava)
-    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnMsb, ScMidiRpn.MpeConfigurationMessageMsb).asJava)
-    tuner.process(CcScMidiMessage(channel, ScMidiCc.DataEntryMsb, memberCount).asJava)
   }
 
   it should "reconfigure lower zone on MCM received on channel 0" in new Fixture(dualZoneTuner) {
@@ -1905,18 +1870,33 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
     tuner.zones.lower.memberPitchBendSensitivity shouldEqual MpeZone.DefaultMemberPitchBendSensitivity
   }
 
-  behavior of "MpeTuner - PBS Processing"
+  behavior of "MpeTuner - PBS Processing - Non-MPE Input"
 
-  /** Sends a complete PBS RPN MSB sequence: CC#100=0, CC#101=0, CC#6=semitones on the given channel. */
-  private def sendPbsMsb(tuner: MpeTuner, channel: Int, semitones: Int): Seq[MidiMessage] = {
-    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb).asJava)
-    tuner.process(CcScMidiMessage(channel, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb).asJava)
-    tuner.process(CcScMidiMessage(channel, ScMidiCc.DataEntryMsb, semitones).asJava)
+  it should "output RPN 0 (Pitch Bend Sensitivity) on all member channels" in new Fixture(tuner7) {
+    // When
+    private val output = tuner.reset()
+    // Then
+    private val ccs = extractCc(output)
+    // Check that PBS is set on member channels 1..7
+    (1 to 7).foreach { ch =>
+      ccs should contain inOrder(
+        CcScMidiMessage(ch, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
+        CcScMidiMessage(ch, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
+        CcScMidiMessage(ch, ScMidiCc.DataEntryMsb, 48)
+      )
+    }
   }
 
-  /** Sends a PBS RPN LSB (cents) on the given channel, assuming RPN is already set to PBS. */
-  private def sendPbsLsb(tuner: MpeTuner, channel: Int, cents: Int): Seq[MidiMessage] = {
-    tuner.process(CcScMidiMessage(channel, ScMidiCc.DataEntryLsb, cents).asJava)
+  it should "output RPN 0 on master channel with configured master pitch bend sensitivity" in new Fixture {
+    // When
+    private val output = tuner.reset()
+    // Then
+    private val ccs = extractCc(output)
+    ccs should contain inOrder(
+      CcScMidiMessage(0, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
+      CcScMidiMessage(0, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
+      CcScMidiMessage(0, ScMidiCc.DataEntryMsb, 2)
+    )
   }
 
   it should "update master PBS on master channel" in new Fixture {
@@ -2008,32 +1988,6 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       MpeZone.DefaultMasterPitchBendSensitivity.semitones, cents = 50)
   }
 
-  it should "preserve intonation of active note with expressive pitch bend after PBS change" in
-    new Fixture(
-      MpeTuner(
-        initialZones = MpeZones(MpeZone(MpeZoneType.Lower, 7), MpeZone(MpeZoneType.Upper, 0)),
-        initialInputMode = MpeInputMode.Mpe
-      ),
-      Some(quarterCommaMeantone)
-    ) {
-      // Given - Play E4 on member channel 1: tuning offset for E is -14.0 cents
-      private val noteOutput = noteOn(1, E4, 100)
-      private val noteChannel = extractNoteOns(noteOutput).head.channel
-      // Send an expressive pitch bend of ~293 cents on that channel (with default PBS=48 semitones)
-      private val eExprCents = 293.0
-      pitchBend(1, eExprCents)
-      // When - Now change member PBS from 48 to 24 semitones
-      private val pbsOutput = sendPbsMsb(tuner, channel = 1, semitones = 24)
-      // Then
-      private val pitchBends = extractPitchBends(pbsOutput).filter(_.channel == noteChannel)
-      pitchBends should have size 1
-      // The output pitch bend should still represent tuning offset + expressive bend in cents.
-      // E tuning offset = -14.0 cents; total ≈ -14 + 293 = 279 cents.
-      private val expectedCents = -14.0 + eExprCents
-      private val newPbs = PitchBendSensitivity(24)
-      pitchBends.head.centsFor(newPbs) shouldEqual expectedCents
-    }
-
   it should "preserve intonation of active note without expressive pitch bend after PBS change" in
     new Fixture(tuner7, Some(quarterCommaMeantone)) {
       // Given - Play E4: tuning offset for E is -14.0 cents
@@ -2063,7 +2017,35 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
     }
   }
 
-  it should "update master PBS on master channel in MPE input mode" in new Fixture(mpeTunerMpeInput) {
+  behavior of "MpeTuner - PBS Processing - MPE Input"
+
+  it should "preserve intonation of active note with expressive pitch bend after PBS change" in
+    new Fixture(
+      MpeTuner(
+        initialZones = MpeZones(MpeZone(MpeZoneType.Lower, 7), MpeZone(MpeZoneType.Upper, 0)),
+        initialInputMode = MpeInputMode.Mpe
+      ),
+      Some(quarterCommaMeantone)
+    ) {
+      // Given - Play E4 on member channel 1: tuning offset for E is -14.0 cents
+      private val noteOutput = noteOn(1, E4, 100)
+      private val noteChannel = extractNoteOns(noteOutput).head.channel
+      // Send an expressive pitch bend of ~293 cents on that channel (with default PBS=48 semitones)
+      private val eExprCents = 293.0
+      pitchBend(1, eExprCents)
+      // When - Now change member PBS from 48 to 24 semitones
+      private val pbsOutput = sendPbsMsb(tuner, channel = 1, semitones = 24)
+      // Then
+      private val pitchBends = extractPitchBends(pbsOutput).filter(_.channel == noteChannel)
+      pitchBends should have size 1
+      // The output pitch bend should still represent tuning offset + expressive bend in cents.
+      // E tuning offset = -14.0 cents; total ≈ -14 + 293 = 279 cents.
+      private val expectedCents = -14.0 + eExprCents
+      private val newPbs = PitchBendSensitivity(24)
+      pitchBends.head.centsFor(newPbs) shouldEqual expectedCents
+    }
+
+  it should "update master PBS on master channel" in new Fixture(mpeTunerMpeInput) {
     // When
     private val output = sendPbsMsb(tuner, channel = 0, semitones = 12)
     // Then
@@ -2076,7 +2058,7 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
     tuner.zones.lower.masterPitchBendSensitivity shouldEqual PitchBendSensitivity(12)
   }
 
-  it should "update member PBS and forward only on the received channel in MPE input mode" in
+  it should "update member PBS and forward only on the received channel" in
     new Fixture(tuner7MpeInput) {
       // When
       private val output = sendPbsMsb(tuner, channel = 1, semitones = 24)
@@ -2095,7 +2077,7 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       tuner.zones.lower.memberPitchBendSensitivity shouldEqual PitchBendSensitivity(24)
     }
 
-  it should "recompute pitch bends on occupied channels after member PBS change in MPE input mode" in
+  it should "recompute pitch bends on occupied channels after member PBS change" in
     new Fixture(tuner7MpeInput, Some(quarterCommaMeantone)) {
       // Given - Play a note to occupy a channel
       private val noteOutput = noteOn(2, E4)
@@ -2109,7 +2091,7 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       pitchBends.head.centsFor(PitchBendSensitivity(24)) shouldEqual -14.0
     }
 
-  it should "revert PBS to initial values on reset() in MPE input mode" in new Fixture(tuner7MpeInput) {
+  it should "revert PBS to initial values on reset()" in new Fixture(tuner7MpeInput) {
     // Given
     sendPbsMsb(tuner, channel = 1, semitones = 24)
     // When


### PR DESCRIPTION
## Summary

Part of #154 (polyphonic expression for MPE Tuner). This PR does not resolve the issue; it reorganizes the existing test suite so future tests for #154 land in a clear, well-structured layout.

- Splits `MpeTunerTest` from 21 mixed-concern `behavior of` sections into 15 sections structured as `MpeTuner - <operation> - <Non-MPE|MPE> Input` (8 operation/mode categories, some with only one mode populated).
- Dissolves 18 old headings (e.g. "Worked Examples", "Non-MPE to MPE Conversion", "Pitch Bend Computation", "Dual-Group Allocation") by distributing their tests into the new layout.
- Drops redundant ` in MPE input mode` / ` in non-MPE mode` suffixes from test names where the new heading already carries the mode.
- No logic changes — all 109 live + 14 ignored tests are preserved verbatim.

The side-by-side category table in `issues/00154-mpe-tuner-poly-expr/tests-reorg.csv` makes coverage gaps between MPE and Non-MPE sides visible at a glance.

## Test plan

- [x] `sbtn "tuner/testOnly org.calinburloiu.music.microtonalist.tuner.MpeTunerTest"` — all 109 live tests pass, 14 remain ignored, counts unchanged.