### PR TITLE
[#212] Factor Architecture section out of `CLAUDE.md` into per-module architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ Scala 3 and is built by using sbt 1.
 
 - Use Metals MCP for compiling and code intelligence (see [Code Intelligence](#code-intelligence) section); fall back to
   sbt only when it is unavailable (see [`docs/development/build.md`](docs/development/build.md)).
+- Before writing code, create a task to explore the architecture: read the always-loaded overview imported in the
+  [Architecture](#architecture) section (from [`docs/agents/architecture.md`](docs/agents/architecture.md)) plus the
+  architecture documents strictly relevant to the prompt — typically the
+  [`docs/architecture/$MODULE/README.md`](docs/architecture/) of each module you will touch and its immediate
+  collaborators. That overview explains how the architecture documents are organized.
 - Use strict Test Driven Development (_TDD_) by following the _red/green/refactor_ cycle:
     - **Red**. Write failing tests first. If the compiler requires it, create the thinnest possible stub (`???` bodies,
       no logic) to get them to compile, then confirm the tests fail for the right reason. The tests failure reason
@@ -133,134 +138,12 @@ implementation is finished.
 
 # Architecture
 
-## Module Overview
+Crucial architecture context — the module dependency graph, the key domain concepts, and the end-to-end data flow — is
+imported below and loads in every session. Deeper, context-specific detail lives in the per-module and per-topic
+documents under [`docs/architecture/`](docs/architecture/), each loaded on demand via its module's `CLAUDE.md`. The
+imported overview also explains how those documents are organized, so you can find the ones relevant to a task.
 
-The project uses a layered module structure. Dependency direction flows from `app` downward:
-
-```
-app
-├── ui            (GUI, depends on tuner)
-├── composition   (domain model, depends on intonation + tuner)
-├── format        (JSON/file I/O, depends on composition + tuner)
-├── tuner         (MIDI tuning, depends on sc-midi + businessync)
-├── sc-midi       (Scala-idiomatic MIDI API, depends on businessync)
-├── intonation    (interval math, no application deps)
-├── businessync   (event bus + threading, no application deps)
-├── common        (shared utilities)
-└── config        (HOCON config, depends on common)
-```
-
-`cli` is a separate executable (utility tool) that depends only on `sc-midi`.
-
-## Key Domain Concepts
-
-**Intonation (`intonation` module, `org.calinburloiu.music.intonation`):**
-
-- `Interval` (sealed trait) — musical interval, base for `RatioInterval`, `CentsInterval`, `EdoInterval`,
-  `RealInterval`; all support arithmetic in logarithmic space and conversion to cents
-- `Scale[I <: Interval]` — ordered sequence of intervals with direction that represent a musical scale, with helper
-  methods for things like relative intervals, softness (entropy) etc.
-- `IntonationStandard` — enum-like sealed trait describing how intervals are expressed (`CentsIntonationStandard`,
-  `JustIntonationStandard`, `EdoIntonationStandard`)
-
-**Composition (`composition` module, `org.calinburloiu.music.microtonalist.composition`):**
-
-- `Composition` — top-level container that models a microtonal musical composition with respect to its microtonal scales
-  and how are mapped to tunings: holds an `IntonationStandard`, a `TuningReference`, a sequence of `TuningSpec`, a
-  `TuningReducer`, and fill configuration
-- `TuningMapper` (trait, Plugin) — maps a `Scale` to a `Tuning`, deciding which keyboard pitch class each scale pitch
-  occupies (unused keys stay `None`) and throwing a `TuningMapperConflictException` when two pitches collide on one key;
-  `AutoTuningMapper` places pitches automatically (handling quarter tones and the soft chromatic genus),
-  `ManualTuningMapper` uses a user-provided `KeyboardMapping`
-- `TuningReducer` (trait, Plugin) — merges the per-`TuningSpec` `Tuning`s into ideally fewer final tunings to minimize
-  the tuning switches a player must make, producing the `TuningList`; `MergeTuningReducer` (default) merges consecutive
-  non-conflicting tunings and applies local back-/fore-fill, while `DirectTuningReducer` applies only the global fill
-  (no reduction)
-- `TuningReference` (trait, Plugin) — defines the composition's base pitch: the keyboard pitch class it maps to
-  (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`;
-  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch frequency
-- `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
-- `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
-
-**Tuner (`tuner` module, `org.calinburloiu.music.microtonalist.tuner`):**
-
-- `Tuning` — 12 optional cent offsets for pitch classes; `Tuning.Standard` is 12-EDO
-- `Tuner` (trait, Plugin) — processes MIDI messages: `reset()`, `tune(tuning)`, `process(message)`; implementations
-  cover all MTS Octave variants, MPE, and monophonic tuning via Pitch Bend
-- `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages (e.g.,
-  `PedalTuningChanger`)
-- `Track` — one instrument pipeline: input device → `TuningChangeProcessor` → `TunerProcessor` → output device
-- `TuningSession` / `TuningService` — holds current tuning index and exposes thread-safe API for changing it
-- `TrackManager` — lifecycle manager for tracks; reacts to MIDI device events
-
-**Plugin pattern:** `Tuner`, `TuningMapper`, `TuningReducer`, `TuningReference`, and `TuningChanger` all extend
-`Plugin` (from `common`). Each plugin has a `familyName` and `typeName` used for JSON (de)serialization via Play JSON.
-
-## Threading Model (Businessync)
-
-`Businessync` (`businessync` module) manages two threads:
-
-- **Business thread** — all domain/MIDI logic; annotate handlers with `@Subscribe` and call `businessync.run {}`
-- **UI thread** — all GUI updates; use `businessync.runOnUi {}`
-
-Cross-thread calls use `businessync.callAsync`. Never mutate domain state from the UI thread directly.
-
-## Data Flow
-
-```
-JSON composition file
-  → DefaultCompositionRepo (format module)
-  → Composition
-  → TuningList.fromComposition()   (applies TuningMapper, TuningReducer, fill)
-  → TuningSession.tunings
-  → TuningIndexUpdatedEvent (via Businessync)
-  → TrackManager → Track.tune()
-  → TunerProcessor → Tuner
-  → MTS/MPE MIDI messages
-  → MIDI output device
-```
-
-## Format / Serialization
-
-All file I/O is in the `format` module (`org.calinburloiu.music.microtonalist.format`).
-
-**The `*Format` / `*Repo` pattern.** Each kind of persistable domain object is handled by a pair of collaborating
-abstractions that separate _how_ a value is encoded from _where_ it is stored:
-
-- A **`*Format`** does pure serialization/deserialization between a byte stream (`InputStream`/`OutputStream`) and a
-  domain object. It knows the encoding (typically JSON via Play JSON) but nothing about the data source. Example:
-  `JsonCompositionFormat` implements `CompositionFormat`.
-- A **`*Repo`** follows the repository pattern: it retrieves and persists a domain object identified by a `URI`,
-  abstracting the underlying data source (local file, HTTP, scale library). Each exposes synchronous and asynchronous
-  `read`/`write` methods. Source-specific implementations (`File*Repo`, `Http*Repo`, `Library*Repo`) delegate the actual
-  encoding/decoding to the matching `*Format`, while a `Default*Repo` dispatches to them by URI scheme (relative or
-  `file:` → file, `http(s):` → HTTP) using a `RepoSelector`.
-
-The concrete `*Format` / `*Repo` pairs are:
-
-- `CompositionFormat` / `CompositionRepo` — reads JSON `.mtlist` composition files
-- `ScaleFormat` / `ScaleRepo` — reads embedded JSON `.jscl` scales or Huygens-Fokker `.scl` files; scales can be inlined
-  in a composition file or referenced by URI
-- `TrackFormat` / `TrackRepo` — reads `.mtlist.tracks` JSON files that encode a collection of `Track`s (the `TrackRepo`
-  trait lives in the `tuner` module, its formats and concrete repos in `format`)
-
-Supporting types:
-
-- `JsonPreprocessor` — resolves `$ref`-style URIs (file or HTTP) before parsing
-- `FormatModule` — lazy-initializes all repos/formats; inject this rather than constructing individual components
-
-## Application Entry Point
-
-`MicrotonalistApp` (`app` module) wires everything:
-
-1. Parses CLI args (composition URI, optional config file)
-2. Creates `Businessync` and starts business thread
-3. Builds `FormatModule`, loads `Composition`, builds `TuningList`
-4. Builds `TunerModule`, loads tracks
-5. Opens `TuningListFrame` (Swing GUI)
-6. Registers JVM shutdown hook for cleanup
-
-Application config (HOCON) lives at `~/.microtonalist/microtonalist.conf` on macOS.
+@docs/agents/architecture.md
 
 # Contributing (issues, PRs, branches)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ app
 ├── composition   (domain model, depends on intonation + tuner)
 ├── format        (JSON/file I/O, depends on composition + tuner)
 ├── tuner         (MIDI tuning, depends on sc-midi + businessync)
-├── sc-midi       (Java MIDI wrappers, depends on businessync)
+├── sc-midi       (Scala-idiomatic MIDI API, depends on businessync)
 ├── intonation    (interval math, no application deps)
 ├── businessync   (event bus + threading, no application deps)
 ├── common        (shared utilities)
@@ -156,17 +156,29 @@ app
 
 **Intonation (`intonation` module, `org.calinburloiu.music.intonation`):**
 
-- `Interval` (sealed trait) — base for `RatioInterval`, `CentsInterval`, `EdoInterval`, `RealInterval`; all support
-  arithmetic in logarithmic space and conversion to cents
-- `Scale[I <: Interval]` — ordered sequence of intervals with direction, helper methods for relative intervals and
-  softness (entropy)
+- `Interval` (sealed trait) — musical interval, base for `RatioInterval`, `CentsInterval`, `EdoInterval`,
+  `RealInterval`; all support arithmetic in logarithmic space and conversion to cents
+- `Scale[I <: Interval]` — ordered sequence of intervals with direction that represent a musical scale, with helper
+  methods for things like relative intervals, softness (entropy) etc.
 - `IntonationStandard` — enum-like sealed trait describing how intervals are expressed (`CentsIntonationStandard`,
   `JustIntonationStandard`, `EdoIntonationStandard`)
 
 **Composition (`composition` module, `org.calinburloiu.music.microtonalist.composition`):**
 
-- `Composition` — top-level container: holds an `IntonationStandard`, a `TuningReference`, a sequence of `TuningSpec`, a
+- `Composition` — top-level container that models a microtonal musical composition with respect to its microtonal scales
+  and how are mapped to tunings: holds an `IntonationStandard`, a `TuningReference`, a sequence of `TuningSpec`, a
   `TuningReducer`, and fill configuration
+- `TuningMapper` (trait, Plugin) — maps a `Scale` to a `Tuning`, deciding which keyboard pitch class each scale pitch
+  occupies (unused keys stay `None`) and throwing a `TuningMapperConflictException` when two pitches collide on one key;
+  `AutoTuningMapper` places pitches automatically (handling quarter tones and the soft chromatic genus),
+  `ManualTuningMapper` uses a user-provided `KeyboardMapping`
+- `TuningReducer` (trait, Plugin) — merges the per-`TuningSpec` `Tuning`s into ideally fewer final tunings to minimize
+  the tuning switches a player must make, producing the `TuningList`; `MergeTuningReducer` (default) merges consecutive
+  non-conflicting tunings and applies local back-/fore-fill, while `DirectTuningReducer` applies only the global fill
+  (no reduction)
+- `TuningReference` (trait, Plugin) — defines the composition's base pitch: the keyboard pitch class it maps to
+  (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`;
+  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch frequency
 - `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
 - `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
 
@@ -210,12 +222,30 @@ JSON composition file
 
 ## Format / Serialization
 
-All file I/O is in the `format` module (`org.calinburloiu.music.microtonalist.format`). Key types:
+All file I/O is in the `format` module (`org.calinburloiu.music.microtonalist.format`).
+
+**The `*Format` / `*Repo` pattern.** Each kind of persistable domain object is handled by a pair of collaborating
+abstractions that separate _how_ a value is encoded from _where_ it is stored:
+
+- A **`*Format`** does pure serialization/deserialization between a byte stream (`InputStream`/`OutputStream`) and a
+  domain object. It knows the encoding (typically JSON via Play JSON) but nothing about the data source. Example:
+  `JsonCompositionFormat` implements `CompositionFormat`.
+- A **`*Repo`** follows the repository pattern: it retrieves and persists a domain object identified by a `URI`,
+  abstracting the underlying data source (local file, HTTP, scale library). Each exposes synchronous and asynchronous
+  `read`/`write` methods. Source-specific implementations (`File*Repo`, `Http*Repo`, `Library*Repo`) delegate the actual
+  encoding/decoding to the matching `*Format`, while a `Default*Repo` dispatches to them by URI scheme (relative or
+  `file:` → file, `http(s):` → HTTP) using a `RepoSelector`.
+
+The concrete `*Format` / `*Repo` pairs are:
 
 - `CompositionFormat` / `CompositionRepo` — reads JSON `.mtlist` composition files
 - `ScaleFormat` / `ScaleRepo` — reads embedded JSON `.jscl` scales or Huygens-Fokker `.scl` files; scales can be inlined
-  or referenced by URI
-- `TrackFormat` / `TrackRepo` — reads `.mtlist.tracks` JSON files
+  in a composition file or referenced by URI
+- `TrackFormat` / `TrackRepo` — reads `.mtlist.tracks` JSON files that encode a collection of `Track`s (the `TrackRepo`
+  trait lives in the `tuner` module, its formats and concrete repos in `format`)
+
+Supporting types:
+
 - `JsonPreprocessor` — resolves `$ref`-style URIs (file or HTTP) before parsing
 - `FormatModule` — lazy-initializes all repos/formats; inject this rather than constructing individual components
 

--- a/composition/src/main/scala/org/calinburloiu/music/microtonalist/composition/Composition.scala
+++ b/composition/src/main/scala/org/calinburloiu/music/microtonalist/composition/Composition.scala
@@ -22,7 +22,7 @@ import org.calinburloiu.music.microtonalist.tuner.Tuning
 import java.net.URI
 
 /**
- * A collection of scales to be mapped to tunings.
+ * Models a microtonal musical composition with respect to its microtonal scales and how are mapped to tunings.
  *
  * @param url                    Optional URL associated with the composition which might have been used to
  *                               load it from.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,107 @@
+# Architecture (Agents)
+
+This is the crucial, always-loaded architecture overview for coding agents. It is `@import`ed by the root
+[`AGENTS.md`](../../AGENTS.md) / `CLAUDE.md` so it loads in every session. Deeper, context-specific detail lives in
+the per-module and per-topic documents under [`docs/architecture/`](../architecture/) and is loaded on demand.
+
+## How architecture docs are organized
+
+- **This file (`docs/agents/architecture.md`)** — the always-in-context overview: the module dependency graph, the key
+  domain concepts, and the end-to-end data flow. Read it to orient yourself in any task.
+- **Per-module deep dives (`docs/architecture/$MODULE/README.md`)** — one document per SBT module (an architecture
+  document covering responsibility, key types, dependencies, and module-specific concerns). Each module's
+  `$MODULE/CLAUDE.md` `@import`s its document, so when you work inside a module that detail loads automatically. To read
+  another module's architecture without editing in it, open its `docs/architecture/$MODULE/README.md` directly.
+- **Per-topic documents** — some directories carry focused topic docs alongside the module README, e.g.
+  [`docs/architecture/tuner/mpe-spec.md`](../architecture/tuner/mpe-spec.md) and
+  [`docs/architecture/tuner/mpe-tuner-paper.md`](../architecture/tuner/mpe-tuner-paper.md) for MPE tuning.
+- **Human-facing index (`docs/architecture/README.md`)** — the same material framed for human readers, with a table
+  mapping each module to its directory and document.
+
+**Before coding**, identify which architecture documents are strictly relevant to the task (this overview plus the
+README(s) of the module(s) you will touch and their immediate collaborators) and read them. Architecture docs may note
+that an area is *subject to change* under the GitHub `Architecture` milestone; treat those notes as forward-looking, not
+as the current state of the code.
+
+## Module Overview
+
+The project uses a layered module structure. Dependency direction flows from `app` downward:
+
+```
+app
+├── ui            (GUI, depends on tuner)
+├── composition   (domain model, depends on intonation + tuner)
+├── format        (JSON/file I/O, depends on composition + tuner)
+├── tuner         (MIDI tuning, depends on sc-midi + businessync)
+├── sc-midi       (Scala-idiomatic MIDI API, depends on businessync)
+├── intonation    (interval math, no application deps)
+├── businessync   (event bus + threading, no application deps)
+├── common        (shared utilities)
+└── config        (HOCON config, depends on common)
+```
+
+`cli` is a separate executable (utility tool) that depends only on `sc-midi`.
+
+## Key Domain Concepts
+
+**Intonation (`intonation` module, `org.calinburloiu.music.intonation`):**
+
+- `Interval` (sealed trait) — musical interval, base for `RatioInterval`, `CentsInterval`, `EdoInterval`,
+  `RealInterval`; all support arithmetic in logarithmic space and conversion to cents
+- `Scale[I <: Interval]` — ordered sequence of intervals with direction that represent a musical scale, with helper
+  methods for things like relative intervals, softness (entropy) etc.
+- `IntonationStandard` — enum-like sealed trait describing how intervals are expressed (`CentsIntonationStandard`,
+  `JustIntonationStandard`, `EdoIntonationStandard`)
+
+**Composition (`composition` module, `org.calinburloiu.music.microtonalist.composition`):**
+
+- `Composition` — top-level container that models a microtonal musical composition with respect to its microtonal scales
+  and how are mapped to tunings: holds an `IntonationStandard`, a `TuningReference`, a sequence of `TuningSpec`, a
+  `TuningReducer`, and fill configuration
+- `TuningMapper` (trait, Plugin) — maps a `Scale` to a `Tuning`, deciding which keyboard pitch class each scale pitch
+  occupies (unused keys stay `None`) and throwing a `TuningMapperConflictException` when two pitches collide on one key;
+  `AutoTuningMapper` places pitches automatically (handling quarter tones and the soft chromatic genus),
+  `ManualTuningMapper` uses a user-provided `KeyboardMapping`
+- `TuningReducer` (trait, Plugin) — merges the per-`TuningSpec` `Tuning`s into ideally fewer final tunings to minimize
+  the tuning switches a player must make, producing the `TuningList`; `MergeTuningReducer` (default) merges consecutive
+  non-conflicting tunings and applies local back-/fore-fill, while `DirectTuningReducer` applies only the global fill
+  (no reduction)
+- `TuningReference` (trait, Plugin) — defines the composition's base pitch: the keyboard pitch class it maps to
+  (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`;
+  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch frequency
+- `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
+- `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
+
+**Tuner (`tuner` module, `org.calinburloiu.music.microtonalist.tuner`):**
+
+- `Tuning` — 12 optional cent offsets for pitch classes; `Tuning.Standard` is 12-EDO
+- `Tuner` (trait, Plugin) — processes MIDI messages: `reset()`, `tune(tuning)`, `process(message)`; implementations
+  cover all MTS Octave variants, MPE, and monophonic tuning via Pitch Bend
+- `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages (e.g.,
+  `PedalTuningChanger`)
+- `Track` — one instrument pipeline: input device → `TuningChangeProcessor` → `TunerProcessor` → output device
+- `TuningSession` / `TuningService` — holds current tuning index and exposes thread-safe API for changing it
+- `TrackManager` — lifecycle manager for tracks; reacts to MIDI device events
+
+**Plugin pattern:** `Tuner`, `TuningMapper`, `TuningReducer`, `TuningReference`, and `TuningChanger` all extend
+`Plugin` (from `common`). Each plugin has a `familyName` and `typeName` used for JSON (de)serialization via Play JSON.
+
+## Data Flow
+
+```
+JSON composition file
+  → DefaultCompositionRepo (format module)
+  → Composition
+  → TuningList.fromComposition()   (applies TuningMapper, TuningReducer, fill)
+  → TuningSession.tunings
+  → TuningIndexUpdatedEvent (via Businessync)
+  → TrackManager → Track.tune()
+  → TunerProcessor → Tuner
+  → MTS/MPE MIDI messages
+  → MIDI output device
+```
+
+> **More detail:** the threading model behind this flow is documented in
+> [`docs/architecture/businessync/`](../architecture/businessync/README.md); serialization in
+> [`docs/architecture/format/`](../architecture/format/README.md); the startup wiring that builds this pipeline in
+> [`docs/architecture/app/`](../architecture/app/README.md).

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -6,8 +6,14 @@ the per-module and per-topic documents under [`docs/architecture/`](../architect
 
 ## How architecture docs are organized
 
-- **This file (`docs/agents/architecture.md`)** — the always-in-context overview: the module dependency graph, the key
-  domain concepts, and the end-to-end data flow. Read it to orient yourself in any task.
+- **This file (`docs/agents/architecture.md`)** — the always-in-context overview. It adds agent-specific guidance (how
+  the docs are organized and what to read before coding), then `@import`s the three shared overview documents below so
+  they stay always-loaded for agents. It holds no architecture content of its own.
+- **Shared overview documents (`docs/architecture/`)** — the single source of truth for the cross-cutting basics,
+  imported here and linked from the human-facing index:
+  [`module-overview.md`](../architecture/module-overview.md) (the module dependency graph),
+  [`domain-concepts.md`](../architecture/domain-concepts.md) (the key domain types), and
+  [`data-flow.md`](../architecture/data-flow.md) (the end-to-end data flow). Edit these there, not here.
 - **Per-module deep dives (`docs/architecture/$MODULE/README.md`)** — one document per SBT module (an architecture
   document covering responsibility, key types, dependencies, and module-specific concerns). Each module's
   `$MODULE/CLAUDE.md` `@import`s its document, so when you work inside a module that detail loads automatically. To read
@@ -23,86 +29,12 @@ README(s) of the module(s) you will touch and their immediate collaborators) and
 that an area is *subject to change* under the GitHub `Architecture` milestone; treat those notes as forward-looking, not
 as the current state of the code.
 
-## Module Overview
+## Always-loaded overview
 
-The project uses a layered module structure. Dependency direction flows from `app` downward:
+The module dependency graph, the key domain concepts, and the end-to-end data flow are imported below so they remain in
+context for every session. They are maintained under [`docs/architecture/`](../architecture/) as the single source of
+truth — humans read them via the [index](../architecture/README.md); edit them there, not here.
 
-```
-app
-├── ui            (GUI, depends on tuner)
-├── composition   (domain model, depends on intonation + tuner)
-├── format        (JSON/file I/O, depends on composition + tuner)
-├── tuner         (MIDI tuning, depends on sc-midi + businessync)
-├── sc-midi       (Scala-idiomatic MIDI API, depends on businessync)
-├── intonation    (interval math, no application deps)
-├── businessync   (event bus + threading, no application deps)
-├── common        (shared utilities)
-└── config        (HOCON config, depends on common)
-```
-
-`cli` is a separate executable (utility tool) that depends only on `sc-midi`.
-
-## Key Domain Concepts
-
-**Intonation (`intonation` module, `org.calinburloiu.music.intonation`):**
-
-- `Interval` (sealed trait) — musical interval, base for `RatioInterval`, `CentsInterval`, `EdoInterval`,
-  `RealInterval`; all support arithmetic in logarithmic space and conversion to cents
-- `Scale[I <: Interval]` — ordered sequence of intervals with direction that represent a musical scale, with helper
-  methods for things like relative intervals, softness (entropy) etc.
-- `IntonationStandard` — enum-like sealed trait describing how intervals are expressed (`CentsIntonationStandard`,
-  `JustIntonationStandard`, `EdoIntonationStandard`)
-
-**Composition (`composition` module, `org.calinburloiu.music.microtonalist.composition`):**
-
-- `Composition` — top-level container that models a microtonal musical composition with respect to its microtonal scales
-  and how are mapped to tunings: holds an `IntonationStandard`, a `TuningReference`, a sequence of `TuningSpec`, a
-  `TuningReducer`, and fill configuration
-- `TuningMapper` (trait, Plugin) — maps a `Scale` to a `Tuning`, deciding which keyboard pitch class each scale pitch
-  occupies (unused keys stay `None`) and throwing a `TuningMapperConflictException` when two pitches collide on one key;
-  `AutoTuningMapper` places pitches automatically (handling quarter tones and the soft chromatic genus),
-  `ManualTuningMapper` uses a user-provided `KeyboardMapping`
-- `TuningReducer` (trait, Plugin) — merges the per-`TuningSpec` `Tuning`s into ideally fewer final tunings to minimize
-  the tuning switches a player must make, producing the `TuningList`; `MergeTuningReducer` (default) merges consecutive
-  non-conflicting tunings and applies local back-/fore-fill, while `DirectTuningReducer` applies only the global fill
-  (no reduction)
-- `TuningReference` (trait, Plugin) — defines the composition's base pitch: the keyboard pitch class it maps to
-  (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`;
-  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch
-  frequency
-- `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
-- `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
-
-**Tuner (`tuner` module, `org.calinburloiu.music.microtonalist.tuner`):**
-
-- `Tuning` — 12 optional cent offsets for pitch classes; `Tuning.Standard` is 12-EDO
-- `Tuner` (trait, Plugin) — processes MIDI messages: `reset()`, `tune(tuning)`, `process(message)`; implementations
-  cover all MTS Octave variants, MPE, and monophonic tuning via Pitch Bend
-- `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages (e.g.,
-  `PedalTuningChanger`)
-- `Track` — one instrument pipeline: input device → `TuningChangeProcessor` → `TunerProcessor` → output device
-- `TuningSession` / `TuningService` — holds current tuning index and exposes thread-safe API for changing it
-- `TrackManager` — lifecycle manager for tracks; reacts to MIDI device events
-
-**Plugin pattern:** `Tuner`, `TuningMapper`, `TuningReducer`, `TuningReference`, and `TuningChanger` all extend
-`Plugin` (from `common`). Each plugin has a `familyName` and `typeName` used for JSON (de)serialization via Play JSON.
-
-## Data Flow
-
-```
-JSON composition file
-  → DefaultCompositionRepo (format module)
-  → Composition
-  → TuningList.fromComposition()   (applies TuningMapper, TuningReducer, fill)
-  → TuningSession.tunings
-  → TuningIndexUpdatedEvent (via Businessync)
-  → TrackManager → Track.tune()
-  → TunerProcessor → Tuner
-  → MTS/MPE MIDI messages
-  → MIDI output device
-```
-
-> **More detail:** the threading model behind this flow is documented in
-> [`docs/architecture/businessync/`](../architecture/businessync/README.md); serialization in
-> [`docs/architecture/format/`](../architecture/format/README.md); the startup wiring that builds this pipeline in
-> [`docs/architecture/app/`](../architecture/app/README.md).
+@../architecture/module-overview.md
+@../architecture/domain-concepts.md
+@../architecture/data-flow.md

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -68,7 +68,8 @@ app
   (no reduction)
 - `TuningReference` (trait, Plugin) — defines the composition's base pitch: the keyboard pitch class it maps to
   (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`;
-  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch frequency
+  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch
+  frequency
 - `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
 - `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,35 +4,22 @@ This directory documents the architecture of Microtonalist. It is consumed by bo
 module (an SBT project, see `build.sbt`) gets its own subdirectory here, and each module's `CLAUDE.md` `@import`s its
 architecture document so the relevant context loads on demand when an agent works in that module.
 
-A concise, always-in-context overview — the module dependency graph, the key domain concepts, and the end-to-end data
-flow — is maintained for coding agents in [`../agents/architecture.md`](../agents/architecture.md) and imported by the
-root [`CLAUDE.md`](../../CLAUDE.md) / [`AGENTS.md`](../../AGENTS.md). This directory holds the deeper, per-module
-detail: start with the overview, then follow the module index below into whichever module(s) a task touches.
+Start with the cross-cutting overview below, then follow the module index into whichever module(s) a task touches. The
+three overview documents are the single source of truth for the basics; coding agents get them always-loaded because
+[`../agents/architecture.md`](../agents/architecture.md) (imported by the root [`CLAUDE.md`](../../CLAUDE.md) /
+[`AGENTS.md`](../../AGENTS.md)) `@import`s them and adds agent-specific guidance on top.
 
 Some documents note that an area is *subject to change* under the GitHub
 [`Architecture`](https://github.com/calinburloiu/microtonalist/milestone/13) milestone (e.g. the Swing→JavaFX GUI
 migration, the module-wiring/dependency-injection refactor, and the businessync threading/sequential-consistency work).
 Those notes are forward-looking; the surrounding text describes the code as it is today.
 
-## Module dependency overview
+## Architecture overview
 
-The project uses a layered module structure; dependency direction flows from `app` downward:
-
-```
-app
-├── ui            (GUI, depends on tuner)
-├── composition   (domain model, depends on intonation + tuner)
-├── format        (JSON/file I/O, depends on composition + tuner)
-├── tuner         (MIDI tuning, depends on sc-midi + businessync)
-├── sc-midi       (Scala-idiomatic MIDI API, depends on businessync)
-├── intonation    (interval math, no application deps)
-├── businessync   (event bus + threading, no application deps)
-├── common        (shared utilities)
-└── config        (HOCON config, depends on common)
-```
-
-`cli` is a separate executable (a utility tool, e.g. listing MIDI devices) that depends only on `sc-midi`;
-`experiments` is a separate executable for ad-hoc research studies that depends on `intonation`.
+- [`module-overview.md`](module-overview.md) — the layered module structure and dependency graph.
+- [`domain-concepts.md`](domain-concepts.md) — the key domain types (intervals, scales, compositions, tunings, tuners)
+  and the plugin pattern, grouped by module.
+- [`data-flow.md`](data-flow.md) — how a composition file becomes tuning MIDI messages, end to end.
 
 ## Module index
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -6,8 +6,8 @@ architecture document so the relevant context loads on demand when an agent work
 
 A concise, always-in-context overview — the module dependency graph, the key domain concepts, and the end-to-end data
 flow — is maintained for coding agents in [`../agents/architecture.md`](../agents/architecture.md) and imported by the
-root [`CLAUDE.md`](../../CLAUDE.md) / [`AGENTS.md`](../../AGENTS.md). This directory holds the deeper, per-module detail:
-start with the overview, then follow the module index below into whichever module(s) a task touches.
+root [`CLAUDE.md`](../../CLAUDE.md) / [`AGENTS.md`](../../AGENTS.md). This directory holds the deeper, per-module
+detail: start with the overview, then follow the module index below into whichever module(s) a task touches.
 
 Some documents note that an area is *subject to change* under the GitHub
 [`Architecture`](https://github.com/calinburloiu/microtonalist/milestone/13) milestone (e.g. the Swing→JavaFX GUI

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,9 +4,35 @@ This directory documents the architecture of Microtonalist. It is consumed by bo
 module (an SBT project, see `build.sbt`) gets its own subdirectory here, and each module's `CLAUDE.md` `@import`s its
 architecture document so the relevant context loads on demand when an agent works in that module.
 
-> **Status:** Most per-module documents below are placeholders to be filled in. Until they are written, the
-> authoritative architecture overview (module dependency graph, key domain concepts, threading model, data flow) lives
-> in the "Architecture" section of the root [`CLAUDE.md`](../../CLAUDE.md) / [`AGENTS.md`](../../AGENTS.md).
+A concise, always-in-context overview — the module dependency graph, the key domain concepts, and the end-to-end data
+flow — is maintained for coding agents in [`../agents/architecture.md`](../agents/architecture.md) and imported by the
+root [`CLAUDE.md`](../../CLAUDE.md) / [`AGENTS.md`](../../AGENTS.md). This directory holds the deeper, per-module detail:
+start with the overview, then follow the module index below into whichever module(s) a task touches.
+
+Some documents note that an area is *subject to change* under the GitHub
+[`Architecture`](https://github.com/calinburloiu/microtonalist/milestone/13) milestone (e.g. the Swing→JavaFX GUI
+migration, the module-wiring/dependency-injection refactor, and the businessync threading/sequential-consistency work).
+Those notes are forward-looking; the surrounding text describes the code as it is today.
+
+## Module dependency overview
+
+The project uses a layered module structure; dependency direction flows from `app` downward:
+
+```
+app
+├── ui            (GUI, depends on tuner)
+├── composition   (domain model, depends on intonation + tuner)
+├── format        (JSON/file I/O, depends on composition + tuner)
+├── tuner         (MIDI tuning, depends on sc-midi + businessync)
+├── sc-midi       (Scala-idiomatic MIDI API, depends on businessync)
+├── intonation    (interval math, no application deps)
+├── businessync   (event bus + threading, no application deps)
+├── common        (shared utilities)
+└── config        (HOCON config, depends on common)
+```
+
+`cli` is a separate executable (a utility tool, e.g. listing MIDI devices) that depends only on `sc-midi`;
+`experiments` is a separate executable for ad-hoc research studies that depends on `intonation`.
 
 ## Module index
 

--- a/docs/architecture/app/README.md
+++ b/docs/architecture/app/README.md
@@ -1,17 +1,189 @@
 # `app` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `app` module (`app/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+`app` is the top-level executable module. It is the only module with a `main` entry point intended for end users
+(the `cli` and `experiments` modules are separate, smaller executables). Its single job is **composition root**
+wiring and **application lifecycle**:
+
+- parse command-line arguments;
+- construct and connect the lower-level modules (`config`/`appConfig`, `format`, `tuner`, `ui`) and the cross-cutting
+  `businessync` event/threading layer;
+- load the user's composition, build the resolved `TuningList`, load tracks, and open the GUI;
+- own the process lifecycle: top-level error handling, exit codes, and a JVM shutdown hook for clean teardown.
+
+`app` contains almost no domain logic of its own — it is deliberately thin glue. The actual work lives in the modules
+it depends on. There is exactly one Scala source file in the module:
+`app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala`.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### `MicrotonalistApp`
+
+`app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala:35`
+
+The `object` that holds `main` and the wiring logic. Notable members:
+
+- `main(args)` — `MicrotonalistApp.scala:51`. Wraps everything in a `Try`, dispatches on the argument count, and
+  recovers by mapping exceptions to process exits (see error handling below).
+- `run(inputUrl, maybeConfigPath)` — `MicrotonalistApp.scala:76`. The composition root: builds every module and starts
+  the application. This is the method to read first to understand the wiring.
+- `parseUrlArg` / `parsePathArg` — `MicrotonalistApp.scala:68`, `:72`. Parse the composition URI (via
+  `common.parseUrlOrPath`) and the optional config-file path; both throw `AppUsageException` on malformed input.
+- `AppException` (sealed) and its cases — `MicrotonalistApp.scala:37`. Each carries a `statusCode` and an
+  `exitWithMessage()` that prints to `stderr` and calls `System.exit`:
+  - `AppUsageException` (exit 1) — wrong argument count or unparseable URL/path.
+  - `NoDeviceAvailableException` (exit 2) — declared for the case where no configured MIDI device is available.
+  - `AppConfigException(message)` (exit 3) — configuration problem.
+  - Any other `Exception` is logged and the process exits with code 1000 (`MicrotonalistApp.scala:64`).
+
+### `BuildInfo`
+
+`org.calinburloiu.music.microtonalist.BuildInfo` is generated at compile time by the `sbt-buildinfo` plugin
+(`enablePlugins(BuildInfoPlugin)` in `build.sbt:65`, with `buildInfoPackage` set on `build.sbt:72`). It exposes
+`name`, `version`, `scalaVersion`, and `sbtVersion`; `MicrotonalistApp` uses `BuildInfo.version` in the startup banner
+(`MicrotonalistApp.scala:52`). It is the only generated type in the module.
+
+### Module wiring objects (constructed by `run`, owned by the depended-on modules)
+
+`app` does not define these classes; it instantiates them. They are the seams through which each lower module exposes
+its public surface as a small manually-wired container.
+
+- **`MainConfigManager`** (`config` module) —
+  `config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigManagement.scala:30`. Loads and manages the
+  HOCON application config. `MainConfigManager(configPath)` parses the file (`ConfigFactory.parseFile(...).resolve()`),
+  exposes typed sub-configs through `SubConfigManager`/`CoreConfigManager`, periodically auto-saves dirty config, and
+  saves on close. `MainConfigManager.defaultConfigFile` (`ConfigManagement.scala:114`) returns
+  `~/.microtonalist/microtonalist.conf` on macOS.
+- **`CoreConfig`** (`config` module) —
+  `config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala:27`. The typed core config:
+  `libraryBaseUrl` (the scale/track library root, defaulting to `~/Music/microtonalist/lib/` on macOS) and a nested
+  `MetaConfig` (`saveIntervalMillis`, `saveOnExit`). `app` reads `mainConfigManager.coreConfig.libraryBaseUrl` to wire
+  the `FormatModule`.
+- **`FormatModule`** (`format` module) —
+  `format/src/main/scala/org/calinburloiu/music/microtonalist/format/FormatModule.scala:26`. A lazy container that
+  builds all file/HTTP/library repos and their JSON formats. `app` uses `defaultCompositionRepo` (to read the
+  `.mtlist` composition) and `defaultTrackRepo` (passed into `TunerModule`). Constructor takes the `Businessync` and
+  the `libraryBaseUrl` from config.
+- **`TunerModule`** (`tuner` module) —
+  `tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/TunerModule.scala:22`. A lazy container, also
+  `AutoCloseable`, that builds the MIDI/tuning runtime: `tuningSession`, `tuningService`, `trackService`,
+  `MidiManager`, and `TrackManager` (registered on the `Businessync` bus). `app` sets `tuningSession.tunings`, opens
+  tracks via `trackService`, hands `tuningService` to the GUI, and calls `close()` from the shutdown hook.
+- **`Businessync`** (`businessync` module) — the event bus + threading layer (business thread / UI thread). Created
+  once in `run` (`MicrotonalistApp.scala:79`) over a Guava `EventBus` and threaded through every module that needs to
+  publish events or run work on the business thread. The GUI frame and `TrackManager` register themselves on it.
+- **`TuningList`** (`composition` module) — built from the loaded `Composition` via
+  `TuningList.fromComposition(composition)` (`MicrotonalistApp.scala:85`); its `tunings` feed `TuningSession`.
+- **`TuningListFrame`** (`ui` module) — the Swing window, constructed with the `TunerModule.tuningService`
+  (`MicrotonalistApp.scala:96`), registered on the bus, and shown.
+
+> Note: the "module" classes (`FormatModule`, `TunerModule`) are hand-rolled `lazy val` service containers, not a DI
+> framework. Wiring is explicit and ordered in `run`. See "Future / planned changes".
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+`app` sits at the very top of the layer graph: nothing depends on it, and it depends — directly or transitively — on
+every other application module. From `build.sbt:52`:
+
+```scala
+lazy val app = (project in file("app"))
+  .dependsOn(
+    appConfig,            // config/  — HOCON application config
+    businessync,          // event bus + threading
+    common,               // shared utilities (e.g. parseUrlOrPath, PlatformUtils)
+    commonTestUtils % Test,
+    composition,          // domain model: Composition, TuningList
+    intonation,           // interval math (also reached transitively via composition)
+    format,               // JSON/file I/O repos and formats
+    scMidi,               // Scala-idiomatic MIDI API (also reached via tuner)
+    tuner,                // MIDI tuning runtime
+    ui,                   // Swing GUI
+  )
+  .enablePlugins(BuildInfoPlugin)
+```
+
+Library dependencies declared directly on `app` (`build.sbt:73`): `coreMidi4j`, `guava` (Guava `EventBus`), and
+`playJson`. The module also enables `BuildInfoPlugin` and `assembly` — `app` is the assembly target whose fat JAR's
+main class is `org.calinburloiu.music.microtonalist.MicrotonalistApp` (`build.sbt:70`).
+
+Because it is a thin wiring layer, `app`'s coverage floor is intentionally 0 (`build.sbt:79`, tracked by issue #180).
+
+The relationship between the SBT project id and the directory is worth flagging: the project is `app` in `file("app")`,
+but the **config** module's SBT project id is `appConfig` while its directory is `config/` (`build.sbt:82`). So
+`app.dependsOn(appConfig)` pulls in `config/`. Throughout the codebase, the package is
+`org.calinburloiu.music.microtonalist.config`.
+
+Transitive layering (each arrow is a `dependsOn`):
+
+```
+app → ui → tuner → sc-midi → businessync
+app → composition → { intonation, tuner }
+app → format → { common, composition, tuner }
+app → appConfig → common
+app → tuner → { businessync, common, sc-midi }
+```
+
+## Application entry point
+
+The end-to-end startup sequence, verified against `MicrotonalistApp.scala`:
+
+1. **Parse CLI args** — `main` (`:51`) logs the welcome banner with `BuildInfo.version`, then matches on `args`:
+   - `Array(url)` → `run(parseUrlArg(url))`;
+   - `Array(url, configFile)` → `run(parseUrlArg(url), Some(parsePathArg(configFile)))`;
+   - anything else → `AppUsageException` (usage: `microtonalist <input-composition-url> [config-file]`).
+   The composition argument may be a URL or a local path (resolved by `common.parseUrlOrPath`).
+
+2. **Resolve config path & load config** — in `run` (`:76`): the config path is the provided one or
+   `MainConfigManager.defaultConfigFile` (`~/.microtonalist/microtonalist.conf` on macOS). `MainConfigManager(configPath)`
+   parses and resolves the HOCON file, exposing `coreConfig` (including `libraryBaseUrl`).
+
+3. **Create the event/threading layer** — a Guava `EventBus` and a `Businessync` wrapping it are created (`:78`–`:79`).
+   This is the backbone for cross-thread communication used by the tuner runtime and the GUI.
+
+4. **Build `FormatModule` and load the composition** — `new FormatModule(businessync, coreConfig.libraryBaseUrl)`
+   (`:82`); then `formatModule.defaultCompositionRepo.read(inputUrl)` loads the `.mtlist` `Composition` (`:84`), and
+   `TuningList.fromComposition(composition)` (`:85`) resolves it into the ordered list of `Tuning`s (applying the
+   composition's `TuningMapper`s, `TuningReducer`, and fill).
+
+5. **Build `TunerModule` and load tracks** — `new TunerModule(businessync, formatModule.defaultTrackRepo)` (`:87`).
+   If the composition declares a tracks URL (`composition.tracksUrl`), the tracks file is opened **synchronously** via
+   `Await.result(trackService.open(uri), 10 seconds)` (`:91`). Then the resolved tunings are pushed into the session:
+   `tunerModule.tuningSession.tunings = tuningList.tunings` (`:93`). (Opening tracks here is temporary — see the
+   `// TODO #87` note in the source; it is to move into a composition-opening workflow.)
+
+6. **Open the GUI** — `new TuningListFrame(tunerModule.tuningService)` (`:96`) is constructed, registered on the
+   `Businessync` bus (`:97`), and made visible (`:98`). The frame observes tuning-index changes through the bus and
+   lets the user switch the active tuning.
+
+7. **Register the shutdown hook** — a JVM shutdown hook (`:100`) logs, calls `tunerModule.close()` (closing the
+   `TrackManager` and `MidiManager`), sleeps ~1s to let teardown settle, and logs goodbye.
+
+### Error handling and exit codes
+
+`main` runs the whole flow inside `Try { … }.recover { … }` (`:51`, `:61`). Recognized `AppException`s call their own
+`exitWithMessage()` (exit codes 1/2/3). Any other exception is logged as "Unexpected error" and the process exits with
+code 1000 (`:64`). This keeps all process-termination logic in one place at the top of the stack.
+
+### Configuration: the `config`/`appConfig` relationship
+
+- The HOCON config file location defaults to `~/.microtonalist/microtonalist.conf` (macOS only today;
+  `ConfigManagement.scala:114` throws on other platforms — relevant to cross-platform work, issue #149).
+- `MainConfigManager` loads/saves the raw HOCON and dispenses typed sub-configs via `SubConfigManager` subclasses
+  (e.g. `CoreConfigManager`), each owning a config root path (`core` for `CoreConfig`).
+- `CoreConfig.libraryBaseUrl` (default `~/Music/microtonalist/lib/`) is the scale/track library root that
+  `FormatModule` uses to resolve library-relative URIs; `MetaConfig` controls auto-save cadence and save-on-exit.
+- All of the above live in the **`appConfig`** SBT project (directory `config/`, package `…microtonalist.config`),
+  which `app` depends on directly. The `appConfig` module depends only on `common`.
+
+## Future / planned changes
+
+- **Module wiring (issue #100, "Refactor modules wiring").** The current `run` method wires everything by hand with
+  explicit construction order and `lazy val` "module" containers. This is planned to move toward proper module
+  classes/traits and possibly a dependency-injection mechanism. Treat the manual wiring documented here as the
+  current state, not a long-term contract.
+- **GUI migration (issue #99, Swing → JavaFX).** `app` currently opens the Swing `TuningListFrame`. When the GUI
+  migrates to JavaFX, the entry-point's GUI-construction step (`:96`–`:98`) will change accordingly. The GUI internals
+  themselves are documented in the `ui` module doc, not here.
+- **Track opening (issue #87).** Opening tracks inside `run` is a temporary placement and is expected to move into a
+  dedicated composition-opening workflow.

--- a/docs/architecture/app/README.md
+++ b/docs/architecture/app/README.md
@@ -3,80 +3,40 @@
 ## Responsibility
 
 `app` is the top-level executable module — the only one with a `main` entry point intended for end users (`cli` and
-`experiments` are separate, smaller executables). Its single job is **composition-root wiring** and **application
-lifecycle**:
-
-- parse command-line arguments;
-- construct and connect the lower-level modules (`appConfig`, `format`, `tuner`, `ui`) and the cross-cutting
-  `businessync` event/threading layer;
-- load the user's composition, build the resolved `TuningList`, load tracks, and open the GUI;
-- own the process lifecycle: top-level error handling, exit codes, and a JVM shutdown hook for clean teardown.
-
-`app` contains almost no domain logic of its own — it is deliberately thin glue, a single Scala source file
-(`MicrotonalistApp.scala`). The real work lives in the modules it depends on.
+`experiments` are separate, smaller executables). It is deliberately thin glue with almost no domain logic of its own:
+its job is **composition-root wiring** (constructing and connecting the lower-level modules) and **application
+lifecycle** (CLI parsing, top-level error handling, exit codes, and clean teardown). The real work lives in the modules
+it depends on.
 
 ## Key types
 
-**`MicrotonalistApp`** is the `object` holding `main` and the wiring logic. `main` wraps everything in a `Try`,
-dispatches on the argument count, and recovers by mapping exceptions to process exits. The method to read first is
-`run`, the composition root that builds every module and starts the application. Its sealed `AppException` hierarchy
-carries the process exit codes: `AppUsageException` (1, wrong arguments or unparseable URL/path),
-`NoDeviceAvailableException` (2), `AppConfigException` (3); any other exception is logged and exits with 1000.
+**`MicrotonalistApp`** is the `object` holding `main` and the wiring logic, currently a single Scala source file. `main`
+parses the arguments and wraps the whole run in a `Try` that maps exceptions to process exits; `run` is the composition
+root that builds every module and starts the application — read it first. The sealed `AppException` hierarchy carries
+the exit codes: `AppUsageException` (1), `NoDeviceAvailableException` (2), `AppConfigException` (3); any other exception
+is logged and exits with 1000.
 
-**`BuildInfo`** is generated at compile time by the `sbt-buildinfo` plugin and exposes `name`/`version`/`scalaVersion`/
-`sbtVersion`; `MicrotonalistApp` uses `BuildInfo.version` in the startup banner.
+**`BuildInfo`** is generated at compile time by the `sbt-buildinfo` plugin; `MicrotonalistApp` uses `BuildInfo.version`
+in the startup banner.
 
-**Module wiring objects.** `app` does not define these — it instantiates them, treating each as the seam through which a
-lower module exposes its public surface as a small manually-wired container. Each is documented in its own module's
-architecture doc:
+## Wiring
 
-- **`MainConfigManager`** / **`CoreConfig`** (`appConfig`) — load the HOCON config and expose
-  `coreConfig.libraryBaseUrl`.
-- **`FormatModule`** (`format`) — the repos/formats container; `app` uses `defaultCompositionRepo` to read the `.mtlist`
-  composition and `defaultTrackRepo` (passed into `TunerModule`).
-- **`TunerModule`** (`tuner`) — the MIDI/tuning runtime; `app` sets `tuningSession.tunings`, opens tracks via
-  `trackService`, hands `tuningService` to the GUI, and calls `close()` from the shutdown hook.
-- **`Businessync`** (`businessync`) — created once in `run` and threaded through every module that publishes events or
-  runs work on the business thread.
-- **`TuningList`** (`composition`) — built from the loaded `Composition` via `TuningList.fromComposition`; feeds
-  `TuningSession`.
-- **`TuningListFrame`** (`ui`) — the Swing window, constructed with `tuningService`, registered on the bus, and shown.
+`run` is the composition root. It builds the cross-cutting `Businessync` event/threading layer once and threads it
+through every module, then wires the modules in dependency order: load the HOCON config, load the user's `.mtlist`
+composition and resolve it into a `TuningList`, start the tuner runtime and open its tracks, and finally open the Swing
+GUI. A JVM shutdown hook closes the tuner runtime for clean teardown.
 
-> Note: `FormatModule` and `TunerModule` are hand-rolled `lazy val` service containers, not a DI framework. Wiring is
-> explicit and ordered in `run` — see [Future / planned changes](#future--planned-changes).
-
-## Application entry point
-
-The end-to-end startup sequence in `run`:
-
-1. **Parse CLI args.** `main` logs the welcome banner, then matches `args`: `<url>` or `<url> <config-file>` call `run`,
-   anything else raises `AppUsageException`. The composition argument may be a URL or a local path (resolved by
-   `common.parseUrlOrPath`).
-2. **Resolve config & load it.** The config path is the provided one or `MainConfigManager.defaultConfigFile`;
-   `MainConfigManager` parses and resolves the HOCON file, exposing `coreConfig` (including `libraryBaseUrl`).
-3. **Create the event/threading layer** — a Guava `EventBus` and the `Businessync` wrapping it, the backbone for
-   cross-thread communication used by the tuner runtime and the GUI.
-4. **Build `FormatModule` and load the composition** — `defaultCompositionRepo.read(inputUrl)` loads the `.mtlist`
-   `Composition`, and `TuningList.fromComposition` resolves it into the ordered list of `Tuning`s.
-5. **Build `TunerModule` and load tracks** — if the composition declares a tracks URL, the tracks file is opened
-   **synchronously** (an `Await.result` over `trackService.open`); then the resolved tunings are pushed into the
-   session. (Opening tracks here is temporary — see `// TODO #87`.)
-6. **Open the GUI** — `TuningListFrame(tuningService)` is constructed, registered on the bus, and made visible. It
-   observes tuning-index changes through the bus and lets the user switch the active tuning.
-7. **Register the shutdown hook** — a JVM shutdown hook calls `tunerModule.close()` (closing the `TrackManager` and
-   `MidiManager`) and lets teardown settle.
-
-All process-termination logic lives in one place: `main` runs the whole flow inside `Try { … }.recover { … }`, where
-recognized `AppException`s call their own `exitWithMessage()` and anything else exits with 1000.
+Each lower module exposes its public surface through a small wiring seam that `app` instantiates rather than reaching
+into the module's internals; the details of each seam belong to that module's own architecture doc. Today these seams
+are hand-rolled `lazy val` service containers (e.g. `FormatModule`, `TunerModule`), not a DI framework — the plan is to
+give every module a dedicated `*Module` class (issue #100). Treat the current manual wiring as the present state, not a
+long-term contract.
 
 ## Dependencies
 
-`app` sits at the very top of the layer graph: nothing depends on it, and it depends — directly or transitively — on
-every other application module. Its direct `dependsOn` set is `appConfig`, `businessync`, `common`, `composition`,
-`intonation`, `format`, `scMidi`, `tuner`, and `ui`; it declares the `coreMidi4j`, `guava`, and `playJson` libraries and
-enables `BuildInfoPlugin`. `app` is the assembly target whose fat JAR main class is `MicrotonalistApp`.
-
-Because it is thin wiring, `app`'s coverage floor is intentionally 0 (tracked by issue #180).
+`app` sits at the top of the layer graph: nothing depends on it, and it depends — directly or transitively — on every
+other application module. It is the assembly target whose fat JAR main class is `MicrotonalistApp`. Because it is thin
+wiring, its coverage floor is intentionally 0 (issue #180).
 
 One naming subtlety: the **config** module's SBT project id is `appConfig` while its directory is `config/`, so
 `app.dependsOn(appConfig)` pulls in `config/` (package `org.calinburloiu.music.microtonalist.config`). The transitive
@@ -91,9 +51,8 @@ app → appConfig → common
 
 ## Future / planned changes
 
-- **Module wiring (issue #100).** The hand-wired `run` with `lazy val` containers is planned to move toward proper
-  module classes/traits and possibly dependency injection. Treat the manual wiring documented here as the current state,
-  not a long-term contract.
+- **Module wiring (issue #100).** The hand-wired `run` with `lazy val` containers is planned to move toward dedicated
+  `*Module` classes/traits and possibly dependency injection.
 - **GUI migration (issue #99, Swing → JavaFX).** The GUI-construction step will change when the GUI migrates; the GUI
   internals are documented in the `ui` module doc.
 - **Track opening (issue #87).** Opening tracks inside `run` is a temporary placement and is expected to move into a

--- a/docs/architecture/app/README.md
+++ b/docs/architecture/app/README.md
@@ -2,189 +2,99 @@
 
 ## Responsibility
 
-`app` is the top-level executable module. It is the only module with a `main` entry point intended for end users
-(the `cli` and `experiments` modules are separate, smaller executables). Its single job is **composition root**
-wiring and **application lifecycle**:
+`app` is the top-level executable module — the only one with a `main` entry point intended for end users (`cli` and
+`experiments` are separate, smaller executables). Its single job is **composition-root wiring** and **application
+lifecycle**:
 
 - parse command-line arguments;
-- construct and connect the lower-level modules (`config`/`appConfig`, `format`, `tuner`, `ui`) and the cross-cutting
+- construct and connect the lower-level modules (`appConfig`, `format`, `tuner`, `ui`) and the cross-cutting
   `businessync` event/threading layer;
 - load the user's composition, build the resolved `TuningList`, load tracks, and open the GUI;
 - own the process lifecycle: top-level error handling, exit codes, and a JVM shutdown hook for clean teardown.
 
-`app` contains almost no domain logic of its own — it is deliberately thin glue. The actual work lives in the modules
-it depends on. There is exactly one Scala source file in the module:
-`app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala`.
+`app` contains almost no domain logic of its own — it is deliberately thin glue, a single Scala source file
+(`MicrotonalistApp.scala`). The real work lives in the modules it depends on.
 
 ## Key types
 
-### `MicrotonalistApp`
+**`MicrotonalistApp`** is the `object` holding `main` and the wiring logic. `main` wraps everything in a `Try`,
+dispatches on the argument count, and recovers by mapping exceptions to process exits. The method to read first is
+`run`, the composition root that builds every module and starts the application. Its sealed `AppException` hierarchy
+carries the process exit codes: `AppUsageException` (1, wrong arguments or unparseable URL/path),
+`NoDeviceAvailableException` (2), `AppConfigException` (3); any other exception is logged and exits with 1000.
 
-`app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala:35`
+**`BuildInfo`** is generated at compile time by the `sbt-buildinfo` plugin and exposes `name`/`version`/`scalaVersion`/
+`sbtVersion`; `MicrotonalistApp` uses `BuildInfo.version` in the startup banner.
 
-The `object` that holds `main` and the wiring logic. Notable members:
+**Module wiring objects.** `app` does not define these — it instantiates them, treating each as the seam through which a
+lower module exposes its public surface as a small manually-wired container. Each is documented in its own module's
+architecture doc:
 
-- `main(args)` — `MicrotonalistApp.scala:51`. Wraps everything in a `Try`, dispatches on the argument count, and
-  recovers by mapping exceptions to process exits (see error handling below).
-- `run(inputUrl, maybeConfigPath)` — `MicrotonalistApp.scala:76`. The composition root: builds every module and starts
-  the application. This is the method to read first to understand the wiring.
-- `parseUrlArg` / `parsePathArg` — `MicrotonalistApp.scala:68`, `:72`. Parse the composition URI (via
-  `common.parseUrlOrPath`) and the optional config-file path; both throw `AppUsageException` on malformed input.
-- `AppException` (sealed) and its cases — `MicrotonalistApp.scala:37`. Each carries a `statusCode` and an
-  `exitWithMessage()` that prints to `stderr` and calls `System.exit`:
-  - `AppUsageException` (exit 1) — wrong argument count or unparseable URL/path.
-  - `NoDeviceAvailableException` (exit 2) — declared for the case where no configured MIDI device is available.
-  - `AppConfigException(message)` (exit 3) — configuration problem.
-  - Any other `Exception` is logged and the process exits with code 1000 (`MicrotonalistApp.scala:64`).
+- **`MainConfigManager`** / **`CoreConfig`** (`appConfig`) — load the HOCON config and expose
+  `coreConfig.libraryBaseUrl`.
+- **`FormatModule`** (`format`) — the repos/formats container; `app` uses `defaultCompositionRepo` to read the `.mtlist`
+  composition and `defaultTrackRepo` (passed into `TunerModule`).
+- **`TunerModule`** (`tuner`) — the MIDI/tuning runtime; `app` sets `tuningSession.tunings`, opens tracks via
+  `trackService`, hands `tuningService` to the GUI, and calls `close()` from the shutdown hook.
+- **`Businessync`** (`businessync`) — created once in `run` and threaded through every module that publishes events or
+  runs work on the business thread.
+- **`TuningList`** (`composition`) — built from the loaded `Composition` via `TuningList.fromComposition`; feeds
+  `TuningSession`.
+- **`TuningListFrame`** (`ui`) — the Swing window, constructed with `tuningService`, registered on the bus, and shown.
 
-### `BuildInfo`
+> Note: `FormatModule` and `TunerModule` are hand-rolled `lazy val` service containers, not a DI framework. Wiring is
+> explicit and ordered in `run` — see [Future / planned changes](#future--planned-changes).
 
-`org.calinburloiu.music.microtonalist.BuildInfo` is generated at compile time by the `sbt-buildinfo` plugin
-(`enablePlugins(BuildInfoPlugin)` in `build.sbt:65`, with `buildInfoPackage` set on `build.sbt:72`). It exposes
-`name`, `version`, `scalaVersion`, and `sbtVersion`; `MicrotonalistApp` uses `BuildInfo.version` in the startup banner
-(`MicrotonalistApp.scala:52`). It is the only generated type in the module.
+## Application entry point
 
-### Module wiring objects (constructed by `run`, owned by the depended-on modules)
+The end-to-end startup sequence in `run`:
 
-`app` does not define these classes; it instantiates them. They are the seams through which each lower module exposes
-its public surface as a small manually-wired container.
+1. **Parse CLI args.** `main` logs the welcome banner, then matches `args`: `<url>` or `<url> <config-file>` call `run`,
+   anything else raises `AppUsageException`. The composition argument may be a URL or a local path (resolved by
+   `common.parseUrlOrPath`).
+2. **Resolve config & load it.** The config path is the provided one or `MainConfigManager.defaultConfigFile`;
+   `MainConfigManager` parses and resolves the HOCON file, exposing `coreConfig` (including `libraryBaseUrl`).
+3. **Create the event/threading layer** — a Guava `EventBus` and the `Businessync` wrapping it, the backbone for
+   cross-thread communication used by the tuner runtime and the GUI.
+4. **Build `FormatModule` and load the composition** — `defaultCompositionRepo.read(inputUrl)` loads the `.mtlist`
+   `Composition`, and `TuningList.fromComposition` resolves it into the ordered list of `Tuning`s.
+5. **Build `TunerModule` and load tracks** — if the composition declares a tracks URL, the tracks file is opened
+   **synchronously** (an `Await.result` over `trackService.open`); then the resolved tunings are pushed into the
+   session. (Opening tracks here is temporary — see `// TODO #87`.)
+6. **Open the GUI** — `TuningListFrame(tuningService)` is constructed, registered on the bus, and made visible. It
+   observes tuning-index changes through the bus and lets the user switch the active tuning.
+7. **Register the shutdown hook** — a JVM shutdown hook calls `tunerModule.close()` (closing the `TrackManager` and
+   `MidiManager`) and lets teardown settle.
 
-- **`MainConfigManager`** (`config` module) —
-  `config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigManagement.scala:30`. Loads and manages the
-  HOCON application config. `MainConfigManager(configPath)` parses the file (`ConfigFactory.parseFile(...).resolve()`),
-  exposes typed sub-configs through `SubConfigManager`/`CoreConfigManager`, periodically auto-saves dirty config, and
-  saves on close. `MainConfigManager.defaultConfigFile` (`ConfigManagement.scala:114`) returns
-  `~/.microtonalist/microtonalist.conf` on macOS.
-- **`CoreConfig`** (`config` module) —
-  `config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala:27`. The typed core config:
-  `libraryBaseUrl` (the scale/track library root, defaulting to `~/Music/microtonalist/lib/` on macOS) and a nested
-  `MetaConfig` (`saveIntervalMillis`, `saveOnExit`). `app` reads `mainConfigManager.coreConfig.libraryBaseUrl` to wire
-  the `FormatModule`.
-- **`FormatModule`** (`format` module) —
-  `format/src/main/scala/org/calinburloiu/music/microtonalist/format/FormatModule.scala:26`. A lazy container that
-  builds all file/HTTP/library repos and their JSON formats. `app` uses `defaultCompositionRepo` (to read the
-  `.mtlist` composition) and `defaultTrackRepo` (passed into `TunerModule`). Constructor takes the `Businessync` and
-  the `libraryBaseUrl` from config.
-- **`TunerModule`** (`tuner` module) —
-  `tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/TunerModule.scala:22`. A lazy container, also
-  `AutoCloseable`, that builds the MIDI/tuning runtime: `tuningSession`, `tuningService`, `trackService`,
-  `MidiManager`, and `TrackManager` (registered on the `Businessync` bus). `app` sets `tuningSession.tunings`, opens
-  tracks via `trackService`, hands `tuningService` to the GUI, and calls `close()` from the shutdown hook.
-- **`Businessync`** (`businessync` module) — the event bus + threading layer (business thread / UI thread). Created
-  once in `run` (`MicrotonalistApp.scala:79`) over a Guava `EventBus` and threaded through every module that needs to
-  publish events or run work on the business thread. The GUI frame and `TrackManager` register themselves on it.
-- **`TuningList`** (`composition` module) — built from the loaded `Composition` via
-  `TuningList.fromComposition(composition)` (`MicrotonalistApp.scala:85`); its `tunings` feed `TuningSession`.
-- **`TuningListFrame`** (`ui` module) — the Swing window, constructed with the `TunerModule.tuningService`
-  (`MicrotonalistApp.scala:96`), registered on the bus, and shown.
-
-> Note: the "module" classes (`FormatModule`, `TunerModule`) are hand-rolled `lazy val` service containers, not a DI
-> framework. Wiring is explicit and ordered in `run`. See "Future / planned changes".
+All process-termination logic lives in one place: `main` runs the whole flow inside `Try { … }.recover { … }`, where
+recognized `AppException`s call their own `exitWithMessage()` and anything else exits with 1000.
 
 ## Dependencies
 
 `app` sits at the very top of the layer graph: nothing depends on it, and it depends — directly or transitively — on
-every other application module. From `build.sbt:52`:
+every other application module. Its direct `dependsOn` set is `appConfig`, `businessync`, `common`, `composition`,
+`intonation`, `format`, `scMidi`, `tuner`, and `ui`; it declares the `coreMidi4j`, `guava`, and `playJson` libraries and
+enables `BuildInfoPlugin`. `app` is the assembly target whose fat JAR main class is `MicrotonalistApp`.
 
-```scala
-lazy val app = (project in file("app"))
-  .dependsOn(
-    appConfig,            // config/  — HOCON application config
-    businessync,          // event bus + threading
-    common,               // shared utilities (e.g. parseUrlOrPath, PlatformUtils)
-    commonTestUtils % Test,
-    composition,          // domain model: Composition, TuningList
-    intonation,           // interval math (also reached transitively via composition)
-    format,               // JSON/file I/O repos and formats
-    scMidi,               // Scala-idiomatic MIDI API (also reached via tuner)
-    tuner,                // MIDI tuning runtime
-    ui,                   // Swing GUI
-  )
-  .enablePlugins(BuildInfoPlugin)
-```
+Because it is thin wiring, `app`'s coverage floor is intentionally 0 (tracked by issue #180).
 
-Library dependencies declared directly on `app` (`build.sbt:73`): `coreMidi4j`, `guava` (Guava `EventBus`), and
-`playJson`. The module also enables `BuildInfoPlugin` and `assembly` — `app` is the assembly target whose fat JAR's
-main class is `org.calinburloiu.music.microtonalist.MicrotonalistApp` (`build.sbt:70`).
-
-Because it is a thin wiring layer, `app`'s coverage floor is intentionally 0 (`build.sbt:79`, tracked by issue #180).
-
-The relationship between the SBT project id and the directory is worth flagging: the project is `app` in `file("app")`,
-but the **config** module's SBT project id is `appConfig` while its directory is `config/` (`build.sbt:82`). So
-`app.dependsOn(appConfig)` pulls in `config/`. Throughout the codebase, the package is
-`org.calinburloiu.music.microtonalist.config`.
-
-Transitive layering (each arrow is a `dependsOn`):
+One naming subtlety: the **config** module's SBT project id is `appConfig` while its directory is `config/`, so
+`app.dependsOn(appConfig)` pulls in `config/` (package `org.calinburloiu.music.microtonalist.config`). The transitive
+layering is:
 
 ```
 app → ui → tuner → sc-midi → businessync
 app → composition → { intonation, tuner }
 app → format → { common, composition, tuner }
 app → appConfig → common
-app → tuner → { businessync, common, sc-midi }
 ```
-
-## Application entry point
-
-The end-to-end startup sequence, verified against `MicrotonalistApp.scala`:
-
-1. **Parse CLI args** — `main` (`:51`) logs the welcome banner with `BuildInfo.version`, then matches on `args`:
-   - `Array(url)` → `run(parseUrlArg(url))`;
-   - `Array(url, configFile)` → `run(parseUrlArg(url), Some(parsePathArg(configFile)))`;
-   - anything else → `AppUsageException` (usage: `microtonalist <input-composition-url> [config-file]`).
-   The composition argument may be a URL or a local path (resolved by `common.parseUrlOrPath`).
-
-2. **Resolve config path & load config** — in `run` (`:76`): the config path is the provided one or
-   `MainConfigManager.defaultConfigFile` (`~/.microtonalist/microtonalist.conf` on macOS).
-   `MainConfigManager(configPath)` parses and resolves the HOCON file, exposing `coreConfig` (including
-   `libraryBaseUrl`).
-
-3. **Create the event/threading layer** — a Guava `EventBus` and a `Businessync` wrapping it are created (`:78`–`:79`).
-   This is the backbone for cross-thread communication used by the tuner runtime and the GUI.
-
-4. **Build `FormatModule` and load the composition** — `new FormatModule(businessync, coreConfig.libraryBaseUrl)`
-   (`:82`); then `formatModule.defaultCompositionRepo.read(inputUrl)` loads the `.mtlist` `Composition` (`:84`), and
-   `TuningList.fromComposition(composition)` (`:85`) resolves it into the ordered list of `Tuning`s (applying the
-   composition's `TuningMapper`s, `TuningReducer`, and fill).
-
-5. **Build `TunerModule` and load tracks** — `new TunerModule(businessync, formatModule.defaultTrackRepo)` (`:87`).
-   If the composition declares a tracks URL (`composition.tracksUrl`), the tracks file is opened **synchronously** via
-   `Await.result(trackService.open(uri), 10 seconds)` (`:91`). Then the resolved tunings are pushed into the session:
-   `tunerModule.tuningSession.tunings = tuningList.tunings` (`:93`). (Opening tracks here is temporary — see the
-   `// TODO #87` note in the source; it is to move into a composition-opening workflow.)
-
-6. **Open the GUI** — `new TuningListFrame(tunerModule.tuningService)` (`:96`) is constructed, registered on the
-   `Businessync` bus (`:97`), and made visible (`:98`). The frame observes tuning-index changes through the bus and
-   lets the user switch the active tuning.
-
-7. **Register the shutdown hook** — a JVM shutdown hook (`:100`) logs, calls `tunerModule.close()` (closing the
-   `TrackManager` and `MidiManager`), sleeps ~1s to let teardown settle, and logs goodbye.
-
-### Error handling and exit codes
-
-`main` runs the whole flow inside `Try { … }.recover { … }` (`:51`, `:61`). Recognized `AppException`s call their own
-`exitWithMessage()` (exit codes 1/2/3). Any other exception is logged as "Unexpected error" and the process exits with
-code 1000 (`:64`). This keeps all process-termination logic in one place at the top of the stack.
-
-### Configuration: the `config`/`appConfig` relationship
-
-- The HOCON config file location defaults to `~/.microtonalist/microtonalist.conf` (macOS only today;
-  `ConfigManagement.scala:114` throws on other platforms — relevant to cross-platform work, issue #149).
-- `MainConfigManager` loads/saves the raw HOCON and dispenses typed sub-configs via `SubConfigManager` subclasses
-  (e.g. `CoreConfigManager`), each owning a config root path (`core` for `CoreConfig`).
-- `CoreConfig.libraryBaseUrl` (default `~/Music/microtonalist/lib/`) is the scale/track library root that
-  `FormatModule` uses to resolve library-relative URIs; `MetaConfig` controls auto-save cadence and save-on-exit.
-- All of the above live in the **`appConfig`** SBT project (directory `config/`, package `…microtonalist.config`),
-  which `app` depends on directly. The `appConfig` module depends only on `common`.
 
 ## Future / planned changes
 
-- **Module wiring (issue #100, "Refactor modules wiring").** The current `run` method wires everything by hand with
-  explicit construction order and `lazy val` "module" containers. This is planned to move toward proper module
-  classes/traits and possibly a dependency-injection mechanism. Treat the manual wiring documented here as the
-  current state, not a long-term contract.
-- **GUI migration (issue #99, Swing → JavaFX).** `app` currently opens the Swing `TuningListFrame`. When the GUI
-  migrates to JavaFX, the entry-point's GUI-construction step (`:96`–`:98`) will change accordingly. The GUI internals
-  themselves are documented in the `ui` module doc, not here.
+- **Module wiring (issue #100).** The hand-wired `run` with `lazy val` containers is planned to move toward proper
+  module classes/traits and possibly dependency injection. Treat the manual wiring documented here as the current state,
+  not a long-term contract.
+- **GUI migration (issue #99, Swing → JavaFX).** The GUI-construction step will change when the GUI migrates; the GUI
+  internals are documented in the `ui` module doc.
 - **Track opening (issue #87).** Opening tracks inside `run` is a temporary placement and is expected to move into a
   dedicated composition-opening workflow.

--- a/docs/architecture/app/README.md
+++ b/docs/architecture/app/README.md
@@ -135,8 +135,9 @@ The end-to-end startup sequence, verified against `MicrotonalistApp.scala`:
    The composition argument may be a URL or a local path (resolved by `common.parseUrlOrPath`).
 
 2. **Resolve config path & load config** — in `run` (`:76`): the config path is the provided one or
-   `MainConfigManager.defaultConfigFile` (`~/.microtonalist/microtonalist.conf` on macOS). `MainConfigManager(configPath)`
-   parses and resolves the HOCON file, exposing `coreConfig` (including `libraryBaseUrl`).
+   `MainConfigManager.defaultConfigFile` (`~/.microtonalist/microtonalist.conf` on macOS).
+   `MainConfigManager(configPath)` parses and resolves the HOCON file, exposing `coreConfig` (including
+   `libraryBaseUrl`).
 
 3. **Create the event/threading layer** — a Guava `EventBus` and a `Businessync` wrapping it are created (`:78`–`:79`).
    This is the backbone for cross-thread communication used by the tuner runtime and the GUI.

--- a/docs/architecture/app/README.md
+++ b/docs/architecture/app/README.md
@@ -35,8 +35,7 @@ long-term contract.
 ## Dependencies
 
 `app` sits at the top of the layer graph: nothing depends on it, and it depends — directly or transitively — on every
-other application module. It is the assembly target whose fat JAR main class is `MicrotonalistApp`. Because it is thin
-wiring, its coverage floor is intentionally 0 (issue #180).
+other application module. It is the assembly target whose fat JAR main class is `MicrotonalistApp`.
 
 One naming subtlety: the **config** module's SBT project id is `appConfig` while its directory is `config/`, so
 `app.dependsOn(appConfig)` pulls in `config/` (package `org.calinburloiu.music.microtonalist.config`). The transitive

--- a/docs/architecture/businessync/README.md
+++ b/docs/architecture/businessync/README.md
@@ -5,20 +5,22 @@
 `businessync` is Microtonalist's threading and event-bus infrastructure. It centralizes two concerns that otherwise leak
 into every domain and GUI component:
 
-- **Thread affinity** — running work on the right thread (a dedicated *Business Thread* for all domain/MIDI logic, the
-  *UI Thread* for all GUI updates) so domain and GUI state can be mutated without explicit locking.
+- **Thread affinity** — running work on the right thread (a dedicated *Business Thread* for all domain logic, the *UI
+  Thread* for all GUI updates) so domain and GUI state can be mutated without explicit locking, and *Track Threads*, one
+  for each track (not yet implemented).
 - **Decoupled communication** — a publish/subscribe event bus so producers (MIDI device changes, tuning changes) notify
-  consumers (the GUI) without direct references, delivering each event on the correct thread for its subscriber.
+  consumers (the GUI or other components) without direct references, delivering each event on the correct thread for its
+  subscriber.
 
 It is pure infrastructure: it has **no application dependencies** and knows nothing about scales, tunings, MIDI, or the
 GUI. Domain and UI modules depend on it, never the other way around.
 
 > **Implementation status (important).** The module is currently an early skeleton. `Businessync` is a thin wrapper
 > around a Guava [`EventBus`](https://github.com/google/guava/wiki/EventBusExplained); most of the threading API is
-> either stubbed (`???`) or runs work inline on the caller's thread. The richer two-thread, queue-based, sequentially
+> either stubbed (`???`) or runs work inline on the caller's thread. The richer multi-thread, queue-based, sequentially
 > consistent design described in issue [#90](https://github.com/calinburloiu/microtonalist/issues/90) is **planned, not
-> yet built**. Treat the two-thread API described under [Threading model](#threading-model) as the *target*, not current
-> behavior.
+> yet built**. Treat the multi-thread API described under [Threading model](#threading-model) as the *target*, not
+> current behavior.
 
 ## Key types
 
@@ -37,7 +39,7 @@ All types live in package `org.calinburloiu.businessync`.
 
 ### Current behavior
 
-The `Businessync` API is written against the *target* two-thread semantics but is mostly not backed by real dispatch
+The `Businessync` API is written against the *target* multi-thread semantics but is mostly not backed by real dispatch
 yet: `publish`/`register` delegate straight to the Guava `EventBus` (synchronous, on the caller's thread); `run`/`runIf`
 run their function inline; `call`/`callAsync` use the Scala global `ExecutionContext`; and the UI-thread methods
 (`runOnUi`, `callOnUi`, `handleOnUi`) plus the keyed `subscribe`/`subscribeOnUi` are stubs (`???` or no-ops). The
@@ -51,10 +53,10 @@ migration to `subscribe`/`subscribeOnUi`.
 
 ## Threading model
 
-This is the *intended* two-thread model (see also the project [Threading Model wiki
+This is the *intended* multi-thread model (see also the project [Threading Model wiki
 page](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model)); the current code does not yet enforce it.
 
-- **Business Thread** — owns all domain and MIDI logic. Domain state is mutated only here, so it needs no locks. Work is
+- **Business Thread** — owns all domain logic. Domain state is mutated only here, so it needs no locks. Work is
   submitted with `run` (fire-and-forget) or `call` (returns a `Future`); business-side handlers register with
   `subscribe` (today: `@Subscribe` + `register`).
 - **UI Thread** — owns all GUI updates. Work is submitted with `runOnUi`/`callOnUi` and UI-side handlers with

--- a/docs/architecture/businessync/README.md
+++ b/docs/architecture/businessync/README.md
@@ -1,17 +1,173 @@
 # `businessync` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `businessync` module (`businessync/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+`businessync` is Microtonalist's threading and event-bus infrastructure. It is meant to centralize two concerns that
+otherwise leak into every domain and GUI component:
+
+- **Thread affinity** — running work on the right thread (a dedicated *Business Thread* for all domain/MIDI logic, and
+  the *UI Thread* for all GUI updates) so that domain and GUI state can be mutated without explicit locking.
+- **Decoupled communication** — a publish/subscribe event bus so producers (e.g. MIDI device changes, tuning changes)
+  can notify consumers (e.g. the GUI) without direct references, and so events can be delivered on the correct thread
+  for the subscriber.
+
+It is pure infrastructure: it has **no application dependencies** and knows nothing about scales, tunings, MIDI, or the
+GUI. Domain and UI modules depend on it, never the other way around.
+
+> **Implementation status (important).** The module is currently an early skeleton. `Businessync` is a thin wrapper
+> around a Guava [`EventBus`](https://github.com/google/guava/wiki/EventBusExplained); most of the threading API is
+> either stubbed (`???`) or runs work inline on the caller's thread. The richer two-thread, queue-based, sequentially
+> consistent design described in issue
+> [#90](https://github.com/calinburloiu/microtonalist/issues/90) is **planned, not yet built**. The
+> [Threading model](#threading-model) and [Planned design](#planned-design-issue-90) sections below separate what the
+> code does *today* from what is intended. Treat the intended two-thread API documented below (separate Business/UI
+> threads, `runOnUi`, `callAsync`) as the *target*, not the current behavior.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+All types live in package `org.calinburloiu.businessync`.
+
+- **`Businessync`** — `businessync/src/main/scala/org/calinburloiu/businessync/Businessync.scala:27`
+  The single entry point. Constructed with a Guava `EventBus` (`Businessync(eventBus)`) and injected into the modules
+  that need cross-thread communication. Wraps event publish/subscribe and (eventually) thread-dispatch. See the
+  [API surface](#api-surface-current-code) below for the per-method status.
+
+- **`BusinessyncEvent`** — `businessync/src/main/scala/org/calinburloiu/businessync/BusinessyncEvent.scala:22`
+  Abstract base class for every event posted through the bus. Provides a single `name: String` member defaulting to the
+  runtime simple class name. All domain events extend it, typically as `case class`/`case object` hierarchies under a
+  sealed base (e.g. `MidiEvent`, `TuningEvent`, `TrackEvent`, `ScaleLossyConversionEvent`). Because Guava's `EventBus`
+  dispatches by the event's runtime type and walks its supertypes, **subscribing to a base class catches all of its
+  subclasses** — e.g. `TrackManager` subscribes to `TuningEvent` and receives every concrete `TuningEvent` subtype.
+
+- **`BusinessyncUiHandler`** — `businessync/src/main/scala/org/calinburloiu/businessync/Businessync.scala:24`
+  A small `case class` holding `run: () => Unit` and `isUiThread: () => Boolean`. This is the seam intended to make the
+  UI-thread submission *pluggable*: a GUI toolkit (Swing today, JavaFX planned) supplies the lambda that schedules work
+  onto its event thread and a predicate that reports whether the current thread is that UI thread. It is defined but not
+  yet wired into `Businessync` (no constructor parameter consumes it in the current code).
+
+### API surface (current code)
+
+The table reflects the actual bodies in `Businessync.scala`, not the target semantics.
+
+| Method | Signature | Current behavior |
+| ------ | --------- | ---------------- |
+| `publish` | `publish(event: BusinessyncEvent): Unit` | Delegates to `eventBus.post(event)`. Dispatch happens synchronously on the caller's thread. |
+| `handle` | `handle(event: BusinessyncEvent): Unit` | Currently an alias for `publish`. Intended: deliver to Business-thread subscribers only, throwing if not on the Business Thread. |
+| `handleOnUi` | `handleOnUi(event: BusinessyncEvent): Unit` | Stub (`???`). Intended: deliver to UI-thread subscribers only, throwing if not on the UI Thread. |
+| `subscribe` | `subscribe[E <: BusinessyncEvent](eventClass: Class[E], handler: E => Unit): Unit` | No-op (`{}`). Intended: register a Business-thread handler keyed by event class. |
+| `subscribeOnUi` | `subscribeOnUi[E <: BusinessyncEvent](eventClass: Class[E], handler: E => Unit): Unit` | No-op (`{}`). Intended: register a UI-thread handler keyed by event class. |
+| `register` | `register(obj: AnyRef): Unit` | Delegates to `eventBus.register(obj)`. The mechanism actually used today — see below. To be replaced by `subscribe`. |
+| `run` | `run(fn: () => Unit): Unit` | Runs `fn()` inline (no thread hop). Intended: schedule on the Business Thread. |
+| `runIf` | `runIf(condition: Boolean)(fn: () => Unit): Unit` | Runs `fn()` inline iff `condition`. |
+| `runOnUi` | `runOnUi(fn: () => Unit): Unit` | Stub (`???`). Intended: schedule on the UI Thread. |
+| `call` | `call[R](fn: () => R): Future[R]` | Runs `fn()` on the Scala global `ExecutionContext` via `Future { fn() }`. Intended: run on the Business Thread and return its result. |
+| `callAsync` | `callAsync[R](fn: () => Future[R]): Future[R]` | Invokes `fn()` and returns its `Future` directly (no thread hop). |
+| `callOnUi` | `callOnUi[R](fn: () => R): Future[R]` | Stub (`???`). Intended: run on the UI Thread and return its result. |
+
+Note a naming subtlety in the current API: `callAsync` takes a `() => Future[R]` (it flattens an already-async call),
+while `call` takes a `() => R`. Every method except the bus delegations and the inline `run`/`runIf`/`call`/`callAsync`
+is either a no-op or `???`.
+
+### Event delivery today (`@Subscribe` + `register`)
+
+Until `subscribe`/`subscribeOnUi` are implemented, subscription goes straight through Guava:
+
+1. A subscriber method is annotated with `com.google.common.eventbus.@Subscribe` and takes exactly one parameter whose
+   type is the event class (or a base class) it wants. Example:
+   `ui/.../TuningListFrame.scala:89` (`onTuningChanged(e: TuningIndexUpdatedEvent)`),
+   `tuner/.../TrackManager.scala:113` (`onTuningChanged(e: TuningEvent)` — base class, catches all subtypes).
+2. The owning object is handed to `businessync.register(obj)`, which forwards to `eventBus.register(obj)`
+   (e.g. `MicrotonalistApp.scala:97`, `TunerModule.scala:33`).
+3. Producers call `businessync.publish(event)`; Guava invokes the matching `@Subscribe` methods synchronously **on the
+   publishing thread** (there is no thread hop yet).
+
+The `@Subscribe`-based call sites carry `// TODO #90 Remove @Subscribe after implementing businessync` comments,
+marking them for migration to `subscribe`/`subscribeOnUi` once the real implementation lands.
+
+```scala
+// Producer (sc-midi)
+businessync.publish(MidiDeviceConnectedEvent(id))
+
+// Subscriber (ui) — registered via businessync.register(this)
+@Subscribe
+def onTuningChanged(event: TuningIndexUpdatedEvent): Unit = {
+  listComponent.setSelectedIndex(event.tuningIndex)
+}
+```
+
+## Threading model
+
+This section documents the *intended* two-thread model (see also the project
+[Threading Model wiki page](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model)) and flags where the
+current code does not yet enforce it.
+
+- **Business Thread** — owns all domain and MIDI logic. Domain state is mutated only here, so it needs no locks. Work is
+  meant to be submitted with `businessync.run { … }` (fire-and-forget) or `businessync.call { … }` (returns a
+  `Future`). Handlers for business-side events are registered with `subscribe` (today: `@Subscribe` + `register`).
+- **UI Thread** — owns all GUI updates. GUI components are touched only here. Work is meant to be submitted with
+  `businessync.runOnUi { … }` / `callOnUi`, and UI-side event handlers with `subscribeOnUi`. The actual UI thread is
+  the GUI toolkit's event thread (Swing EDT now; JavaFX Application Thread is the migration target — see TODOs `#99`
+  referencing the JavaFX move). The toolkit-specific submission is meant to be supplied via `BusinessyncUiHandler`.
+- **Cross-thread rule.** Never mutate domain state from the UI thread or GUI state from the Business Thread directly;
+  always hop via the appropriate `Businessync` method. Results computed on worker threads (Scala `Future`s — e.g. file
+  I/O) must be funneled back onto the Business Thread before touching domain state.
+
+Other threads in the wider system (documented on the wiki, not owned by this module): **Track threads** (one per
+`Track`, so each instrument's MIDI flows on a single thread), **MIDI threads** (managed by CoreMidi4J), and **worker
+threads** (the `Future` execution context).
+
+**Current reality vs. the model.** No dedicated Business or UI thread is started by this module yet. `run`/`runIf`
+execute inline on the caller; `call` runs on the global `ExecutionContext`; `publish` dispatches synchronously on the
+caller's thread; `runOnUi`/`callOnUi`/`handleOnUi` are unimplemented (`???`). In practice this means the threading
+*contracts* are expressed at call sites (e.g. `TuningService.changeTuning` wraps its body in `businessync.run`,
+`TrackService.open` uses `businessync.callAsync`) but are not yet *enforced* by `Businessync`. The call sites are
+written against the target API so that, once the real dispatcher exists, behavior tightens without touching callers.
+
+## Planned design (issue #90)
+
+Issue [#90 "Add businessync infrastructure"](https://github.com/calinburloiu/microtonalist/issues/90) (milestone
+*Architecture*) specifies the full design. Status below is verified against the current source.
+
+- **Async calls on both threads** — `run` (fire-and-forget, `Unit`) and `call` (`Future`-wrapped result), each in a
+  Business and a UI variant. *Partially present as method signatures; not backed by real thread dispatch.*
+- **Class-keyed pub/sub with base-class matching** — `subscribe`/`subscribeOnUi` keyed by event class, where
+  subscribing to a base class catches all subclasses. *Base-class matching already works via Guava `EventBus` +
+  `@Subscribe`; the `subscribe`/`subscribeOnUi` methods themselves are stubs.*
+- **Pluggable UI-thread submission** — a configurable lambda that runs work on the UI thread. *Type
+  (`BusinessyncUiHandler`) exists but is not yet consumed by `Businessync`.*
+- **Sequential consistency of UI updates** — *Not implemented.* The plan:
+  - The business thread drains a concurrent queue of updates; calls are modeled as special events on that queue.
+  - Each UI→business update increments a UI-side **version** (a global counter) attached to the queued update; the
+    business thread (the *consumer*) advances its own version as it dequeues, so `businessVersion <= uiVersion`.
+  - Events published by the business thread carry its current business version.
+  - A UI subscription may **opt in** to sequential consistency; if so, the UI rejects an incoming event whose attached
+    business version is strictly less than the UI's own version (i.e. a stale response).
+  - For updates handled **asynchronously** on the business thread (e.g. I/O), the business version may advance before
+    the async work finishes, which would break consistency. The developer must then **explicitly attach the originating
+    business version** when publishing the response event, or use a special max version that the UI always accepts.
+  - To force this discipline, publishing an event that has UI subscribers **from an unmanaged thread** (neither UI nor
+    business) is intended to throw from `publish`, requiring an explicit version.
+
+Because none of the version/queue/sequential-consistency machinery exists in the code yet, these behaviors are
+**planned and subject to change**; this document will be updated when the implementation lands. The numerous
+`// TODO #90` markers in `Businessync.scala` and at the `@Subscribe` call sites track that work.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+- **Application dependencies: none.** In `build.sbt`, the `businessync` project has no `.dependsOn(...)`. It is a leaf
+  in the application dependency graph, alongside `intonation` and `common`.
+- **Third-party dependency:** Guava (`com.google.common.eventbus.EventBus`), declared as `guava` in `build.sbt`, plus
+  the common logging stack inherited from `commonDependencies`.
+- **Modules that depend on `businessync`** (directly, per `build.sbt`):
+  - `scMidi` (`sc-midi`) — publishes `MidiEvent`s from `MidiManager` / `MidiDeviceHandle`.
+  - `tuner` — `TuningSession`/`TuningService`, `TrackSession`/`TrackService`, `TrackManager`, `TunerModule` publish and
+    subscribe to `TuningEvent`/`TrackEvent`.
+  - `app` — `MicrotonalistApp` constructs the `Businessync` instance and wires it into the modules below.
+  - `cli` — depends transitively via `scMidi`; `MicrotonalistToolApp` constructs a `Businessync` for `MidiManager`.
+  - `format` — receives a `Businessync` (via `FormatModule`) and publishes `ScaleLossyConversionEvent`; the dependency
+    is supplied transitively (e.g. through `tuner`/`composition`) rather than as a direct `dependsOn`.
+  - `ui` — `TuningListFrame` subscribes to `TuningIndexUpdatedEvent`; reached transitively via `tuner`.
+
+The instance is created once in the application entry point (`MicrotonalistApp.run`,
+`app/.../MicrotonalistApp.scala:79`) and injected into `FormatModule`, `TunerModule`, `MidiManager`, etc., so a single
+event bus/threading context is shared across the whole running app.

--- a/docs/architecture/businessync/README.md
+++ b/docs/architecture/businessync/README.md
@@ -2,14 +2,13 @@
 
 ## Responsibility
 
-`businessync` is Microtonalist's threading and event-bus infrastructure. It is meant to centralize two concerns that
-otherwise leak into every domain and GUI component:
+`businessync` is Microtonalist's threading and event-bus infrastructure. It centralizes two concerns that otherwise leak
+into every domain and GUI component:
 
-- **Thread affinity** — running work on the right thread (a dedicated *Business Thread* for all domain/MIDI logic, and
-  the *UI Thread* for all GUI updates) so that domain and GUI state can be mutated without explicit locking.
-- **Decoupled communication** — a publish/subscribe event bus so producers (e.g. MIDI device changes, tuning changes)
-  can notify consumers (e.g. the GUI) without direct references, and so events can be delivered on the correct thread
-  for the subscriber.
+- **Thread affinity** — running work on the right thread (a dedicated *Business Thread* for all domain/MIDI logic, the
+  *UI Thread* for all GUI updates) so domain and GUI state can be mutated without explicit locking.
+- **Decoupled communication** — a publish/subscribe event bus so producers (MIDI device changes, tuning changes) notify
+  consumers (the GUI) without direct references, delivering each event on the correct thread for its subscriber.
 
 It is pure infrastructure: it has **no application dependencies** and knows nothing about scales, tunings, MIDI, or the
 GUI. Domain and UI modules depend on it, never the other way around.
@@ -17,157 +16,84 @@ GUI. Domain and UI modules depend on it, never the other way around.
 > **Implementation status (important).** The module is currently an early skeleton. `Businessync` is a thin wrapper
 > around a Guava [`EventBus`](https://github.com/google/guava/wiki/EventBusExplained); most of the threading API is
 > either stubbed (`???`) or runs work inline on the caller's thread. The richer two-thread, queue-based, sequentially
-> consistent design described in issue
-> [#90](https://github.com/calinburloiu/microtonalist/issues/90) is **planned, not yet built**. The
-> [Threading model](#threading-model) and [Planned design](#planned-design-issue-90) sections below separate what the
-> code does *today* from what is intended. Treat the intended two-thread API documented below (separate Business/UI
-> threads, `runOnUi`, `callAsync`) as the *target*, not the current behavior.
+> consistent design described in issue [#90](https://github.com/calinburloiu/microtonalist/issues/90) is **planned, not
+> yet built**. Treat the two-thread API described under [Threading model](#threading-model) as the *target*, not current
+> behavior.
 
 ## Key types
 
 All types live in package `org.calinburloiu.businessync`.
 
-- **`Businessync`** — `businessync/src/main/scala/org/calinburloiu/businessync/Businessync.scala:27`
-  The single entry point. Constructed with a Guava `EventBus` (`Businessync(eventBus)`) and injected into the modules
-  that need cross-thread communication. Wraps event publish/subscribe and (eventually) thread-dispatch. See the
-  [API surface](#api-surface-current-code) below for the per-method status.
+- **`Businessync`** — the single entry point, constructed with a Guava `EventBus` and injected into the modules that
+  need cross-thread communication. It wraps event publish/subscribe and (eventually) thread dispatch.
+- **`BusinessyncEvent`** — the abstract base class for every event posted through the bus, providing a `name` defaulting
+  to the runtime simple class name. Domain events extend it as sealed `case class`/`case object` hierarchies (e.g.
+  `MidiEvent`, `TuningEvent`, `TrackEvent`). Because Guava's `EventBus` dispatches by runtime type and walks supertypes,
+  **subscribing to a base class catches all of its subclasses** — e.g. `TrackManager` subscribes to `TuningEvent` and
+  receives every concrete subtype.
+- **`BusinessyncUiHandler`** — a small `case class` (`run` lambda + `isUiThread` predicate) intended to make UI-thread
+  submission *pluggable*: a GUI toolkit supplies the lambda that schedules work onto its event thread. It is defined but
+  not yet consumed by `Businessync`.
 
-- **`BusinessyncEvent`** — `businessync/src/main/scala/org/calinburloiu/businessync/BusinessyncEvent.scala:22`
-  Abstract base class for every event posted through the bus. Provides a single `name: String` member defaulting to the
-  runtime simple class name. All domain events extend it, typically as `case class`/`case object` hierarchies under a
-  sealed base (e.g. `MidiEvent`, `TuningEvent`, `TrackEvent`, `ScaleLossyConversionEvent`). Because Guava's `EventBus`
-  dispatches by the event's runtime type and walks its supertypes, **subscribing to a base class catches all of its
-  subclasses** — e.g. `TrackManager` subscribes to `TuningEvent` and receives every concrete `TuningEvent` subtype.
+### Current behavior
 
-- **`BusinessyncUiHandler`** — `businessync/src/main/scala/org/calinburloiu/businessync/Businessync.scala:24`
-  A small `case class` holding `run: () => Unit` and `isUiThread: () => Boolean`. This is the seam intended to make the
-  UI-thread submission *pluggable*: a GUI toolkit (Swing today, JavaFX planned) supplies the lambda that schedules work
-  onto its event thread and a predicate that reports whether the current thread is that UI thread. It is defined but not
-  yet wired into `Businessync` (no constructor parameter consumes it in the current code).
+The `Businessync` API is written against the *target* two-thread semantics but is mostly not backed by real dispatch
+yet: `publish`/`register` delegate straight to the Guava `EventBus` (synchronous, on the caller's thread); `run`/`runIf`
+run their function inline; `call`/`callAsync` use the Scala global `ExecutionContext`; and the UI-thread methods
+(`runOnUi`, `callOnUi`, `handleOnUi`) plus the keyed `subscribe`/`subscribeOnUi` are stubs (`???` or no-ops). The
+numerous `// TODO #90` markers track the work to back these with a real dispatcher.
 
-### API surface (current code)
-
-The table reflects the actual bodies in `Businessync.scala`, not the target semantics.
-
-| Method | Signature | Current behavior |
-| ------ | --------- | ---------------- |
-| `publish` | `publish(event: BusinessyncEvent): Unit` | Delegates to `eventBus.post(event)`. Dispatch happens synchronously on the caller's thread. |
-| `handle` | `handle(event: BusinessyncEvent): Unit` | Currently an alias for `publish`. Intended: deliver to Business-thread subscribers only, throwing if not on the Business Thread. |
-| `handleOnUi` | `handleOnUi(event: BusinessyncEvent): Unit` | Stub (`???`). Intended: deliver to UI-thread subscribers only, throwing if not on the UI Thread. |
-| `subscribe` | `subscribe[E <: BusinessyncEvent](eventClass: Class[E], handler: E => Unit): Unit` | No-op (`{}`). Intended: register a Business-thread handler keyed by event class. |
-| `subscribeOnUi` | `subscribeOnUi[E <: BusinessyncEvent](eventClass: Class[E], handler: E => Unit): Unit` | No-op (`{}`). Intended: register a UI-thread handler keyed by event class. |
-| `register` | `register(obj: AnyRef): Unit` | Delegates to `eventBus.register(obj)`. The mechanism actually used today — see below. To be replaced by `subscribe`. |
-| `run` | `run(fn: () => Unit): Unit` | Runs `fn()` inline (no thread hop). Intended: schedule on the Business Thread. |
-| `runIf` | `runIf(condition: Boolean)(fn: () => Unit): Unit` | Runs `fn()` inline iff `condition`. |
-| `runOnUi` | `runOnUi(fn: () => Unit): Unit` | Stub (`???`). Intended: schedule on the UI Thread. |
-| `call` | `call[R](fn: () => R): Future[R]` | Runs `fn()` on the Scala global `ExecutionContext` via `Future { fn() }`. Intended: run on the Business Thread and return its result. |
-| `callAsync` | `callAsync[R](fn: () => Future[R]): Future[R]` | Invokes `fn()` and returns its `Future` directly (no thread hop). |
-| `callOnUi` | `callOnUi[R](fn: () => R): Future[R]` | Stub (`???`). Intended: run on the UI Thread and return its result. |
-
-Note a naming subtlety in the current API: `callAsync` takes a `() => Future[R]` (it flattens an already-async call),
-while `call` takes a `() => R`. Every method except the bus delegations and the inline `run`/`runIf`/`call`/`callAsync`
-is either a no-op or `???`.
-
-### Event delivery today (`@Subscribe` + `register`)
-
-Until `subscribe`/`subscribeOnUi` are implemented, subscription goes straight through Guava:
-
-1. A subscriber method is annotated with `com.google.common.eventbus.@Subscribe` and takes exactly one parameter whose
-   type is the event class (or a base class) it wants. Example:
-   `ui/.../TuningListFrame.scala:89` (`onTuningChanged(e: TuningIndexUpdatedEvent)`),
-   `tuner/.../TrackManager.scala:113` (`onTuningChanged(e: TuningEvent)` — base class, catches all subtypes).
-2. The owning object is handed to `businessync.register(obj)`, which forwards to `eventBus.register(obj)`
-   (e.g. `MicrotonalistApp.scala:97`, `TunerModule.scala:33`).
-3. Producers call `businessync.publish(event)`; Guava invokes the matching `@Subscribe` methods synchronously **on the
-   publishing thread** (there is no thread hop yet).
-
-The `@Subscribe`-based call sites carry `// TODO #90 Remove @Subscribe after implementing businessync` comments,
-marking them for migration to `subscribe`/`subscribeOnUi` once the real implementation lands.
-
-```scala
-// Producer (sc-midi)
-businessync.publish(MidiDeviceConnectedEvent(id))
-
-// Subscriber (ui) — registered via businessync.register(this)
-@Subscribe
-def onTuningChanged(event: TuningIndexUpdatedEvent): Unit = {
-  listComponent.setSelectedIndex(event.tuningIndex)
-}
-```
+Until `subscribe`/`subscribeOnUi` exist, subscription goes straight through Guava: a handler method is annotated with
+`com.google.common.eventbus.@Subscribe` (taking the event class or a base class it wants), the owning object is handed
+to `businessync.register(obj)`, and producers call `businessync.publish(event)` — Guava then invokes the matching
+handlers synchronously on the publishing thread. Those call sites carry `// TODO #90` comments marking them for
+migration to `subscribe`/`subscribeOnUi`.
 
 ## Threading model
 
-This section documents the *intended* two-thread model (see also the project
-[Threading Model wiki page](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model)) and flags where the
-current code does not yet enforce it.
+This is the *intended* two-thread model (see also the project [Threading Model wiki
+page](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model)); the current code does not yet enforce it.
 
 - **Business Thread** — owns all domain and MIDI logic. Domain state is mutated only here, so it needs no locks. Work is
-  meant to be submitted with `businessync.run { … }` (fire-and-forget) or `businessync.call { … }` (returns a
-  `Future`). Handlers for business-side events are registered with `subscribe` (today: `@Subscribe` + `register`).
-- **UI Thread** — owns all GUI updates. GUI components are touched only here. Work is meant to be submitted with
-  `businessync.runOnUi { … }` / `callOnUi`, and UI-side event handlers with `subscribeOnUi`. The actual UI thread is
-  the GUI toolkit's event thread (Swing EDT now; JavaFX Application Thread is the migration target — see TODOs `#99`
-  referencing the JavaFX move). The toolkit-specific submission is meant to be supplied via `BusinessyncUiHandler`.
+  submitted with `run` (fire-and-forget) or `call` (returns a `Future`); business-side handlers register with
+  `subscribe` (today: `@Subscribe` + `register`).
+- **UI Thread** — owns all GUI updates. Work is submitted with `runOnUi`/`callOnUi` and UI-side handlers with
+  `subscribeOnUi`. The actual UI thread is the GUI toolkit's event thread (Swing EDT now; JavaFX is the migration
+  target), supplied via `BusinessyncUiHandler`.
 - **Cross-thread rule.** Never mutate domain state from the UI thread or GUI state from the Business Thread directly;
-  always hop via the appropriate `Businessync` method. Results computed on worker threads (Scala `Future`s — e.g. file
+  always hop via the appropriate `Businessync` method. Results computed on worker threads (Scala `Future`s, e.g. file
   I/O) must be funneled back onto the Business Thread before touching domain state.
 
-Other threads in the wider system (documented on the wiki, not owned by this module): **Track threads** (one per
-`Track`, so each instrument's MIDI flows on a single thread), **MIDI threads** (managed by CoreMidi4J), and **worker
-threads** (the `Future` execution context).
+Other threads in the wider system (documented on the wiki, not owned here): **Track threads** (one per `Track`), **MIDI
+threads** (CoreMidi4J), and **worker threads** (the `Future` execution context).
 
-**Current reality vs. the model.** No dedicated Business or UI thread is started by this module yet. `run`/`runIf`
-execute inline on the caller; `call` runs on the global `ExecutionContext`; `publish` dispatches synchronously on the
-caller's thread; `runOnUi`/`callOnUi`/`handleOnUi` are unimplemented (`???`). In practice this means the threading
-*contracts* are expressed at call sites (e.g. `TuningService.changeTuning` wraps its body in `businessync.run`,
-`TrackService.open` uses `businessync.callAsync`) but are not yet *enforced* by `Businessync`. The call sites are
-written against the target API so that, once the real dispatcher exists, behavior tightens without touching callers.
+**Current reality.** No dedicated Business or UI thread is started yet, so the threading *contracts* are expressed at
+call sites (e.g. `TuningService.changeTuning` wraps its body in `businessync.run`, `TrackService.open` uses
+`businessync.callAsync`) but are not yet *enforced* by `Businessync`. Call sites are written against the target API so
+that, once the real dispatcher exists, behavior tightens without touching callers.
 
 ## Planned design (issue #90)
 
-Issue [#90 "Add businessync infrastructure"](https://github.com/calinburloiu/microtonalist/issues/90) (milestone
-*Architecture*) specifies the full design. Status below is verified against the current source.
+Issue [#90](https://github.com/calinburloiu/microtonalist/issues/90) (milestone *Architecture*) specifies the full
+design; treat it as planned and subject to change. The headline elements:
 
-- **Async calls on both threads** — `run` (fire-and-forget, `Unit`) and `call` (`Future`-wrapped result), each in a
-  Business and a UI variant. *Partially present as method signatures; not backed by real thread dispatch.*
-- **Class-keyed pub/sub with base-class matching** — `subscribe`/`subscribeOnUi` keyed by event class, where
-  subscribing to a base class catches all subclasses. *Base-class matching already works via Guava `EventBus` +
-  `@Subscribe`; the `subscribe`/`subscribeOnUi` methods themselves are stubs.*
-- **Pluggable UI-thread submission** — a configurable lambda that runs work on the UI thread. *Type
-  (`BusinessyncUiHandler`) exists but is not yet consumed by `Businessync`.*
-- **Sequential consistency of UI updates** — *Not implemented.* The plan:
-  - The business thread drains a concurrent queue of updates; calls are modeled as special events on that queue.
-  - Each UI→business update increments a UI-side **version** (a global counter) attached to the queued update; the
-    business thread (the *consumer*) advances its own version as it dequeues, so `businessVersion <= uiVersion`.
-  - Events published by the business thread carry its current business version.
-  - A UI subscription may **opt in** to sequential consistency; if so, the UI rejects an incoming event whose attached
-    business version is strictly less than the UI's own version (i.e. a stale response).
-  - For updates handled **asynchronously** on the business thread (e.g. I/O), the business version may advance before
-    the async work finishes, which would break consistency. The developer must then **explicitly attach the originating
-    business version** when publishing the response event, or use a special max version that the UI always accepts.
-  - To force this discipline, publishing an event that has UI subscribers **from an unmanaged thread** (neither UI nor
-    business) is intended to throw from `publish`, requiring an explicit version.
-
-Because none of the version/queue/sequential-consistency machinery exists in the code yet, these behaviors are
-**planned and subject to change**; this document will be updated when the implementation lands. The numerous
-`// TODO #90` markers in `Businessync.scala` and at the `@Subscribe` call sites track that work.
+- **Async calls on both threads** — `run`/`call`, each in a Business and a UI variant. *Present as signatures; not yet
+  backed by real thread dispatch.*
+- **Class-keyed pub/sub with base-class matching.** *Base-class matching already works via Guava `@Subscribe`; the
+  `subscribe`/`subscribeOnUi` methods are stubs.*
+- **Pluggable UI-thread submission** via `BusinessyncUiHandler`. *Type exists but is not yet consumed.*
+- **Sequential consistency of UI updates** — *not implemented.* The plan uses a UI-side **version** counter attached to
+  each queued update so the business thread (the consumer) can reject stale responses, with explicit version handling
+  for async business-thread work and a rule that publishing to UI subscribers from an unmanaged thread must throw. See
+  the issue for the queue/version mechanics.
 
 ## Dependencies
 
-- **Application dependencies: none.** In `build.sbt`, the `businessync` project has no `.dependsOn(...)`. It is a leaf
-  in the application dependency graph, alongside `intonation` and `common`.
-- **Third-party dependency:** Guava (`com.google.common.eventbus.EventBus`), declared as `guava` in `build.sbt`, plus
-  the common logging stack inherited from `commonDependencies`.
-- **Modules that depend on `businessync`** (directly, per `build.sbt`):
-  - `scMidi` (`sc-midi`) — publishes `MidiEvent`s from `MidiManager` / `MidiDeviceHandle`.
-  - `tuner` — `TuningSession`/`TuningService`, `TrackSession`/`TrackService`, `TrackManager`, `TunerModule` publish and
-    subscribe to `TuningEvent`/`TrackEvent`.
-  - `app` — `MicrotonalistApp` constructs the `Businessync` instance and wires it into the modules below.
-  - `cli` — depends transitively via `scMidi`; `MicrotonalistToolApp` constructs a `Businessync` for `MidiManager`.
-  - `format` — receives a `Businessync` (via `FormatModule`) and publishes `ScaleLossyConversionEvent`; the dependency
-    is supplied transitively (e.g. through `tuner`/`composition`) rather than as a direct `dependsOn`.
-  - `ui` — `TuningListFrame` subscribes to `TuningIndexUpdatedEvent`; reached transitively via `tuner`.
+`businessync` has **no application `dependsOn`** — it is a leaf in the dependency graph, alongside `intonation` and
+`common`. Its only third-party dependency is Guava (`EventBus`), plus the inherited common logging stack.
 
-The instance is created once in the application entry point (`MicrotonalistApp.run`,
-`app/.../MicrotonalistApp.scala:79`) and injected into `FormatModule`, `TunerModule`, `MidiManager`, etc., so a single
-event bus/threading context is shared across the whole running app.
+Modules that depend on it: `scMidi` (publishes `MidiEvent`s), `tuner` (publishes/subscribes to `TuningEvent`/
+`TrackEvent`), `app` (constructs the instance and wires it in), `cli` (constructs one for `MidiManager`), and
+transitively `format` (publishes `ScaleLossyConversionEvent`) and `ui` (subscribes to `TuningIndexUpdatedEvent`). The
+instance is created once in `MicrotonalistApp.run` and injected everywhere, so a single bus/threading context is shared
+across the running app.

--- a/docs/architecture/cli/README.md
+++ b/docs/architecture/cli/README.md
@@ -3,17 +3,17 @@
 ## Responsibility
 
 The `cli` module is a **separate command-line executable** — a small utilities tool, distinct from the main
-Microtonalist desktop application (the `app` module). It is not loaded by, and is not part of, the GUI application; it is
-assembled and run on its own.
+Microtonalist desktop application (the `app` module). It is not loaded by, and is not part of, the GUI application;
+it is assembled and run on its own.
 
 Its purpose is to provide developer/operator utilities that need access to the local MIDI subsystem without launching
-the full app. Currently it offers a single subcommand that **lists the MIDI devices connected to the computer**, printing
-each input and output device along with its metadata (name, vendor, version, description) and its maximum
-transmitter/receiver count. This is useful for discovering device names to reference in compositions and track
-configurations.
+the full app. Currently it offers a single subcommand that **lists the MIDI devices connected to the computer**,
+printing each input and output device along with its metadata (name, vendor, version, description) and its
+maximum transmitter/receiver count. This is useful for discovering device names to reference in compositions and
+track configurations.
 
-In the layered architecture it sits to the side of the main stack: it depends only on `sc-midi` (the Scala-idiomatic MIDI
-API) and the transitive `businessync` event bus that `MidiManager` requires. Nothing depends on `cli`. See
+In the layered architecture it sits to the side of the main stack: it depends only on `sc-midi` (the Scala-idiomatic
+MIDI API) and the transitive `businessync` event bus that `MidiManager` requires. Nothing depends on `cli`. See
 [Dependencies](#dependencies).
 
 Package: `org.calinburloiu.music.microtonalist.cli`.

--- a/docs/architecture/cli/README.md
+++ b/docs/architecture/cli/README.md
@@ -1,17 +1,64 @@
 # `cli` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `cli` module (`cli/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+The `cli` module is a **separate command-line executable** — a small utilities tool, distinct from the main
+Microtonalist desktop application (the `app` module). It is not loaded by, and is not part of, the GUI application; it is
+assembled and run on its own.
+
+Its purpose is to provide developer/operator utilities that need access to the local MIDI subsystem without launching
+the full app. Currently it offers a single subcommand that **lists the MIDI devices connected to the computer**, printing
+each input and output device along with its metadata (name, vendor, version, description) and its maximum
+transmitter/receiver count. This is useful for discovering device names to reference in compositions and track
+configurations.
+
+In the layered architecture it sits to the side of the main stack: it depends only on `sc-midi` (the Scala-idiomatic MIDI
+API) and the transitive `businessync` event bus that `MidiManager` requires. Nothing depends on `cli`. See
+[Dependencies](#dependencies).
+
+Package: `org.calinburloiu.music.microtonalist.cli`.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### `MicrotonalistToolApp` (`cli/src/main/scala/org/calinburloiu/music/microtonalist/cli/MicrotonalistToolApp.scala:25`)
+
+A plain Scala `object` with a `main` method — the executable's entry point and the assembly `mainClass`
+(`build.sbt:105`). It does its own minimal argument dispatch (no CLI-parsing library):
+
+- `main(args)` (`MicrotonalistToolApp.scala:27`) pattern-matches the first argument. `midi-devices` invokes
+  `printMidiDevices()`; anything else prints a usage message listing the available subcommands.
+- `printMidiDevices()` (`:38`) constructs a `Businessync` (over a Guava `EventBus`) and a
+  `org.calinburloiu.music.scmidi.MidiManager`, then iterates `midiManager.inputDevicesInfo` and
+  `midiManager.outputDevicesInfo`, opening each `MidiDevice` via `javax.sound.midi.MidiSystem` to print its metadata and
+  handler counts. It always calls `midiManager.close()` when done. The nested helpers `printMidiDevicesByEndpoint`,
+  `printTransmitters`, and `printReceivers` factor out the per-endpoint (input vs. output) printing.
+- `fromHandlerCountToString(handlerCount)` (`:76`) renders the JVM's `-1` "unlimited" sentinel (used for
+  max transmitters/receivers) as the string `"unlimited"`.
+
+There are no subcommand classes, traits, or a command framework — the tool is intentionally a single flat object.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Per `build.sbt:97`, the `cli` project declares exactly one application dependency:
+
+```scala
+lazy val cli = (project in file("cli"))
+  .dependsOn(
+    scMidi,
+  )
+```
+
+- **`sc-midi` (`scMidi`)** — the only direct application dependency, used for `MidiManager` and the MIDI endpoint
+  abstraction. `businessync` is pulled in transitively (and is referenced directly here only to satisfy `MidiManager`'s
+  constructor).
+- It also uses the JDK's `javax.sound.midi` API and Guava's `EventBus` (the latter via `Businessync`).
+- **Nothing depends on `cli`.** It is aggregated by `root` for building/testing but is not on any other module's
+  classpath; it is packaged as its own fat JAR (`microtonalist-cli`, `build.sbt:102`).
+
+## Future / planned changes
+
+- `build.sbt:106` carries `// TODO #181`: coverage thresholds are currently `0`/`0` and are to be raised toward the
+  project's 80% statement/branch target, which will require adding tests for this module.
+- The hand-rolled argument dispatch in `main` is structured to grow: new subcommands are added as additional `case`
+  branches. The plural naming (`MicrotonalistToolApp`, "prints all available MIDI devices") signals the tool is intended
+  to host more utilities over time.

--- a/docs/architecture/cli/README.md
+++ b/docs/architecture/cli/README.md
@@ -3,62 +3,37 @@
 ## Responsibility
 
 The `cli` module is a **separate command-line executable** — a small utilities tool, distinct from the main
-Microtonalist desktop application (the `app` module). It is not loaded by, and is not part of, the GUI application;
-it is assembled and run on its own.
+Microtonalist desktop application (`app`). It is not loaded by, nor part of, the GUI application; it is assembled and
+run on its own (as the `microtonalist-cli` fat JAR).
 
-Its purpose is to provide developer/operator utilities that need access to the local MIDI subsystem without launching
-the full app. Currently it offers a single subcommand that **lists the MIDI devices connected to the computer**,
-printing each input and output device along with its metadata (name, vendor, version, description) and its
-maximum transmitter/receiver count. This is useful for discovering device names to reference in compositions and
-track configurations.
+Its purpose is developer/operator utilities that need the local MIDI subsystem without launching the full app. Currently
+it offers a single subcommand that **lists the MIDI devices connected to the computer**, printing each input and output
+device with its metadata (name, vendor, version, description) and its maximum transmitter/receiver count — useful for
+discovering device names to reference in compositions and track configurations.
 
-In the layered architecture it sits to the side of the main stack: it depends only on `sc-midi` (the Scala-idiomatic
-MIDI API) and the transitive `businessync` event bus that `MidiManager` requires. Nothing depends on `cli`. See
-[Dependencies](#dependencies).
+In the layered architecture it sits to the side of the main stack: it depends only on `sc-midi` (and the transitive
+`businessync` that `MidiManager` requires). Nothing depends on `cli`.
 
 Package: `org.calinburloiu.music.microtonalist.cli`.
 
 ## Key types
 
-### `MicrotonalistToolApp` (`cli/src/main/scala/org/calinburloiu/music/microtonalist/cli/MicrotonalistToolApp.scala:25`)
-
-A plain Scala `object` with a `main` method — the executable's entry point and the assembly `mainClass`
-(`build.sbt:105`). It does its own minimal argument dispatch (no CLI-parsing library):
-
-- `main(args)` (`MicrotonalistToolApp.scala:27`) pattern-matches the first argument. `midi-devices` invokes
-  `printMidiDevices()`; anything else prints a usage message listing the available subcommands.
-- `printMidiDevices()` (`:38`) constructs a `Businessync` (over a Guava `EventBus`) and a
-  `org.calinburloiu.music.scmidi.MidiManager`, then iterates `midiManager.inputDevicesInfo` and
-  `midiManager.outputDevicesInfo`, opening each `MidiDevice` via `javax.sound.midi.MidiSystem` to print its metadata and
-  handler counts. It always calls `midiManager.close()` when done. The nested helpers `printMidiDevicesByEndpoint`,
-  `printTransmitters`, and `printReceivers` factor out the per-endpoint (input vs. output) printing.
-- `fromHandlerCountToString(handlerCount)` (`:76`) renders the JVM's `-1` "unlimited" sentinel (used for
-  max transmitters/receivers) as the string `"unlimited"`.
-
-There are no subcommand classes, traits, or a command framework — the tool is intentionally a single flat object.
+**`MicrotonalistToolApp`** is a plain Scala `object` with a `main` method — the executable's entry point and the
+assembly `mainClass`. It does its own minimal argument dispatch (no CLI-parsing library): `main` pattern-matches the
+first argument, routing `midi-devices` to `printMidiDevices()` and anything else to a usage message. `printMidiDevices`
+constructs a `Businessync` and a `MidiManager`, iterates the input and output devices to print their metadata and
+handler counts (rendering the JVM's `-1` "unlimited" sentinel as `"unlimited"`), and always closes the `MidiManager`
+when done. There is no command framework — the tool is intentionally a single flat object.
 
 ## Dependencies
 
-Per `build.sbt:97`, the `cli` project declares exactly one application dependency:
-
-```scala
-lazy val cli = (project in file("cli"))
-  .dependsOn(
-    scMidi,
-  )
-```
-
-- **`sc-midi` (`scMidi`)** — the only direct application dependency, used for `MidiManager` and the MIDI endpoint
-  abstraction. `businessync` is pulled in transitively (and is referenced directly here only to satisfy `MidiManager`'s
-  constructor).
-- It also uses the JDK's `javax.sound.midi` API and Guava's `EventBus` (the latter via `Businessync`).
-- **Nothing depends on `cli`.** It is aggregated by `root` for building/testing but is not on any other module's
-  classpath; it is packaged as its own fat JAR (`microtonalist-cli`, `build.sbt:102`).
+`cli` declares exactly one application dependency, `sc-midi` (`scMidi`), used for `MidiManager` and the MIDI endpoint
+abstraction; `businessync` is pulled in transitively (referenced directly only to satisfy `MidiManager`'s constructor).
+It also uses the JDK's `javax.sound.midi` and Guava's `EventBus` (via `Businessync`). Nothing depends on `cli`; it is
+aggregated by `root` for building/testing but packaged as its own fat JAR.
 
 ## Future / planned changes
 
-- `build.sbt:106` carries `// TODO #181`: coverage thresholds are currently `0`/`0` and are to be raised toward the
-  project's 80% statement/branch target, which will require adding tests for this module.
-- The hand-rolled argument dispatch in `main` is structured to grow: new subcommands are added as additional `case`
-  branches. The plural naming (`MicrotonalistToolApp`, "prints all available MIDI devices") signals the tool is intended
-  to host more utilities over time.
+- Coverage thresholds are currently 0 with `// TODO #181` to raise them toward the project's 80% target, which will
+  require adding tests for this module.
+- The hand-rolled argument dispatch is structured to grow: new subcommands are added as additional `case` branches.

--- a/docs/architecture/common/README.md
+++ b/docs/architecture/common/README.md
@@ -18,8 +18,9 @@ Package: `org.calinburloiu.music.microtonalist.common` (sub-package `.concurrenc
 **`Plugin`** is the base trait for all of Microtonalist's pluggable, user-selectable components. It defines a two-level
 naming contract used both at runtime and for JSON (de)serialization: `familyName` (the family/context, e.g.
 `tuningMapper`) and `typeName` (the chosen type within it, e.g. `auto`). Within one family the user can swap between
-types. The families across the project are `TuningMapper`, `TuningReducer`, `TuningReference` (in `composition`) and
-`Tuner`, `TuningChanger` (in `tuner`). The serialization side lives in `format` (`JsonPluginFormat[P]` keys off these
+types. The families across the project live in `composition` (`TuningMapper`, `TuningReducer`, `TuningReference`,
+`SoftChromaticGenusMapping`) and `tuner` (`Tuner`, `TuningChanger`, and the track I/O specs `TrackInputSpec` /
+`TrackOutputSpec`). The serialization side lives in `format` (`JsonPluginFormat[P]` keys off these
 names); the `Plugin` trait itself carries only the two `val`s and no serialization logic.
 
 **`Locking`** is a mix-in trait providing `@inline` helpers (`withLock` / `withReadLock` / `withWriteLock`) that run a

--- a/docs/architecture/common/README.md
+++ b/docs/architecture/common/README.md
@@ -1,17 +1,94 @@
 # `common` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `common` module (`common/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+The `common` module is a small collection of cross-cutting utilities and abstractions shared by the rest of
+Microtonalist. It is not a domain module: it holds no musical concepts. Instead it provides the few building blocks that
+many higher modules need but that do not belong to any single one — the `Plugin` extension point, a lock-scoping helper,
+a session lifecycle trait, URL/path parsing, and platform detection.
+
+Its role in the layered architecture:
+
+- It sits near the bottom of the dependency graph and is **widely depended upon** (`tuner`, `format`, `scMidi`,
+  `appConfig`, `app`), so it deliberately keeps almost no dependencies of its own. See [Dependencies](#dependencies).
+- Each utility here is independent of the others; there is no internal coupling between `Plugin`, `Locking`,
+  `OpenableSession`, and the package-object functions.
+
+Package: `org.calinburloiu.music.microtonalist.common` (sub-package `.concurrency`).
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### `Plugin` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/Plugin.scala`)
+
+`Plugin` (`Plugin.scala:27`) is the base trait for all of Microtonalist's pluggable, user-selectable components. It
+defines a two-level naming contract used both at runtime and for JSON (de)serialization:
+
+- `familyName: String` (`Plugin.scala:28`) — the _family_ (context) a plugin belongs to, e.g. `tuningMapper`.
+- `typeName: String` (`Plugin.scala:29`) — the specific _type_ within that family that the user chose, e.g. `auto` for
+  `AutoTuningMapper`.
+
+The idea is that within one family the user can swap between multiple types. The plugin families across the project are:
+
+- `TuningMapper` (`composition`) — e.g. `AutoTuningMapper`, `ManualTuningMapper`.
+- `TuningReducer` (`composition`) — e.g. `MergeTuningReducer`, `DirectTuningReducer`.
+- `TuningReference` (`composition`) — e.g. `StandardTuningReference`, `ConcertPitchTuningReference`.
+- `Tuner` (`tuner`) — the MTS Octave / MPE / monophonic pitch-bend implementations.
+- `TuningChanger` (`tuner`) — e.g. `PedalTuningChanger`.
+
+The serialization side lives in the `format` module: `JsonPluginFormat[P]`
+(`format/.../JsonPluginFormat.scala:36`) parses a whole family and uses each type's `typeName` as the JSON `type`
+discriminator (`familyName` names the family; a `defaultTypeName` lets the `type` property be omitted). The `Plugin`
+trait itself carries only the two `val`s — it has no serialization logic.
+
+### `Locking` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/concurrency/Locking.scala`)
+
+`Locking` (`Locking.scala:44`) is a mix-in trait providing `@inline` helpers that run a block while holding a lock and
+always release it in a `finally`. The lock is passed implicitly, so call sites read like `withReadLock { _x }`:
+
+- `withLock(block)(implicit lock: Lock)` (`Locking.scala:55`) — a plain `java.util.concurrent.locks.Lock`.
+- `withReadLock(block)` / `withWriteLock(block)` (`Locking.scala:73`, `:91`) — the read / write side of an implicit
+  `ReadWriteLock`.
+
+Used for thread-safe getters/setters in `appConfig` (`ConfigManagement`), `format` (`DeferrableRead`), and `scMidi`
+(`MidiDeviceHandle`, `MidiProcessor`).
+
+### `OpenableSession` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/OpenableSession.scala`)
+
+`OpenableSession` (`OpenableSession.scala:23`) is a small lifecycle trait extending `java.io.Closeable` for a
+resource that can be opened against a `URI`, asynchronously: `open(uri): Future[Unit]`, `close()`, `isOpened: Boolean`,
+and `uri: Option[URI]`. Implemented by `TrackSession` in the `tuner` module.
+
+### Package-object functions (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/package.scala`)
+
+- `parseUrlOrPath(urlString): Option[URI]` (`package.scala:31`) — parses a string as either an absolute URL or a local
+  file path, returning a `URI`. The private `mapPathToUri` enforces the project convention that a directory URI ends in
+  `/` (which the Java `Path` API tends to strip). Used by `app` (`MicrotonalistApp`) and `appConfig` (`CoreConfig`).
+
+### `PlatformUtils` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/PlatformUtils.scala`)
+
+`PlatformUtils` (`PlatformUtils.scala:20`) exposes `isMac` / `isWindows` / `isLinux` for OS-conditional behavior (e.g.
+directory-slash handling in `parseUrlOrPath`, config paths in `appConfig`). It is currently **hardcoded to macOS**
+(`isMac == true`, the others `false`) — see notes below.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Verified against `build.sbt` (the `common` project block at `build.sbt:122`).
+
+**Upstream (what `common` depends on):**
+
+- No other Microtonalist modules — `common` has no `dependsOn` except `commonTestUtils % Test` (shared test helpers,
+  test-only).
+- External libraries: **Guava** (`guava`) plus the project-wide `commonDependencies` (Logback, scala-logging, and
+  ScalaTest/ScalaMock in `Test` scope).
+
+**Downstream (what depends on `common`):**
+
+- Direct `dependsOn(common)`: `appConfig`, `tuner`, `format`, `scMidi`, and `app`.
+- Transitively, `composition` (via `tuner`) and `ui` (via `tuner`) also reach `common`. (`cli` and `experiments` do not
+  depend on it.)
+
+## Notes / subject to change
+
+- `PlatformUtils` is a stub hardcoded to macOS. A `// TODO Add support for Windows and maybe GNU/Linux` marks the intent
+  to detect the OS at runtime; until then non-macOS branches of callers are effectively dead. (Note: per project
+  convention TODOs carry an issue number; this one does not yet.)

--- a/docs/architecture/common/README.md
+++ b/docs/architecture/common/README.md
@@ -3,92 +3,47 @@
 ## Responsibility
 
 The `common` module is a small collection of cross-cutting utilities and abstractions shared by the rest of
-Microtonalist. It is not a domain module: it holds no musical concepts. Instead it provides the few building blocks that
-many higher modules need but that do not belong to any single one — the `Plugin` extension point, a lock-scoping helper,
-a session lifecycle trait, URL/path parsing, and platform detection.
+Microtonalist. It is not a domain module — it holds no musical concepts. Instead it provides the few building blocks
+that many higher modules need but that belong to no single one: the `Plugin` extension point, a lock-scoping helper, a
+session-lifecycle trait, URL/path parsing, and platform detection.
 
-Its role in the layered architecture:
-
-- It sits near the bottom of the dependency graph and is **widely depended upon** (`tuner`, `format`, `scMidi`,
-  `appConfig`, `app`), so it deliberately keeps almost no dependencies of its own. See [Dependencies](#dependencies).
-- Each utility here is independent of the others; there is no internal coupling between `Plugin`, `Locking`,
-  `OpenableSession`, and the package-object functions.
+It sits near the bottom of the dependency graph and is **widely depended upon** (`tuner`, `format`, `scMidi`,
+`appConfig`, `app`), so it deliberately keeps almost no dependencies of its own. Each utility here is independent of the
+others.
 
 Package: `org.calinburloiu.music.microtonalist.common` (sub-package `.concurrency`).
 
 ## Key types
 
-### `Plugin` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/Plugin.scala`)
+**`Plugin`** is the base trait for all of Microtonalist's pluggable, user-selectable components. It defines a two-level
+naming contract used both at runtime and for JSON (de)serialization: `familyName` (the family/context, e.g.
+`tuningMapper`) and `typeName` (the chosen type within it, e.g. `auto`). Within one family the user can swap between
+types. The families across the project are `TuningMapper`, `TuningReducer`, `TuningReference` (in `composition`) and
+`Tuner`, `TuningChanger` (in `tuner`). The serialization side lives in `format` (`JsonPluginFormat[P]` keys off these
+names); the `Plugin` trait itself carries only the two `val`s and no serialization logic.
 
-`Plugin` (`Plugin.scala:27`) is the base trait for all of Microtonalist's pluggable, user-selectable components. It
-defines a two-level naming contract used both at runtime and for JSON (de)serialization:
-
-- `familyName: String` (`Plugin.scala:28`) — the _family_ (context) a plugin belongs to, e.g. `tuningMapper`.
-- `typeName: String` (`Plugin.scala:29`) — the specific _type_ within that family that the user chose, e.g. `auto` for
-  `AutoTuningMapper`.
-
-The idea is that within one family the user can swap between multiple types. The plugin families across the project are:
-
-- `TuningMapper` (`composition`) — e.g. `AutoTuningMapper`, `ManualTuningMapper`.
-- `TuningReducer` (`composition`) — e.g. `MergeTuningReducer`, `DirectTuningReducer`.
-- `TuningReference` (`composition`) — e.g. `StandardTuningReference`, `ConcertPitchTuningReference`.
-- `Tuner` (`tuner`) — the MTS Octave / MPE / monophonic pitch-bend implementations.
-- `TuningChanger` (`tuner`) — e.g. `PedalTuningChanger`.
-
-The serialization side lives in the `format` module: `JsonPluginFormat[P]`
-(`format/.../JsonPluginFormat.scala:36`) parses a whole family and uses each type's `typeName` as the JSON `type`
-discriminator (`familyName` names the family; a `defaultTypeName` lets the `type` property be omitted). The `Plugin`
-trait itself carries only the two `val`s — it has no serialization logic.
-
-### `Locking` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/concurrency/Locking.scala`)
-
-`Locking` (`Locking.scala:44`) is a mix-in trait providing `@inline` helpers that run a block while holding a lock and
-always release it in a `finally`. The lock is passed implicitly, so call sites read like `withReadLock { _x }`:
-
-- `withLock(block)(implicit lock: Lock)` (`Locking.scala:55`) — a plain `java.util.concurrent.locks.Lock`.
-- `withReadLock(block)` / `withWriteLock(block)` (`Locking.scala:73`, `:91`) — the read / write side of an implicit
-  `ReadWriteLock`.
-
-Used for thread-safe getters/setters in `appConfig` (`ConfigManagement`), `format` (`DeferrableRead`), and `scMidi`
+**`Locking`** is a mix-in trait providing `@inline` helpers (`withLock` / `withReadLock` / `withWriteLock`) that run a
+block while holding an implicitly-passed lock and always release it in a `finally`, so call sites read like
+`withReadLock { _x }`. Used for thread-safe getters/setters in `appConfig`, `format` (`DeferrableRead`), and `scMidi`
 (`MidiDeviceHandle`, `MidiProcessor`).
 
-### `OpenableSession` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/OpenableSession.scala`)
+**`OpenableSession`** is a small lifecycle trait (extending `java.io.Closeable`) for a resource opened asynchronously
+against a `URI`: `open(uri): Future[Unit]`, `close()`, `isOpened`, `uri`. Implemented by `TrackSession` in `tuner`.
 
-`OpenableSession` (`OpenableSession.scala:23`) is a small lifecycle trait extending `java.io.Closeable` for a
-resource that can be opened against a `URI`, asynchronously: `open(uri): Future[Unit]`, `close()`, `isOpened: Boolean`,
-and `uri: Option[URI]`. Implemented by `TrackSession` in the `tuner` module.
+**Package-object functions** — chiefly `parseUrlOrPath(urlString): Option[URI]`, which parses a string as either an
+absolute URL or a local file path, enforcing the project convention that a directory URI ends in `/`. Used by `app` and
+`appConfig`.
 
-### Package-object functions (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/package.scala`)
-
-- `parseUrlOrPath(urlString): Option[URI]` (`package.scala:31`) — parses a string as either an absolute URL or a local
-  file path, returning a `URI`. The private `mapPathToUri` enforces the project convention that a directory URI ends in
-  `/` (which the Java `Path` API tends to strip). Used by `app` (`MicrotonalistApp`) and `appConfig` (`CoreConfig`).
-
-### `PlatformUtils` (`common/src/main/scala/org/calinburloiu/music/microtonalist/common/PlatformUtils.scala`)
-
-`PlatformUtils` (`PlatformUtils.scala:20`) exposes `isMac` / `isWindows` / `isLinux` for OS-conditional behavior (e.g.
-directory-slash handling in `parseUrlOrPath`, config paths in `appConfig`). It is currently **hardcoded to macOS**
-(`isMac == true`, the others `false`) — see notes below.
+**`PlatformUtils`** exposes `isMac` / `isWindows` / `isLinux` for OS-conditional behavior. It is currently **hardcoded
+to macOS** — see notes below.
 
 ## Dependencies
 
-Verified against `build.sbt` (the `common` project block at `build.sbt:122`).
-
-**Upstream (what `common` depends on):**
-
-- No other Microtonalist modules — `common` has no `dependsOn` except `commonTestUtils % Test` (shared test helpers,
-  test-only).
-- External libraries: **Guava** (`guava`) plus the project-wide `commonDependencies` (Logback, scala-logging, and
-  ScalaTest/ScalaMock in `Test` scope).
-
-**Downstream (what depends on `common`):**
-
-- Direct `dependsOn(common)`: `appConfig`, `tuner`, `format`, `scMidi`, and `app`.
-- Transitively, `composition` (via `tuner`) and `ui` (via `tuner`) also reach `common`. (`cli` and `experiments` do not
-  depend on it.)
+`common` has no application `dependsOn` (only `commonTestUtils % Test`). Externally it uses Guava plus the inherited
+common logging/test stack. It is depended on directly by `appConfig`, `tuner`, `format`, `scMidi`, and `app`, and
+transitively by `composition` and `ui` (via `tuner`); `cli` and `experiments` do not depend on it.
 
 ## Notes / subject to change
 
-- `PlatformUtils` is a stub hardcoded to macOS. A `// TODO Add support for Windows and maybe GNU/Linux` marks the intent
-  to detect the OS at runtime; until then non-macOS branches of callers are effectively dead. (Note: per project
-  convention TODOs carry an issue number; this one does not yet.)
+- `PlatformUtils` is a stub hardcoded to macOS, so non-macOS branches of its callers are effectively dead until OS
+  detection is implemented. (Its `// TODO` does not yet carry an issue number, contrary to project convention.)

--- a/docs/architecture/composition/README.md
+++ b/docs/architecture/composition/README.md
@@ -2,122 +2,80 @@
 
 The `composition` module (directory `composition/`, package `org.calinburloiu.music.microtonalist.composition`) is the
 domain model that connects the two central abstractions of Microtonalist: high-level musical **scales** and the
-low-level **tunings** that a keyboard/synthesizer is actually configured with. A user composes with a sequence of
-scales; this module turns that sequence into the concrete `Tuning`s the `tuner` module sends to instruments.
+low-level **tunings** a keyboard/synthesizer is actually configured with. A user composes with a sequence of scales;
+this module turns that sequence into the concrete `Tuning`s the `tuner` module sends to instruments.
 
 > **Note:** this module is the subject of the planned refactor tracked by
 > [issue #87 "Refactor composition module"](https://github.com/calinburloiu/microtonalist/issues/87) (Architecture
-> milestone). Some of the structure described below is expected to change as part of that work.
+> milestone). Some of the structure below is expected to change as part of that work.
 
 ## Responsibility
 
-- Hold the in-memory representation of a microtonal composition: a `Composition` aggregates an `IntonationStandard`,
-  a `TuningReference`, an ordered sequence of `TuningSpec`s (each a scale + how to map it), a `TuningReducer`, and a
-  `FillSpec` (fill configuration).
-- Map each scale to a 12-pitch-class `Tuning` (deciding which keyboard key every scale pitch occupies), via the
-  `TuningMapper` plugin family.
-- Reduce/merge the per-spec tunings into as few final tunings as possible — so a player makes the fewest tuning
-  switches — via the `TuningReducer` plugin family, producing a `TuningList`.
+- Hold the in-memory representation of a microtonal composition: a `Composition` aggregates an `IntonationStandard`, a
+  `TuningReference`, an ordered sequence of `TuningSpec`s (each a scale + how to map it), a `TuningReducer`, and a
+  `FillSpec`.
+- Map each scale to a 12-pitch-class `Tuning` via the `TuningMapper` plugin family.
+- Reduce/merge the per-spec tunings into as few final tunings as possible — so a player makes the fewest tuning switches
+  — via the `TuningReducer` plugin family, producing a `TuningList`.
 - Resolve a `Composition` into a final `TuningList` through `TuningList.fromComposition`.
 
 The module is pure domain logic: it knows nothing about file formats (that is `format`), MIDI transport, or the GUI. It
-manipulates intervals and produces `Tuning` values; deciding when/how those tunings reach an instrument is the `tuner`
-module's job.
+manipulates intervals and produces `Tuning` values; deciding when/how those reach an instrument is the `tuner` module's
+job.
 
 ## Key types
 
 ### Aggregate / value types
 
-- **`Composition`** — `Composition.scala:40`. Top-level container modelling a composition: optional source `url`,
-  `intonationStandard`, `tuningReference`, `tuningSpecs: Seq[TuningSpec]`, `tuningReducer`, `fill: FillSpec`, optional
-  `metadata`, and an optional `tracksUrlOverride`. `tracksUrl` derives the tracks-file URI (appends `.tracks`) when not
-  overridden. A plain `case class`.
-- **`TuningSpec`** — `Composition.scala:68`. Pairs a `Scale[Interval]` with a `TuningMapper` and a `transposition`
-  interval. `tuningFor(ref)` transposes+maps the scale into one `Tuning`.
-- **`FillSpec`** / **`LocalFillSpec`** — `Composition.scala:115` / `Composition.scala:86`. Fill configuration. `global`
-  is an optional `TuningSpec` used as the final fallback for unused keys across all tunings; `local` toggles back-fill,
-  fore-fill, and memory-fill. The ScalaDoc on `FillSpec` documents the local vs. global fill taxonomy in detail.
-- **`CompositionMetadata`** — `Composition.scala:129`. Name / composer / author.
-- **`TuningPitch`** — `TuningPitch.scala:32`. A single pitch class plus its cents `offset` from 12-EDO. Helpers:
-  `cents`, `interval`, `isOverflowing` (|offset| ≥ 100), `isQuarterTone`, `almostEquals`. Implicit conversions to/from
-  `PitchClass` and `Int` live in its companion.
-- **`KeyboardMapping`** — `KeyboardMapping.scala:26`. A 12-slot mapping from pitch class → optional scale pitch index
-  (some keys unmapped). Backs `ManualTuningMapper` and the override mechanism of `AutoTuningMapper`. Offers
-  `apply`/`updated`/`removed`/`toMap`/`iterator` plus a named-argument `apply` factory (`c =`, `cSharpOrDFlat =`, …)
-  and `KeyboardMapping.empty`.
-- **`TuningList`** — `TuningList.scala:23`. The resolved output: a `Seq[Tuning]` exposed as an `Iterable[Tuning]` with
-  indexed `apply`. Built by `TuningList.fromComposition` (`TuningList.scala:38`).
+- **`Composition`** — the top-level container: an `intonationStandard`, a `tuningReference`, `tuningSpecs`, a
+  `tuningReducer`, a `fill: FillSpec`, optional `metadata`, and the source/tracks URLs. A plain `case class`.
+- **`TuningSpec`** — pairs a `Scale[Interval]` with a `TuningMapper` and a `transposition` interval; `tuningFor(ref)`
+  transposes and maps the scale into one `Tuning`.
+- **`FillSpec`** / **`LocalFillSpec`** — fill configuration. `global` is an optional `TuningSpec` used as the final
+  fallback for unused keys across all tunings; `local` toggles back-fill, fore-fill, and memory-fill. The `FillSpec`
+  ScalaDoc documents the local-vs-global fill taxonomy in detail.
+- **`TuningPitch`** — a single pitch class plus its cents `offset` from 12-EDO, with helpers such as `isQuarterTone` and
+  `isOverflowing`. Implicit conversions to/from `PitchClass` and `Int` live in its companion.
+- **`KeyboardMapping`** — a 12-slot mapping from pitch class → optional scale-pitch index (some keys unmapped). Backs
+  `ManualTuningMapper` and the override mechanism of `AutoTuningMapper`.
+- **`TuningList`** — the resolved output: a `Seq[Tuning]` exposed as an indexed `Iterable[Tuning]`, built by
+  `TuningList.fromComposition`.
 
 ### Plugin families
 
-`TuningMapper`, `TuningReducer`, `TuningReference` (and the `SoftChromaticGenusMapping` helper) all extend the
-`Plugin` trait from `common` (`common/.../Plugin.scala`). A `Plugin` carries a `familyName` (identifying the extension
-point) and a `typeName` (identifying the concrete variant). The `format` module uses these names to select the right
-Play JSON (de)serializer, so each implementation here corresponds to a JSON `type` discriminator. The `*.Default`
-values in the companions define the variant chosen when a composition does not specify one.
+`TuningMapper`, `TuningReducer`, `TuningReference` (and the `SoftChromaticGenusMapping` helper) all extend the `Plugin`
+trait from `common`: each carries a `familyName` (the extension point) and a `typeName` (the concrete variant), which
+`format` uses to select the right Play-JSON (de)serializer. The `*.Default` value in each companion is the variant
+chosen when a composition does not specify one.
 
-**`TuningMapper`** (family `"tuningMapper"`) — `TuningMapper.scala:31`. Maps a `Scale` to a `Tuning`, leaving unused
-keys as `None`. A *conflict* (two scale pitches landing on the same key) throws `TuningMapperConflictException`
-(`TuningMapper.scala:75`); an out-of-range offset throws `TuningMapperOverflowException` (`TuningMapper.scala:83`).
+**`TuningMapper`** (family `"tuningMapper"`) maps a `Scale` to a `Tuning`, leaving unused keys `None`. A *conflict* (two
+scale pitches on the same key) throws `TuningMapperConflictException`; an out-of-range offset throws
+`TuningMapperOverflowException`.
 
-- **`AutoTuningMapper`** (`typeName = "auto"`) — `AutoTuningMapper.scala:96`. Places pitches automatically. Key
-  behaviours:
-  - `shouldMapQuarterTonesLow` chooses whether a quarter tone snaps to the lower key (+50¢) or the higher key (−50¢);
-    `quarterToneTolerance` absorbs floating-point slack around ±50¢.
-  - Detects and resolves key collisions by re-mapping the quarter tone in the opposite direction
-    (`mapScaleToPitchesInfo`, `AutoTuningMapper.scala:181`).
-  - `softChromaticGenusMapping` (`SoftChromaticGenusMapping`, `AutoTuningMapper.scala:48`) — `Off` / `Strict` /
-    `PseudoChromatic`, itself a `Plugin` (family `"softChromaticGenusMapping"`). Lets a soft-chromatic trichord
-    (e.g. an Easter Hijaz tetrachord) keep its characteristic augmented second instead of being flattened by the
-    quarter-tone rule.
-  - `overrideKeyboardMapping` lets the user pin specific scale pitches to chosen keys; those are delegated to an
-    internal `ManualTuningMapper` and merged with the auto result.
-  - `keyboardMappingOf` reports the mapping the auto algorithm derived for a scale.
-  - `TuningMapper.Default` and `AutoTuningMapper.Default` are `AutoTuningMapper`s with
-    `shouldMapQuarterTonesLow = false`.
-- **`ManualTuningMapper`** (`typeName = "manual"`) — `ManualTuningMapper.scala:29`. Maps strictly from a
-  user-provided `KeyboardMapping`, computing each key's offset and throwing `TuningMapperOverflowException` if an
-  offset leaves the open interval (−100, 100).
+- **`AutoTuningMapper`** (`"auto"`, the default) places pitches automatically. `shouldMapQuarterTonesLow` chooses
+  whether a quarter tone snaps to the lower (+50¢) or higher (−50¢) key, and it resolves key collisions by re-mapping
+  the quarter tone in the opposite direction. Its `softChromaticGenusMapping` (`Off`/`Strict`/`PseudoChromatic`, itself
+  a `Plugin`) lets a soft-chromatic trichord keep its characteristic augmented second instead of being flattened by the
+  quarter-tone rule. An optional `overrideKeyboardMapping` pins specific pitches to chosen keys (delegated to an
+  internal `ManualTuningMapper` and merged with the auto result).
+- **`ManualTuningMapper`** (`"manual"`) maps strictly from a user-provided `KeyboardMapping`.
 
-**`TuningReducer`** (family `"tuningReducer"`) — `TuningReducer.scala:26`. Merges the per-`TuningSpec` tunings into
-ideally fewer final tunings and returns a `TuningList`. `TuningReducer.Default` is a `MergeTuningReducer`.
+**`TuningReducer`** (family `"tuningReducer"`) merges the per-`TuningSpec` tunings into ideally fewer final tunings and
+returns a `TuningList`.
 
-- **`MergeTuningReducer`** (`typeName = "merge"`, the default) — `MergeTuningReducer.scala:43`. Merges *consecutive*
-  non-conflicting tunings (two tunings conflict when any corresponding key has differing offsets beyond
-  `equalityTolerance`), then applies local **back-fill** (offsets from preceding merged tunings) and **fore-fill**
-  (offsets from succeeding ones) to minimise notes retuned on a tuning switch, and finally fills remaining gaps from
-  the global fill tuning.
-- **`DirectTuningReducer`** (`typeName = "direct"`, a singleton `object`) — `DirectTuningReducer.scala:26`. Performs
-  no reduction; only applies the global fill to each tuning. Use when no merging is wanted.
+- **`MergeTuningReducer`** (`"merge"`, the default) merges *consecutive* non-conflicting tunings, then applies local
+  **back-fill** (offsets from preceding merged tunings) and **fore-fill** (from succeeding ones) to minimise notes
+  retuned on a switch, and finally fills remaining gaps from the global fill tuning.
+- **`DirectTuningReducer`** (`"direct"`) performs no reduction; it only applies the global fill to each tuning.
 
-**`TuningReference`** (family `"tuningReference"`) — `TuningReference.scala:27`. Defines the composition's base pitch:
-which keyboard pitch class it occupies (`basePitchClass`), its cents offset from 12-EDO (`baseOffset`), and the two
-combined as a `baseTuningPitch: TuningPitch`.
-
-- **`StandardTuningReference`** (`typeName = "standard"`) — `TuningReference.scala:57`. Base pitch given directly as a
-  pitch class + cents offset relative to 12-EDO.
-- **`ConcertPitchTuningReference`** (`typeName = "concertPitch"`) — `TuningReference.scala:77`. Base pitch derived from
-  a concert-pitch frequency (default A4 = 440 Hz), an interval from concert pitch to the base, and the base MIDI note;
-  `baseOffset` is computed from these.
-
-### Module-level helpers
-
-`package.scala` defines `DefaultQuarterToneTolerance = 13.0` and `roundWithTolerance` (round-half toward a chosen
-direction within a tolerance), used by the auto mapper's quarter-tone logic.
+**`TuningReference`** (family `"tuningReference"`) defines the composition's base pitch: which keyboard pitch class it
+occupies (`basePitchClass`), its cents offset from 12-EDO (`baseOffset`), and the two combined as a `baseTuningPitch`.
+`StandardTuningReference` (`"standard"`) gives the base pitch directly relative to 12-EDO; `ConcertPitchTuningReference`
+(`"concertPitch"`) derives it from a concert-pitch frequency, an interval, and the base MIDI note.
 
 ## How a `Composition` resolves into a `TuningList`
 
-`TuningList.fromComposition(composition)` (`TuningList.scala:38`) drives the pipeline:
-
-```scala
-def fromComposition(composition: Composition): TuningList = {
-  val globalFillTuning = composition.fill.global
-    .map(_.tuningFor(composition.tuningReference))
-    .getOrElse(Tuning.Standard)
-  val tunings = composition.tuningSpecs.map(_.tuningFor(composition.tuningReference))
-  composition.tuningReducer.reduceTunings(tunings, globalFillTuning)
-}
-```
+`TuningList.fromComposition(composition)` drives the pipeline:
 
 1. For each `TuningSpec`, `tuningFor(ref)` transposes the scale and runs its `TuningMapper` against the
    `TuningReference`, yielding one `Tuning` per spec.
@@ -126,25 +84,15 @@ def fromComposition(composition: Composition): TuningList = {
    `TuningList`.
 
 This is the only public way the rest of the app turns composition data into tunings; `MicrotonalistApp` calls it right
-after loading the `Composition` (`app/.../MicrotonalistApp.scala:85`), and the resulting `TuningList` feeds the
-`TuningSession` in the `tuner` module.
+after loading the `Composition`, and the resulting `TuningList` feeds the `TuningSession` in the `tuner` module.
 
 ## Dependencies
 
-Declared in `build.sbt` (`lazy val composition`):
+- **Depends on `intonation`** for the interval math it builds on (`Interval`, `Scale`, `IntonationStandard`, …).
+- **Depends on `tuner`** for the output value type `Tuning` (and `Tuning.Standard`). The arrow points *into* `tuner`:
+  this module produces `Tuning`s but does not perform MIDI tuning. It also uses `sc-midi` types such as `PitchClass` and
+  `MidiNote` (reached via `tuner`) and `common`'s `Plugin` trait.
 
-- **Depends on `intonation`** — `Interval`, `Scale`, `IntonationStandard`, `CentsInterval`, `RealInterval`,
-  `ConcertPitchFreq`, etc. (the interval math this module builds on).
-- **Depends on `tuner`** — `Tuning` (the output value type), `Tuning.Standard`, and the `DefaultCentsTolerance`
-  constant. Note the arrow points *into* `tuner`: this module produces `Tuning`s but does not perform MIDI tuning.
-- **Depends on `common`** (transitively, for `Plugin`) and uses `scMidi` types such as `PitchClass` and `MidiNote`
-  (pulled in via `tuner`'s dependency on `sc-midi`).
-
-Depended on by:
-
-- **`format`** — serializes/deserializes every type here (`JsonCompositionFormat`, the `Json*PluginFormat`s for the
-  mapper/reducer/reference/soft-chromatic families, `KeyboardMappingFormat`, etc.).
-- **`app`** — loads a `Composition` and calls `TuningList.fromComposition`.
-
-Module coverage floor is set high (statement and branch both 80% in `build.sbt`), reflecting its status as a
-core, logic-heavy domain module.
+Depended on by **`format`** (which serializes every type here) and **`app`** (which loads a `Composition` and calls
+`TuningList.fromComposition`). Its coverage floor is set high (statement and branch both 80%), reflecting its status as
+a core, logic-heavy domain module.

--- a/docs/architecture/composition/README.md
+++ b/docs/architecture/composition/README.md
@@ -1,17 +1,150 @@
 # `composition` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `composition` module (`composition/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
+The `composition` module (directory `composition/`, package `org.calinburloiu.music.microtonalist.composition`) is the
+domain model that connects the two central abstractions of Microtonalist: high-level musical **scales** and the
+low-level **tunings** that a keyboard/synthesizer is actually configured with. A user composes with a sequence of
+scales; this module turns that sequence into the concrete `Tuning`s the `tuner` module sends to instruments.
+
+> **Note:** this module is the subject of the planned refactor tracked by
+> [issue #87 "Refactor composition module"](https://github.com/calinburloiu/microtonalist/issues/87) (Architecture
+> milestone). Some of the structure described below is expected to change as part of that work.
 
 ## Responsibility
 
-TODO: what this module does and why it exists.
+- Hold the in-memory representation of a microtonal composition: a `Composition` aggregates an `IntonationStandard`,
+  a `TuningReference`, an ordered sequence of `TuningSpec`s (each a scale + how to map it), a `TuningReducer`, and a
+  `FillSpec` (fill configuration).
+- Map each scale to a 12-pitch-class `Tuning` (deciding which keyboard key every scale pitch occupies), via the
+  `TuningMapper` plugin family.
+- Reduce/merge the per-spec tunings into as few final tunings as possible — so a player makes the fewest tuning
+  switches — via the `TuningReducer` plugin family, producing a `TuningList`.
+- Resolve a `Composition` into a final `TuningList` through `TuningList.fromComposition`.
+
+The module is pure domain logic: it knows nothing about file formats (that is `format`), MIDI transport, or the GUI. It
+manipulates intervals and produces `Tuning` values; deciding when/how those tunings reach an instrument is the `tuner`
+module's job.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### Aggregate / value types
+
+- **`Composition`** — `Composition.scala:40`. Top-level container modelling a composition: optional source `url`,
+  `intonationStandard`, `tuningReference`, `tuningSpecs: Seq[TuningSpec]`, `tuningReducer`, `fill: FillSpec`, optional
+  `metadata`, and an optional `tracksUrlOverride`. `tracksUrl` derives the tracks-file URI (appends `.tracks`) when not
+  overridden. A plain `case class`.
+- **`TuningSpec`** — `Composition.scala:68`. Pairs a `Scale[Interval]` with a `TuningMapper` and a `transposition`
+  interval. `tuningFor(ref)` transposes+maps the scale into one `Tuning`.
+- **`FillSpec`** / **`LocalFillSpec`** — `Composition.scala:115` / `Composition.scala:86`. Fill configuration. `global`
+  is an optional `TuningSpec` used as the final fallback for unused keys across all tunings; `local` toggles back-fill,
+  fore-fill, and memory-fill. The ScalaDoc on `FillSpec` documents the local vs. global fill taxonomy in detail.
+- **`CompositionMetadata`** — `Composition.scala:129`. Name / composer / author.
+- **`TuningPitch`** — `TuningPitch.scala:32`. A single pitch class plus its cents `offset` from 12-EDO. Helpers:
+  `cents`, `interval`, `isOverflowing` (|offset| ≥ 100), `isQuarterTone`, `almostEquals`. Implicit conversions to/from
+  `PitchClass` and `Int` live in its companion.
+- **`KeyboardMapping`** — `KeyboardMapping.scala:26`. A 12-slot mapping from pitch class → optional scale pitch index
+  (some keys unmapped). Backs `ManualTuningMapper` and the override mechanism of `AutoTuningMapper`. Offers
+  `apply`/`updated`/`removed`/`toMap`/`iterator` plus a named-argument `apply` factory (`c =`, `cSharpOrDFlat =`, …)
+  and `KeyboardMapping.empty`.
+- **`TuningList`** — `TuningList.scala:23`. The resolved output: a `Seq[Tuning]` exposed as an `Iterable[Tuning]` with
+  indexed `apply`. Built by `TuningList.fromComposition` (`TuningList.scala:38`).
+
+### Plugin families
+
+`TuningMapper`, `TuningReducer`, `TuningReference` (and the `SoftChromaticGenusMapping` helper) all extend the
+`Plugin` trait from `common` (`common/.../Plugin.scala`). A `Plugin` carries a `familyName` (identifying the extension
+point) and a `typeName` (identifying the concrete variant). The `format` module uses these names to select the right
+Play JSON (de)serializer, so each implementation here corresponds to a JSON `type` discriminator. The `*.Default`
+values in the companions define the variant chosen when a composition does not specify one.
+
+**`TuningMapper`** (family `"tuningMapper"`) — `TuningMapper.scala:31`. Maps a `Scale` to a `Tuning`, leaving unused
+keys as `None`. A *conflict* (two scale pitches landing on the same key) throws `TuningMapperConflictException`
+(`TuningMapper.scala:75`); an out-of-range offset throws `TuningMapperOverflowException` (`TuningMapper.scala:83`).
+
+- **`AutoTuningMapper`** (`typeName = "auto"`) — `AutoTuningMapper.scala:96`. Places pitches automatically. Key
+  behaviours:
+  - `shouldMapQuarterTonesLow` chooses whether a quarter tone snaps to the lower key (+50¢) or the higher key (−50¢);
+    `quarterToneTolerance` absorbs floating-point slack around ±50¢.
+  - Detects and resolves key collisions by re-mapping the quarter tone in the opposite direction
+    (`mapScaleToPitchesInfo`, `AutoTuningMapper.scala:181`).
+  - `softChromaticGenusMapping` (`SoftChromaticGenusMapping`, `AutoTuningMapper.scala:48`) — `Off` / `Strict` /
+    `PseudoChromatic`, itself a `Plugin` (family `"softChromaticGenusMapping"`). Lets a soft-chromatic trichord
+    (e.g. an Easter Hijaz tetrachord) keep its characteristic augmented second instead of being flattened by the
+    quarter-tone rule.
+  - `overrideKeyboardMapping` lets the user pin specific scale pitches to chosen keys; those are delegated to an
+    internal `ManualTuningMapper` and merged with the auto result.
+  - `keyboardMappingOf` reports the mapping the auto algorithm derived for a scale.
+  - `TuningMapper.Default` and `AutoTuningMapper.Default` are `AutoTuningMapper`s with
+    `shouldMapQuarterTonesLow = false`.
+- **`ManualTuningMapper`** (`typeName = "manual"`) — `ManualTuningMapper.scala:29`. Maps strictly from a
+  user-provided `KeyboardMapping`, computing each key's offset and throwing `TuningMapperOverflowException` if an
+  offset leaves the open interval (−100, 100).
+
+**`TuningReducer`** (family `"tuningReducer"`) — `TuningReducer.scala:26`. Merges the per-`TuningSpec` tunings into
+ideally fewer final tunings and returns a `TuningList`. `TuningReducer.Default` is a `MergeTuningReducer`.
+
+- **`MergeTuningReducer`** (`typeName = "merge"`, the default) — `MergeTuningReducer.scala:43`. Merges *consecutive*
+  non-conflicting tunings (two tunings conflict when any corresponding key has differing offsets beyond
+  `equalityTolerance`), then applies local **back-fill** (offsets from preceding merged tunings) and **fore-fill**
+  (offsets from succeeding ones) to minimise notes retuned on a tuning switch, and finally fills remaining gaps from
+  the global fill tuning.
+- **`DirectTuningReducer`** (`typeName = "direct"`, a singleton `object`) — `DirectTuningReducer.scala:26`. Performs
+  no reduction; only applies the global fill to each tuning. Use when no merging is wanted.
+
+**`TuningReference`** (family `"tuningReference"`) — `TuningReference.scala:27`. Defines the composition's base pitch:
+which keyboard pitch class it occupies (`basePitchClass`), its cents offset from 12-EDO (`baseOffset`), and the two
+combined as a `baseTuningPitch: TuningPitch`.
+
+- **`StandardTuningReference`** (`typeName = "standard"`) — `TuningReference.scala:57`. Base pitch given directly as a
+  pitch class + cents offset relative to 12-EDO.
+- **`ConcertPitchTuningReference`** (`typeName = "concertPitch"`) — `TuningReference.scala:77`. Base pitch derived from
+  a concert-pitch frequency (default A4 = 440 Hz), an interval from concert pitch to the base, and the base MIDI note;
+  `baseOffset` is computed from these.
+
+### Module-level helpers
+
+`package.scala` defines `DefaultQuarterToneTolerance = 13.0` and `roundWithTolerance` (round-half toward a chosen
+direction within a tolerance), used by the auto mapper's quarter-tone logic.
+
+## How a `Composition` resolves into a `TuningList`
+
+`TuningList.fromComposition(composition)` (`TuningList.scala:38`) drives the pipeline:
+
+```scala
+def fromComposition(composition: Composition): TuningList = {
+  val globalFillTuning = composition.fill.global
+    .map(_.tuningFor(composition.tuningReference))
+    .getOrElse(Tuning.Standard)
+  val tunings = composition.tuningSpecs.map(_.tuningFor(composition.tuningReference))
+  composition.tuningReducer.reduceTunings(tunings, globalFillTuning)
+}
+```
+
+1. For each `TuningSpec`, `tuningFor(ref)` transposes the scale and runs its `TuningMapper` against the
+   `TuningReference`, yielding one `Tuning` per spec.
+2. The optional global-fill `TuningSpec` is mapped the same way (or `Tuning.Standard` if absent).
+3. The `TuningReducer` merges those tunings, applies local fill (Merge only) and the global fill, and emits the final
+   `TuningList`.
+
+This is the only public way the rest of the app turns composition data into tunings; `MicrotonalistApp` calls it right
+after loading the `Composition` (`app/.../MicrotonalistApp.scala:85`), and the resulting `TuningList` feeds the
+`TuningSession` in the `tuner` module.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Declared in `build.sbt` (`lazy val composition`):
+
+- **Depends on `intonation`** — `Interval`, `Scale`, `IntonationStandard`, `CentsInterval`, `RealInterval`,
+  `ConcertPitchFreq`, etc. (the interval math this module builds on).
+- **Depends on `tuner`** — `Tuning` (the output value type), `Tuning.Standard`, and the `DefaultCentsTolerance`
+  constant. Note the arrow points *into* `tuner`: this module produces `Tuning`s but does not perform MIDI tuning.
+- **Depends on `common`** (transitively, for `Plugin`) and uses `scMidi` types such as `PitchClass` and `MidiNote`
+  (pulled in via `tuner`'s dependency on `sc-midi`).
+
+Depended on by:
+
+- **`format`** — serializes/deserializes every type here (`JsonCompositionFormat`, the `Json*PluginFormat`s for the
+  mapper/reducer/reference/soft-chromatic families, `KeyboardMappingFormat`, etc.).
+- **`app`** — loads a `Composition` and calls `TuningList.fromComposition`.
+
+Module coverage floor is set high (statement and branch both 80% in `build.sbt`), reflecting its status as a
+core, logic-heavy domain module.

--- a/docs/architecture/config/README.md
+++ b/docs/architecture/config/README.md
@@ -23,14 +23,15 @@ wrapper that adds `getAs[T]`/`ValueReader[T]`. Ficus is the only extra library d
 **`MainConfigManager`** is the central, mutable, thread-safe holder of the whole HOCON document. It is `AutoCloseable`
 and mixes in `Locking` (from `common`) to guard the document with a read/write lock. Construction is private — the
 companion `apply` overloads load from a `Path` (with an empty fallback) or run file-less from an in-memory document
-(handy for tests). It parses and `resolve()`s the file, exposes the sub-document at a path and splices updated
-sub-documents back in (marking the config dirty), and persists via `save()` — which renders HOCON (not JSON, no origin
+(handy for tests). It parses and `resolve()`s the file, exposes the **sub-config** at a path — the
+HOCON sub-tree of the full document rooted at that path, itself a `HoconConfig` — and splices updated sub-configs back in
+(marking the config dirty), and persists via `save()` — which renders HOCON (not JSON, no origin
 comments) only when dirty. A scheduler calls `save()` on the configured interval and `close()` does a final save on
 exit. `MainConfigManager.defaultConfigFile` resolves `~/.microtonalist/microtonalist.conf` on macOS and throws on other
 platforms (see [Future / planned changes](#future--planned-changes)).
 
 **`SubConfigManager[C <: Configured]` / `Configured`** are the extension pattern for typed config sections. `Configured`
-marks a typed section; `SubConfigManager` manages one HOCON sub-tree rooted at a `configPath`, exposing a typed `config`
+marks a typed section; `SubConfigManager` manages one such sub-config rooted at a `configPath`, exposing a typed `config`
 getter and a `notifyConfigChanged` that pushes a value back to the owning `MainConfigManager`. Subclasses implement just
 the pure `serialize`/`deserialize` pair. This keeps each settings section self-contained, so a new section is added by
 writing a new `Configured` case class plus a `SubConfigManager` for it.

--- a/docs/architecture/config/README.md
+++ b/docs/architecture/config/README.md
@@ -4,98 +4,53 @@
 
 The `appConfig` module (SBT project `appConfig`, directory `config/`) owns Microtonalist's **application
 configuration**: loading, exposing, mutating, and persisting the user's settings. Settings are stored in
-[HOCON](https://github.com/lightbend/config) format and, on macOS, live at `~/.microtonalist/microtonalist.conf`.
+[HOCON](https://github.com/lightbend/config) and, on macOS, live at `~/.microtonalist/microtonalist.conf`. The module:
 
-The module's job is to:
+- parses a HOCON file into typed, immutable Scala config values (or falls back to defaults when no file is given);
+- exposes those values as domain-friendly case classes (e.g. `CoreConfig`);
+- accepts in-memory updates, marks the config dirty, and periodically (and on exit) writes it back to disk.
 
-- Parse a HOCON config file into typed, immutable Scala config values (or fall back to defaults when no file is given).
-- Expose those values to the rest of the application as domain-friendly case classes (e.g. `CoreConfig`).
-- Accept in-memory updates, mark the config dirty, and periodically (and on exit) write it back to disk.
+It knows nothing about MIDI, tunings, compositions, or the GUI. Its one consumer of note is `MicrotonalistApp`, which
+resolves the config path, constructs a `MainConfigManager`, and reads `coreConfig.libraryBaseUrl` to wire up
+`FormatModule`.
 
-It deliberately knows nothing about MIDI, tunings, compositions, or the GUI — it only deals with reading/writing
-configuration. The single consumer of note is `MicrotonalistApp` (`app` module), which resolves the config path,
-constructs a `MainConfigManager`, and reads `coreConfig.libraryBaseUrl` to wire up the `FormatModule`
-(`app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala:77`).
-
-Package: `org.calinburloiu.music.microtonalist.config`.
-
-### Underlying library
-
-Configuration is parsed and rendered with the **Typesafe/Lightbend Config** library (`com.typesafe.config`, the HOCON
-implementation), aliased throughout the module as `HoconConfig`. Typed reading uses **Ficus** (`com.iheart %% ficus`),
-a thin Scala wrapper over Typesafe Config that adds `getAs[T]` and `ValueReader[T]` typeclasses. Ficus is the only
-extra `libraryDependency` declared for this module in `build.sbt`.
+Package: `org.calinburloiu.music.microtonalist.config`. Configuration is parsed and rendered with the
+**Typesafe/Lightbend Config** library (aliased `HoconConfig` throughout); typed reading uses **Ficus**, a thin Scala
+wrapper that adds `getAs[T]`/`ValueReader[T]`. Ficus is the only extra library dependency declared for this module.
 
 ## Key types
 
-### `MainConfigManager` (`config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigManagement.scala:30`)
+**`MainConfigManager`** is the central, mutable, thread-safe holder of the whole HOCON document. It is `AutoCloseable`
+and mixes in `Locking` (from `common`) to guard the document with a read/write lock. Construction is private — the
+companion `apply` overloads load from a `Path` (with an empty fallback) or run file-less from an in-memory document
+(handy for tests). It parses and `resolve()`s the file, exposes the sub-document at a path and splices updated
+sub-documents back in (marking the config dirty), and persists via `save()` — which renders HOCON (not JSON, no origin
+comments) only when dirty. A scheduler calls `save()` on the configured interval and `close()` does a final save on
+exit. `MainConfigManager.defaultConfigFile` resolves `~/.microtonalist/microtonalist.conf` on macOS and throws on other
+platforms (see [Future / planned changes](#future--planned-changes)).
 
-The central, mutable, thread-safe holder of the whole HOCON document. It is `AutoCloseable` and mixes in `Locking`
-(from `common`) to guard its mutable `_mainHoconConfig` with a `ReentrantReadWriteLock`.
+**`SubConfigManager[C <: Configured]` / `Configured`** are the extension pattern for typed config sections. `Configured`
+marks a typed section; `SubConfigManager` manages one HOCON sub-tree rooted at a `configPath`, exposing a typed `config`
+getter and a `notifyConfigChanged` that pushes a value back to the owning `MainConfigManager`. Subclasses implement just
+the pure `serialize`/`deserialize` pair. This keeps each settings section self-contained, so a new section is added by
+writing a new `Configured` case class plus a `SubConfigManager` for it.
 
-- Construction is private; use the companion `apply` overloads
-  (`ConfigManagement.scala:119`): `MainConfigManager(configFile: Path)` loads from a file with an empty fallback, while
-  `MainConfigManager(mainHoconConfig: HoconConfig)` runs file-less from an in-memory document (handy for tests).
-- `load()` (`:53`) parses and `resolve()`s the file via `ConfigFactory.parseFile`, or logs a warning and uses the
-  fallback when no file path was supplied.
-- `hoconConfig(configPath)` (`:85`) returns the sub-document at a path; `notifyConfigChanged(configPath, hoconConfig)`
-  (`:87`) splices an updated sub-document back in and marks the config dirty.
-- Persistence: `save()` (`:64`) writes the rendered document (only when `isDirty`) using `render()` (`:83`) with
-  `ConfigRenderOptions` that drop origin comments and emit HOCON rather than JSON. A `ScheduledExecutorService` calls
-  `save()` every `metaConfig.saveIntervalMillis` (when > 0), and `close()` (`:91`) does a final save when
-  `metaConfig.saveOnExit` and shuts the scheduler down.
-- It eagerly creates a `CoreConfigManager` and exposes shortcuts `coreConfig` and `metaConfig`.
-- `MainConfigManager.defaultConfigFile` (`:114`) resolves `~/.microtonalist/microtonalist.conf` on macOS and throws on
-  other platforms (see [Future / planned changes](#future--planned-changes)).
+**`CoreConfig` / `MetaConfig` / `CoreConfigManager`** are the one concrete section today, rooted at HOCON path `core`.
+`CoreConfig` holds `libraryBaseUrl` (the scale/track library root, default `~/Music/microtonalist/lib/` on macOS) and a
+nested `MetaConfig` (`saveIntervalMillis`, `saveOnExit`) that drives `MainConfigManager`'s autosave. `CoreConfigManager`
+reads `libraryBaseUrl` via Ficus and `common`'s `parseUrlOrPath`, throwing a `ConfigPropertyException` on a bad value
+and falling back to defaults for missing keys.
 
-### `SubConfigManager[C <: Configured]` and `Configured` (`ConfigManagement.scala:126`)
-
-`Configured` (`:126`) is a marker trait for a typed config section. `SubConfigManager` (`:128`) is the abstract base
-for managing one HOCON sub-tree rooted at `configPath`:
-
-- `config: C` deserializes the current sub-document; `notifyConfigChanged(configured: C)` serializes a value and pushes
-  it back into the owning `MainConfigManager`.
-- Subclasses implement the pure `serialize(C): HoconConfig` and `deserialize(HoconConfig): C` pair.
-
-This pattern keeps each settings section (its typed shape plus its HOCON (de)serialization) self-contained, so new
-config sections are added by writing a new `Configured` case class plus a `SubConfigManager` for it.
-
-### `CoreConfig`, `MetaConfig`, `CoreConfigManager` (`config/.../CoreConfig.scala`)
-
-The one concrete config section, rooted at HOCON path `core` (`CoreConfig.scala:74`).
-
-- `CoreConfig` (`:27`) — `case class` extending `Configured`, holding `libraryBaseUrl: URI` (where the scale library
-  lives; defaults via `CoreConfig.defaultLibraryBaseUrl` to `~/Music/microtonalist/lib/` on macOS) and a nested
-  `metaConfig`.
-- `MetaConfig` (`:39`) — `case class` with `saveIntervalMillis: Int = 5000` and `saveOnExit: Boolean = true`, the
-  knobs that drive `MainConfigManager`'s autosave behavior.
-- `CoreConfigManager` (`:46`) — `SubConfigManager[CoreConfig]`. `deserialize` (`:64`) reads `libraryBaseUrl` via Ficus'
-  `getAs[String]`, parses it with `common`'s `parseUrlOrPath`, and throws a `ConfigPropertyException` on a bad value;
-  it falls back to defaults for any missing key. A private Ficus `ValueReader[MetaConfig]` (`:76`) handles the nested
-  section. `serialize` (`:52`) rebuilds the sub-document with the `withAnyRefValue` helper.
-
-### `ConfigSerDe` (`config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigSerDe.scala:23`)
-
-Serialization helpers bridging plain Scala values and Typesafe Config values:
-
-- `HoconConfigExtension.withAnyRefValue(path, value)` (`:27`) — an implicit extension that sets a value, recursing into
-  `Seq`/`Map`, and skips the write when a scalar is unchanged (avoiding needless dirtying).
-- `createHoconValue(value)` (`:39`) — recursively converts Scala `Seq`/`Map`/scalars into `ConfigValue`s via
-  `ConfigValueFactory`.
-
-### Exceptions
-
-- `ConfigException` (`config/.../ConfigException.scala:22`) — base `RuntimeException` for HOCON configuration errors.
-- `ConfigPropertyException` (`config/.../ConfigPropertyException.scala:26`) — subclass for a single bad property,
-  carrying the HOCON `propertyPath` and a human-readable requirement message.
+Supporting pieces: `ConfigSerDe` provides the serialization helpers bridging plain Scala values and Typesafe Config
+values (notably a `withAnyRefValue` extension that recurses into `Seq`/`Map` and skips unchanged scalars), and the
+exception hierarchy is `ConfigException` (base) with `ConfigPropertyException` for a single bad property (carrying its
+HOCON `propertyPath`).
 
 ## Dependencies
 
-Per `build.sbt`, `appConfig` depends only on the `common` module (for `PlatformUtils`, `parseUrlOrPath`, and the
-`Locking` concurrency trait) plus the external `ficus` library (over Typesafe Config). It has no other
-application-module dependencies, keeping it near the bottom of the layered architecture.
-
-It is depended on by the `app` module, which constructs and queries the `MainConfigManager` during startup.
+`appConfig` depends only on `common` (for `PlatformUtils`, `parseUrlOrPath`, and the `Locking` trait) plus the external
+`ficus` library, keeping it near the bottom of the layered architecture. It is depended on by `app`, which constructs
+and queries the `MainConfigManager` during startup.
 
 ```
 app
@@ -105,9 +60,7 @@ app
 
 ## Future / planned changes
 
-- **macOS-only platform support.** `defaultConfigFile` and `CoreConfig.defaultLibraryBaseUrl` both throw a
-  `RuntimeException("Only Mac platform is currently supported")` on non-Mac platforms, and `PlatformUtils.isMac` is
-  hardcoded to `true`. Cross-platform config-path resolution is an open area.
-- **Single config section.** Only the `core` section exists today. The `SubConfigManager` / `Configured` machinery is
-  built to grow: additional settings sections are expected to be added as new `Configured` case classes with their own
-  `SubConfigManager`s.
+- **macOS-only platform support.** `defaultConfigFile` and `CoreConfig.defaultLibraryBaseUrl` both throw on non-Mac
+  platforms, and `PlatformUtils.isMac` is hardcoded to `true`. Cross-platform config-path resolution is an open area.
+- **Single config section.** Only the `core` section exists today; the `SubConfigManager`/`Configured` machinery is
+  built to grow with additional `Configured` case classes.

--- a/docs/architecture/config/README.md
+++ b/docs/architecture/config/README.md
@@ -60,7 +60,7 @@ for managing one HOCON sub-tree rooted at `configPath`:
 This pattern keeps each settings section (its typed shape plus its HOCON (de)serialization) self-contained, so new
 config sections are added by writing a new `Configured` case class plus a `SubConfigManager` for it.
 
-### `CoreConfig`, `MetaConfig`, `CoreConfigManager` (`config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala`)
+### `CoreConfig`, `MetaConfig`, `CoreConfigManager` (`config/.../CoreConfig.scala`)
 
 The one concrete config section, rooted at HOCON path `core` (`CoreConfig.scala:74`).
 
@@ -92,8 +92,8 @@ Serialization helpers bridging plain Scala values and Typesafe Config values:
 ## Dependencies
 
 Per `build.sbt`, `appConfig` depends only on the `common` module (for `PlatformUtils`, `parseUrlOrPath`, and the
-`Locking` concurrency trait) plus the external `ficus` library (over Typesafe Config). It has no other application-module
-dependencies, keeping it near the bottom of the layered architecture.
+`Locking` concurrency trait) plus the external `ficus` library (over Typesafe Config). It has no other
+application-module dependencies, keeping it near the bottom of the layered architecture.
 
 It is depended on by the `app` module, which constructs and queries the `MainConfigManager` during startup.
 

--- a/docs/architecture/config/README.md
+++ b/docs/architecture/config/README.md
@@ -1,17 +1,113 @@
 # `appConfig` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `appConfig` module (`config/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+The `appConfig` module (SBT project `appConfig`, directory `config/`) owns Microtonalist's **application
+configuration**: loading, exposing, mutating, and persisting the user's settings. Settings are stored in
+[HOCON](https://github.com/lightbend/config) format and, on macOS, live at `~/.microtonalist/microtonalist.conf`.
+
+The module's job is to:
+
+- Parse a HOCON config file into typed, immutable Scala config values (or fall back to defaults when no file is given).
+- Expose those values to the rest of the application as domain-friendly case classes (e.g. `CoreConfig`).
+- Accept in-memory updates, mark the config dirty, and periodically (and on exit) write it back to disk.
+
+It deliberately knows nothing about MIDI, tunings, compositions, or the GUI — it only deals with reading/writing
+configuration. The single consumer of note is `MicrotonalistApp` (`app` module), which resolves the config path,
+constructs a `MainConfigManager`, and reads `coreConfig.libraryBaseUrl` to wire up the `FormatModule`
+(`app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala:77`).
+
+Package: `org.calinburloiu.music.microtonalist.config`.
+
+### Underlying library
+
+Configuration is parsed and rendered with the **Typesafe/Lightbend Config** library (`com.typesafe.config`, the HOCON
+implementation), aliased throughout the module as `HoconConfig`. Typed reading uses **Ficus** (`com.iheart %% ficus`),
+a thin Scala wrapper over Typesafe Config that adds `getAs[T]` and `ValueReader[T]` typeclasses. Ficus is the only
+extra `libraryDependency` declared for this module in `build.sbt`.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### `MainConfigManager` (`config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigManagement.scala:30`)
+
+The central, mutable, thread-safe holder of the whole HOCON document. It is `AutoCloseable` and mixes in `Locking`
+(from `common`) to guard its mutable `_mainHoconConfig` with a `ReentrantReadWriteLock`.
+
+- Construction is private; use the companion `apply` overloads
+  (`ConfigManagement.scala:119`): `MainConfigManager(configFile: Path)` loads from a file with an empty fallback, while
+  `MainConfigManager(mainHoconConfig: HoconConfig)` runs file-less from an in-memory document (handy for tests).
+- `load()` (`:53`) parses and `resolve()`s the file via `ConfigFactory.parseFile`, or logs a warning and uses the
+  fallback when no file path was supplied.
+- `hoconConfig(configPath)` (`:85`) returns the sub-document at a path; `notifyConfigChanged(configPath, hoconConfig)`
+  (`:87`) splices an updated sub-document back in and marks the config dirty.
+- Persistence: `save()` (`:64`) writes the rendered document (only when `isDirty`) using `render()` (`:83`) with
+  `ConfigRenderOptions` that drop origin comments and emit HOCON rather than JSON. A `ScheduledExecutorService` calls
+  `save()` every `metaConfig.saveIntervalMillis` (when > 0), and `close()` (`:91`) does a final save when
+  `metaConfig.saveOnExit` and shuts the scheduler down.
+- It eagerly creates a `CoreConfigManager` and exposes shortcuts `coreConfig` and `metaConfig`.
+- `MainConfigManager.defaultConfigFile` (`:114`) resolves `~/.microtonalist/microtonalist.conf` on macOS and throws on
+  other platforms (see [Future / planned changes](#future--planned-changes)).
+
+### `SubConfigManager[C <: Configured]` and `Configured` (`ConfigManagement.scala:126`)
+
+`Configured` (`:126`) is a marker trait for a typed config section. `SubConfigManager` (`:128`) is the abstract base
+for managing one HOCON sub-tree rooted at `configPath`:
+
+- `config: C` deserializes the current sub-document; `notifyConfigChanged(configured: C)` serializes a value and pushes
+  it back into the owning `MainConfigManager`.
+- Subclasses implement the pure `serialize(C): HoconConfig` and `deserialize(HoconConfig): C` pair.
+
+This pattern keeps each settings section (its typed shape plus its HOCON (de)serialization) self-contained, so new
+config sections are added by writing a new `Configured` case class plus a `SubConfigManager` for it.
+
+### `CoreConfig`, `MetaConfig`, `CoreConfigManager` (`config/src/main/scala/org/calinburloiu/music/microtonalist/config/CoreConfig.scala`)
+
+The one concrete config section, rooted at HOCON path `core` (`CoreConfig.scala:74`).
+
+- `CoreConfig` (`:27`) — `case class` extending `Configured`, holding `libraryBaseUrl: URI` (where the scale library
+  lives; defaults via `CoreConfig.defaultLibraryBaseUrl` to `~/Music/microtonalist/lib/` on macOS) and a nested
+  `metaConfig`.
+- `MetaConfig` (`:39`) — `case class` with `saveIntervalMillis: Int = 5000` and `saveOnExit: Boolean = true`, the
+  knobs that drive `MainConfigManager`'s autosave behavior.
+- `CoreConfigManager` (`:46`) — `SubConfigManager[CoreConfig]`. `deserialize` (`:64`) reads `libraryBaseUrl` via Ficus'
+  `getAs[String]`, parses it with `common`'s `parseUrlOrPath`, and throws a `ConfigPropertyException` on a bad value;
+  it falls back to defaults for any missing key. A private Ficus `ValueReader[MetaConfig]` (`:76`) handles the nested
+  section. `serialize` (`:52`) rebuilds the sub-document with the `withAnyRefValue` helper.
+
+### `ConfigSerDe` (`config/src/main/scala/org/calinburloiu/music/microtonalist/config/ConfigSerDe.scala:23`)
+
+Serialization helpers bridging plain Scala values and Typesafe Config values:
+
+- `HoconConfigExtension.withAnyRefValue(path, value)` (`:27`) — an implicit extension that sets a value, recursing into
+  `Seq`/`Map`, and skips the write when a scalar is unchanged (avoiding needless dirtying).
+- `createHoconValue(value)` (`:39`) — recursively converts Scala `Seq`/`Map`/scalars into `ConfigValue`s via
+  `ConfigValueFactory`.
+
+### Exceptions
+
+- `ConfigException` (`config/.../ConfigException.scala:22`) — base `RuntimeException` for HOCON configuration errors.
+- `ConfigPropertyException` (`config/.../ConfigPropertyException.scala:26`) — subclass for a single bad property,
+  carrying the HOCON `propertyPath` and a human-readable requirement message.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Per `build.sbt`, `appConfig` depends only on the `common` module (for `PlatformUtils`, `parseUrlOrPath`, and the
+`Locking` concurrency trait) plus the external `ficus` library (over Typesafe Config). It has no other application-module
+dependencies, keeping it near the bottom of the layered architecture.
+
+It is depended on by the `app` module, which constructs and queries the `MainConfigManager` during startup.
+
+```
+app
+└── appConfig (config/)
+    └── common
+```
+
+## Future / planned changes
+
+- **macOS-only platform support.** `defaultConfigFile` and `CoreConfig.defaultLibraryBaseUrl` both throw a
+  `RuntimeException("Only Mac platform is currently supported")` on non-Mac platforms, and `PlatformUtils.isMac` is
+  hardcoded to `true`. Cross-platform config-path resolution is an open area.
+- **Single config section.** Only the `core` section exists today. The `SubConfigManager` / `Configured` machinery is
+  built to grow: additional settings sections are expected to be added as new `Configured` case classes with their own
+  `SubConfigManager`s.

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,0 +1,20 @@
+# Data flow
+
+How a composition file becomes tuning MIDI messages, end to end:
+
+```
+JSON composition file
+  → DefaultCompositionRepo (format module)
+  → Composition
+  → TuningList.fromComposition()   (applies TuningMapper, TuningReducer, fill)
+  → TuningSession.tunings
+  → TuningIndexUpdatedEvent (via Businessync)
+  → TrackManager → Track.tune()
+  → TunerProcessor → Tuner
+  → MTS/MPE MIDI messages
+  → MIDI output device
+```
+
+> **More detail:** the threading model behind this flow is documented in [`businessync/`](businessync/README.md);
+> serialization in [`format/`](format/README.md); the startup wiring that builds this pipeline in
+> [`app/`](app/README.md).

--- a/docs/architecture/domain-concepts.md
+++ b/docs/architecture/domain-concepts.md
@@ -1,0 +1,47 @@
+# Key domain concepts
+
+The core domain vocabulary of Microtonalist, grouped by the module that owns each type. This is the high-level model the
+rest of the architecture docs assume; each module's own README in this directory goes deeper.
+
+**Intonation (`intonation` module, `org.calinburloiu.music.intonation`):**
+
+- `Interval` (sealed trait) — musical interval, base for `RatioInterval`, `CentsInterval`, `EdoInterval`,
+  `RealInterval`; all support arithmetic in logarithmic space and conversion to cents
+- `Scale[I <: Interval]` — ordered sequence of intervals with direction that represent a musical scale, with helper
+  methods for things like relative intervals, softness (entropy) etc.
+- `IntonationStandard` — enum-like sealed trait describing how intervals are expressed (`CentsIntonationStandard`,
+  `JustIntonationStandard`, `EdoIntonationStandard`)
+
+**Composition (`composition` module, `org.calinburloiu.music.microtonalist.composition`):**
+
+- `Composition` — top-level container that models a microtonal musical composition with respect to its microtonal
+  scales and how are mapped to tunings: holds an `IntonationStandard`, a `TuningReference`, a sequence of
+  `TuningSpec`, a `TuningReducer`, and fill configuration
+- `TuningMapper` (trait, Plugin) — maps a `Scale` to a `Tuning`, deciding which keyboard pitch class each scale pitch
+  occupies (unused keys stay `None`) and throwing a `TuningMapperConflictException` when two pitches collide on one key;
+  `AutoTuningMapper` places pitches automatically (handling quarter tones and the soft chromatic genus),
+  `ManualTuningMapper` uses a user-provided `KeyboardMapping`
+- `TuningReducer` (trait, Plugin) — merges the per-`TuningSpec` `Tuning`s into ideally fewer final tunings to minimize
+  the tuning switches a player must make, producing the `TuningList`; `MergeTuningReducer` (default) merges consecutive
+  non-conflicting tunings and applies local back-/fore-fill, while `DirectTuningReducer` applies only the global fill
+  (no reduction)
+- `TuningReference` (trait, Plugin) — defines the composition's base pitch: the keyboard pitch class it maps to
+  (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`;
+  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch
+  frequency
+- `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
+- `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
+
+**Tuner (`tuner` module, `org.calinburloiu.music.microtonalist.tuner`):**
+
+- `Tuning` — 12 optional cent offsets for pitch classes; `Tuning.Standard` is 12-EDO
+- `Tuner` (trait, Plugin) — processes MIDI messages: `reset()`, `tune(tuning)`, `process(message)`; implementations
+  cover all MTS Octave variants, MPE, and monophonic tuning via Pitch Bend
+- `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages (e.g.,
+  `PedalTuningChanger`)
+- `Track` — one instrument pipeline: input device → `TuningChangeProcessor` → `TunerProcessor` → output device
+- `TuningSession` / `TuningService` — holds current tuning index and exposes thread-safe API for changing it
+- `TrackManager` — lifecycle manager for tracks; reacts to MIDI device events
+
+**Plugin pattern:** `Tuner`, `TuningMapper`, `TuningReducer`, `TuningReference`, and `TuningChanger` all extend
+`Plugin` (from `common`). Each plugin has a `familyName` and `typeName` used for JSON (de)serialization via Play JSON.

--- a/docs/architecture/experiments/README.md
+++ b/docs/architecture/experiments/README.md
@@ -9,29 +9,15 @@ is throwaway, has no tests, and may be added to, rewritten, or deleted freely as
 
 ## Key types
 
-- `SoftChromaticGenusStudy`
-  (`experiments/src/main/scala/org/calinburloiu/music/microtonalist/experiments/SoftChromaticGenusStudy.scala:22`) —
-  a study of "soft chromatic" Hicaz-style tetrachords. The class
-  (`SoftChromaticGenusStudy.scala:22`) defines a few candidate `RatiosScale`s, a list of "good" EDOs, and helpers
-  (`printStruct`, `printStructForAllEdos`) that print each scale's intervals, its relative intervals, and threshold
-  checks (quarter-tone and augmented-second cutoffs). The companion object
-  (`SoftChromaticGenusStudy.scala:65`) extends `App` and is the executable entry point; it prints the studies first in
-  just intonation, then converted to each EDO.
-
-This single study is currently the entire module. New studies are added as additional `App`-style entry points.
+`SoftChromaticGenusStudy` — a study of "soft chromatic" Hicaz-style tetrachords. The class defines a few candidate
+`RatiosScale`s, a list of "good" EDOs, and helpers that print each scale's intervals, its relative intervals, and
+quarter-tone / augmented-second threshold checks; its companion `object` extends `App` and is the executable entry
+point, printing the studies first in just intonation and then converted to each EDO. This single study is currently the
+whole module; new studies are added as additional `App`-style entry points.
 
 ## Dependencies
 
-Per `build.sbt` (the `experiments` project), the module declares one application dependency:
-
-```scala
-lazy val experiments = (project in file("experiments"))
-  .dependsOn(
-    intonation,
-  )
-```
-
-It uses `intonation` types such as `RatiosScale`, `Scale`, `Interval`, `EdoIntonationStandard`, and the `RatioInterval`
-infix operators. Nothing depends on `experiments`, and it is **not** part of the `root` aggregate (`build.sbt:29-42`),
-so `root` build/test tasks skip it — you build or run it explicitly. Its `assembly` main class is
-`SoftChromaticGenusStudy`.
+The module declares one application dependency, `intonation`, using types such as `RatiosScale`, `Scale`, `Interval`,
+`EdoIntonationStandard`, and the `RatioInterval` infix operators. Nothing depends on `experiments`, and it is **not**
+part of the `root` aggregate, so `root` build/test tasks skip it — build or run it explicitly. Its `assembly` main class
+is `SoftChromaticGenusStudy`.

--- a/docs/architecture/experiments/README.md
+++ b/docs/architecture/experiments/README.md
@@ -32,5 +32,6 @@ lazy val experiments = (project in file("experiments"))
 ```
 
 It uses `intonation` types such as `RatiosScale`, `Scale`, `Interval`, `EdoIntonationStandard`, and the `RatioInterval`
-infix operators. Nothing depends on `experiments`; the `root` project aggregates it but no module builds on it. Its
-`assembly` main class is `SoftChromaticGenusStudy`.
+infix operators. Nothing depends on `experiments`, and it is **not** part of the `root` aggregate (`build.sbt:29-42`),
+so `root` build/test tasks skip it — you build or run it explicitly. Its `assembly` main class is
+`SoftChromaticGenusStudy`.

--- a/docs/architecture/experiments/README.md
+++ b/docs/architecture/experiments/README.md
@@ -1,17 +1,36 @@
 # `experiments` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `experiments` module (`experiments/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+`experiments` is a separate, standalone executable used for research and experimentation — not part of the shipped
+Microtonalist app. It hosts ad-hoc intonation studies that explore musical questions (e.g. how scales behave across
+intonation standards) by computing and printing results to stdout. The code here is exploratory and non-production: it
+is throwaway, has no tests, and may be added to, rewritten, or deleted freely as investigations come and go.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+- `SoftChromaticGenusStudy`
+  (`experiments/src/main/scala/org/calinburloiu/music/microtonalist/experiments/SoftChromaticGenusStudy.scala:22`) —
+  a study of "soft chromatic" Hicaz-style tetrachords. The class
+  (`SoftChromaticGenusStudy.scala:22`) defines a few candidate `RatiosScale`s, a list of "good" EDOs, and helpers
+  (`printStruct`, `printStructForAllEdos`) that print each scale's intervals, its relative intervals, and threshold
+  checks (quarter-tone and augmented-second cutoffs). The companion object
+  (`SoftChromaticGenusStudy.scala:65`) extends `App` and is the executable entry point; it prints the studies first in
+  just intonation, then converted to each EDO.
+
+This single study is currently the entire module. New studies are added as additional `App`-style entry points.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Per `build.sbt` (the `experiments` project), the module declares one application dependency:
+
+```scala
+lazy val experiments = (project in file("experiments"))
+  .dependsOn(
+    intonation,
+  )
+```
+
+It uses `intonation` types such as `RatiosScale`, `Scale`, `Interval`, `EdoIntonationStandard`, and the `RatioInterval`
+infix operators. Nothing depends on `experiments`; the `root` project aggregates it but no module builds on it. Its
+`assembly` main class is `SoftChromaticGenusStudy`.

--- a/docs/architecture/format/README.md
+++ b/docs/architecture/format/README.md
@@ -3,166 +3,88 @@
 ## Responsibility
 
 The `format` module is responsible for **all file I/O of persistable domain objects** in Microtonalist. It reads (and,
-where implemented, writes) compositions, scales, and tracks files from local files, HTTP(S) endpoints, and the user's
-Microtonalist scale/track library, translating between on-disk byte streams and the in-memory domain model.
+where implemented, writes) compositions, scales, and tracks from local files, HTTP(S) endpoints, and the user's
+Microtonalist library, translating between on-disk byte streams and the in-memory domain model.
 
-Everything lives in the package `org.calinburloiu.music.microtonalist.format`. The encoding is almost always JSON via
-[Play JSON](https://github.com/playframework/play-json); the one non-JSON encoder is the Huygens-Fokker `.scl` reader.
-
-The module is currently **read-oriented**: read paths are fully implemented, while most write paths are stubbed with
-`???` (see [Future / planned changes](#future--planned-changes)).
+Everything lives in package `org.calinburloiu.music.microtonalist.format`. The encoding is almost always JSON via [Play
+JSON](https://github.com/playframework/play-json); the one non-JSON encoder is the Huygens-Fokker `.scl` reader. The
+module is currently **read-oriented** — read paths are fully implemented while most write paths are stubbed (see [Future
+/ planned changes](#future--planned-changes)).
 
 ## The `*Format` / `*Repo` pattern
 
 Each kind of persistable domain object is handled by a pair of collaborating abstractions that separate _how_ a value is
 encoded from _where_ it is stored:
 
-- A **`*Format`** does pure serialization/deserialization between a byte stream (`InputStream`/`OutputStream`) and a
-  domain object. It knows the encoding but nothing about the data source.
+- A **`*Format`** does pure serialization/deserialization between a byte stream and a domain object. It knows the
+  encoding but nothing about the data source.
 - A **`*Repo`** follows the repository pattern: it retrieves and persists a domain object identified by a `URI`,
-  abstracting the underlying data source (local file, HTTP, library). Each repo exposes synchronous and asynchronous
-  `read`/`write` methods and delegates the actual encoding/decoding to the matching `*Format`.
+  abstracting the underlying source (local file, HTTP, library) and delegating the actual encoding to the matching
+  `*Format`.
 
-This split keeps encoding logic source-agnostic and storage logic encoding-agnostic, so a new data source only requires
-a new `*Repo` (not a new `*Format`), and a new on-disk encoding only requires a new `*Format`.
+This keeps encoding logic source-agnostic and storage logic encoding-agnostic: a new data source needs only a new
+`*Repo`, and a new on-disk encoding needs only a new `*Format`. Both traits expose a synchronous variant and a `…Async`
+variant returning a `Future`; the async form is primary (scales are loaded concurrently — see [Deferred
+reads](#deferred-reads)), and the synchronous methods are typically thin `Await.result` wrappers over it.
 
-### Why both sync and async
+Three families follow the pattern, one per persistable object:
 
-Repo and format traits each expose a synchronous variant and a `…Async` variant returning a `Future`. The async form
-is primary: scales referenced from a composition are loaded concurrently (see [Deferred reads](#deferred-reads)), the
-synchronous methods are typically thin `Await.result(…, synchronousAwaitTimeout)` wrappers over the async ones
-(e.g. `JsonCompositionFormat.read` at
-`format/src/main/scala/org/calinburloiu/music/microtonalist/format/JsonCompositionFormat.scala:47`). The timeout
-defaults to one minute and is threaded through `FormatModule`.
+| Extension         | Domain object  | Format                          | Encoding |
+| ----------------- | -------------- | ------------------------------- | -------- |
+| `.mtlist`         | `Composition`  | `JsonCompositionFormat`         | Microtonalist JSON |
+| `.jscl` / `.json` | `Scale`        | `JsonScaleFormat`               | Microtonalist JSON scale |
+| `.scl`            | `Scale`        | `HuygensFokkerScalaScaleFormat` | Huygens-Fokker [Scala](https://www.huygens-fokker.org/scala/) text (read-only) |
+| `.mtlist.tracks`  | `TrackSpecs`   | `JsonTrackFormat`               | Microtonalist JSON tracks file |
 
-## Key types
+Each has a `Default*Repo` that dispatches by URI scheme to source-specific `File*Repo` / `Http*Repo` / `Library*Repo`
+variants. Two wrinkles are worth knowing:
 
-### Composition (`.mtlist`)
-
-- `CompositionFormat` — trait; (de)serializes a `Composition` to/from a stream.
-  `format/.../CompositionFormat.scala:28`
-- `JsonCompositionFormat` — the JSON implementation; parses an intermediate `CompositionRepr`, resolves deferred
-  scales, then maps the representation to the domain `Composition`. `format/.../JsonCompositionFormat.scala:39`
-- `CompositionRepr` (+ `TuningSpecRepr`, `FillSpecRepr`, `LocalFillSpecRepr`, `CompositionFormatContext`) — DTO-like
-  representation types that mirror the JSON shape before conversion to domain objects.
-  `format/.../CompositionRepr.scala`
-- `CompositionRepo` — trait; `read`/`readAsync`/`write`/`writeAsync` by `URI`. `format/.../CompositionRepo.scala:29`
-- `DefaultCompositionRepo` — dispatches by URI scheme to `FileCompositionRepo` / `HttpCompositionRepo`.
-  `format/.../DefaultCompositionRepo.scala`
-- `FileCompositionRepo`, `HttpCompositionRepo` — source-specific repos delegating to the `CompositionFormat`.
-
-### Scale (`.jscl`, `.json`, `.scl`)
-
-- `ScaleFormat` — trait; (de)serializes a `Scale[Interval]`, taking an optional `ScaleFormatContext` (name +
-  intonation standard) that may supply values omitted from the file. `format/.../ScaleFormat.scala:27`
-- `JsonScaleFormat` — Microtonalist's own JSON scale format (`.jscl` / `.json`). `format/.../JsonScaleFormat.scala:32`
-- `HuygensFokkerScalaScaleFormat` — reader for [Scala application](https://www.huygens-fokker.org/scala/) `.scl` files
-  (read-only; `write` is `???`). `format/.../HuygensFokkerScalaScaleFormat.scala:33`
-- `ScaleFormatRegistry` — selects the right `ScaleFormat` by media type (MIME) or, failing that, by the URI's file
-  extension. `format/.../ScaleFormatRegistry.scala:30`
-- `ScaleFormatMetadata` — declares a format's name, file extensions, and media types for the registry.
-  `format/.../ScaleFormatMetadata.scala:28`
-- `ScaleContextConverter` — applies the `ScaleFormatContext` after a scale is read: renames it and/or converts its
-  intervals to the composition's intonation standard, publishing a `ScaleLossyConversionEvent` via `Businessync` when
-  the conversion loses precision. `format/.../ScaleContextConverter.scala:31`
-- `ScaleRepo` — trait; `read`/`write` (sync + async) by `URI`, with a `ScaleFormatContext` and optional media type.
-  `format/.../ScaleRepo.scala:29`
-- `DefaultScaleRepo` — dispatches by URI scheme and runs the read result through `ScaleContextConverter`.
-  `format/.../DefaultScaleRepo.scala:51`
-- `FileScaleRepo`, `HttpScaleRepo`, `LibraryScaleRepo` — source-specific repos; `LibraryScaleRepo` resolves
-  `microtonalist:` URIs against the configured library base URL, then reuses the file/HTTP repos.
-  `format/.../LibraryScaleRepo.scala:40`
-
-### Tracks (`.mtlist.tracks`)
-
-- `TrackFormat` — trait; (de)serializes `TrackSpecs` (a collection of `TrackSpec`s). `format/.../TrackFormat.scala:32`
-- `JsonTrackFormat` — the JSON implementation. `format/.../JsonTrackFormat.scala:34`
-- `TrackRepo` — the repository trait, which **lives in the `tuner` module**
-  (`tuner/.../tuner/TrackRepo.scala`) because `Track`/`TrackSpecs` are tuner domain types; its formats and concrete
-  repos live here in `format`.
-- `DefaultTrackRepo`, `FileTrackRepo`, `HttpTrackRepo`, `LibraryTrackRepo` — scheme dispatch + source-specific repos,
-  mirroring the scale repos.
-
-### Cross-cutting infrastructure
-
-- `RepoSelector[R]` / `DefaultRepoSelector[R]` — generic URI-scheme-to-repo selector reused by every `Default*Repo`
-  and by `LibraryScaleRepo`. `format/.../RepoSelector.scala:26`, `format/.../DefaultRepoSelector.scala:31`
-- `UriScheme` — the recognised scheme constants: `file`, `http`, `https`, `microtonalist`.
-  `format/.../UriScheme.scala:22`
-- `JsonPreprocessor` (+ `JsonPreprocessorFileRefLoader`, `JsonPreprocessorHttpRefLoader`,
-  `JsonPreprocessorRefLoader`) — resolves `$ref` URIs before parsing. `format/.../JsonPreprocessor.scala:34`
-- `JsonPluginFormat[P]` (+ `JsonPluginFormat.TypeSpec`) — generic Play-JSON (de)serialization of plugin _families_;
-  see [Plugin (de)serialization](#plugin-deserialization). `format/.../JsonPluginFormat.scala:36`
-- `DeferrableRead[V, P]` (`AlreadyRead` / `DeferredRead`) — lazy, async-loadable JSON values; see
-  [Deferred reads](#deferred-reads). `format/.../DeferrableRead.scala:75`
-- `FormatModule` — the composition root that lazily wires every format and repo; inject this rather than constructing
-  components by hand. `format/.../FormatModule.scala:26`
-- Smaller building-block JSON formats reused by the above: `JsonIntervalFormat`, `JsonIntonationStandardPluginFormat`,
-  `KeyboardMappingFormat`, `MidiNoteFormat`, `PitchClassFormat`, `JsonConstraints`, `JsonCommonMidiFormat`, and the
-  `package.scala` helpers (`uint7Format`, `filePathOf`, `resolveBaseUriWithOverride`, `resolveLibraryUrl`).
+- `JsonCompositionFormat` parses an intermediate representation (`CompositionRepr` and friends) that mirrors the JSON
+  shape, resolves deferred scales, then maps it to the domain `Composition`.
+- The scale read path runs results through `ScaleContextConverter`, which applies a `ScaleFormatContext` (renaming
+  and/or converting intervals to the composition's intonation standard) and publishes a `ScaleLossyConversionEvent` via
+  `Businessync` when the conversion loses precision. `ScaleFormatRegistry` picks the right `ScaleFormat` for an external
+  scale by media type, falling back to file extension.
+- `TrackRepo` is the one repository trait that **lives in the `tuner` module** (because `Track`/`TrackSpecs` are tuner
+  domain types); only its formats and concrete repos live here.
 
 ## URI-scheme dispatch
 
 Every `Default*Repo` resolves a `URI` to a concrete source-specific repo via `DefaultRepoSelector`, keyed purely on the
-URI scheme (`format/.../DefaultRepoSelector.scala:37`):
+scheme:
 
-| URI scheme            | Repo selected        | Notes                                                          |
-| --------------------- | -------------------- | -------------------------------------------------------------- |
-| none (relative) or `file` | `File*Repo`      | Repos have no base URI, so relative URIs are treated as files. |
-| `http`, `https`       | `Http*Repo`          | Loaded over HTTP via a shared `java.net.http.HttpClient`.      |
-| `microtonalist`       | `Library*Repo`       | Resolved against the user-configured library base URL.         |
-| anything else         | none → throws        | `IllegalArgumentException` by default.                         |
+| URI scheme                | Repo selected  | Notes |
+| ------------------------- | -------------- | ----- |
+| none (relative) or `file` | `File*Repo`    | Repos have no base URI, so relative URIs are treated as files. |
+| `http`, `https`           | `Http*Repo`    | Loaded over a shared `java.net.http.HttpClient`. |
+| `microtonalist`           | `Library*Repo` | Resolved against the user-configured library base URL. |
+| anything else             | throws         | `IllegalArgumentException` by default. |
 
-Callers are advised to resolve relative URIs against a base URI _before_ calling a repo, so that a relative reference
-inside, say, an HTTP-loaded composition still resolves over HTTP. Base-URI resolution (including the optional
-`baseUrl` override property in a composition file) is handled by `resolveBaseUriWithOverride`
-(`format/.../package.scala:55`).
+Callers should resolve relative URIs against a base URI _before_ calling a repo, so a relative reference inside, say, an
+HTTP-loaded composition still resolves over HTTP. Base-URI resolution (including the optional `baseUrl` override
+property in a composition file) and `microtonalist:` → library-path mapping are handled by package-object helpers
+(`resolveBaseUriWithOverride`, `resolveLibraryUrl`).
 
-`microtonalist:///<path>` URIs are mapped to the configured library base URL by `resolveLibraryUrl`
-(`format/.../package.scala:71`); e.g. with base `file:///Users/john/Music/lib/`, `microtonalist:///scales/lydian.scl`
-resolves to `/Users/john/Music/lib/scales/lydian.scl`. `LibraryScaleRepo`/`LibraryTrackRepo` then delegate the resolved
-URL to their file/HTTP repos.
+## `$ref` preprocessing
 
-## File formats
-
-| Extension         | Domain object  | Format type                    | Encoding                                              |
-| ----------------- | -------------- | ------------------------------ | ----------------------------------------------------- |
-| `.mtlist`         | `Composition`  | `JsonCompositionFormat`        | Microtonalist JSON.                                   |
-| `.jscl` / `.json` | `Scale`        | `JsonScaleFormat`              | Microtonalist JSON scale (`application/vnd.microtonalist.scale+json`). |
-| `.scl`            | `Scale`        | `HuygensFokkerScalaScaleFormat`| Huygens-Fokker Scala text format (ISO-8859-1).        |
-| `.mtlist.tracks`  | `TrackSpecs`   | `JsonTrackFormat`              | Microtonalist JSON tracks file.                       |
-
-A scale referenced from a composition can be **inlined** in the `.mtlist` file or **referenced by URI** to an external
-`.jscl` / `.json` / `.scl` file. The right `ScaleFormat` for an external scale is chosen by `ScaleFormatRegistry`,
-preferring an explicit media type and falling back to the file extension (`format/.../ScaleFormatRegistry.scala:49`).
-
-## `JsonPreprocessor` and `$ref`
-
-Before any JSON is validated into domain types, `JsonPreprocessor.preprocess` walks the parsed tree and replaces every
-object containing a `$ref` string property with the JSON loaded from that URI; properties already present alongside the
-`$ref` override the loaded ones. References are resolved relative to the current base URI, loaded by an ordered list of
-`JsonPreprocessorRefLoader`s (file then HTTP), and guarded against cycles and excessive nesting (max depth 100). The
-no-op `NoJsonPreprocessor` is available for contexts that should not resolve references.
-`format/.../JsonPreprocessor.scala`
+Before any JSON is validated into domain types, `JsonPreprocessor` walks the parsed tree and replaces every object
+carrying a `$ref` string with the JSON loaded from that URI (properties present alongside the `$ref` override the loaded
+ones). References resolve relative to the current base URI, are loaded by an ordered list of ref loaders (file then
+HTTP), and are guarded against cycles and excessive nesting. A no-op `NoJsonPreprocessor` exists for contexts that
+should not resolve references.
 
 ## Plugin (de)serialization
 
 `TuningMapper`, `TuningReducer`, `TuningReference`, `Tuner`, `TuningChanger`, `IntonationStandard`, the track I/O specs,
-and the soft-chromatic-genus mapping are all **plugin families**. Each extends `Plugin` (from `common`) with a
-`familyName` and a `typeName`, and each has a matching `JsonPluginFormat[P]` (e.g. `JsonTuningMapperPluginFormat`,
-`JsonTuningReducerPluginFormat`, `JsonTunerPluginFormat`, `JsonTuningChangerPluginFormat`,
-`JsonTuningReferencePluginFormat`, `JsonIntonationStandardPluginFormat`, `JsonTrackIOPluginFormat`).
+and the soft-chromatic-genus mapping are all **plugin families** (each extends `Plugin` from `common` with a
+`familyName` and `typeName`). Each has a matching `JsonPluginFormat[P]` that handles the whole family:
 
-How `JsonPluginFormat` works (`format/.../JsonPluginFormat.scala`):
-
-- The plugin's concrete _type_ is identified in JSON by a `"type"` property. A family may declare a `defaultTypeName`,
-  letting users omit `"type"` (and even represent a no-settings plugin as a bare type-name string).
-- Each type is described by a `TypeSpec`, which carries the `typeName`, the Java `Class` (used to pick the writer when
-  serializing), and either a Play `Format` for the type's _settings_ or a singleton plugin value for types that have no
-  settings.
-- A composition file may carry a global `settings` block. On read, effective settings are merged as
-  `defaultSettings ++ globalSettings ++ localSettings` (local wins), where the global slice is looked up by
-  `settings → familyName → typeName`. This lets a user set family/type defaults once per file and override them
+- The concrete _type_ is identified in JSON by a `"type"` property; a family may declare a `defaultTypeName`, letting
+  users omit `"type"` (and represent a no-settings plugin as a bare type-name string).
+- Each type is described by a `TypeSpec` carrying the `typeName`, the Java `Class` (to pick the writer), and either a
+  Play `Format` for the type's _settings_ or a singleton value for settings-less types.
+- A composition file may carry a global `settings` block; on read, effective settings are merged as `defaultSettings ++
+  globalSettings ++ localSettings` (local wins), so a user can set family/type defaults once per file and override them
   per usage.
 
 This is why each plugin lives in its domain module but its wire format lives here: `format` owns the JSON contract and
@@ -170,71 +92,39 @@ the settings-merging policy, keeping serialization concerns out of the domain mo
 
 ## Deferred reads
 
-Scales referenced from a composition are not necessarily loaded eagerly. `DeferrableRead[V, P]`
-(`format/.../DeferrableRead.scala`) models a value that is either:
-
-- `AlreadyRead` — inlined in the JSON and immediately available; or
-- `DeferredRead` — represented by a _placeholder_ (typically a `URI`) resolved later by an async `load(loader)` call.
-  `DeferredRead` is thread-safe (read/write-locked), caches its `Future`, and tracks a load `status`.
-
-`JsonCompositionFormat.readAsync` parses the composition into a `CompositionRepr`, calls
-`CompositionRepr.loadDeferredData(scaleRepo)` to load all deferred scales concurrently (with a per-composition cache so
-each distinct scale URI is fetched once), and only then maps the representation to the domain `Composition`. This is the
-main reason the format/repo APIs are async-first.
+Scales referenced from a composition are not necessarily loaded eagerly. `DeferrableRead[V, P]` models a value that is
+either `AlreadyRead` (inlined in the JSON, immediately available) or `DeferredRead` (a placeholder — typically a `URI` —
+resolved later by an async `load(loader)` call; it is thread-safe, caches its `Future`, and tracks a load status).
+`JsonCompositionFormat.readAsync` parses the composition, loads all deferred scales concurrently (with a per-composition
+cache so each distinct scale URI is fetched once), and only then maps to the domain `Composition`. This is the main
+reason the format/repo APIs are async-first.
 
 ## `FormatModule` (wiring)
 
 `FormatModule` is the module's composition root. Construct it with a `Businessync`, the library base URL, and an
 optional synchronous-await timeout; it then exposes lazily-initialised, fully-wired repos and formats. Consumers should
 depend on `FormatModule` and read its `defaultCompositionRepo` / `defaultScaleRepo` / `defaultTrackRepo` rather than
-constructing individual components (`format/.../FormatModule.scala:26`). `MicrotonalistApp` does exactly this:
+constructing individual components. `MicrotonalistApp` does exactly this at startup.
 
-```scala
-val formatModule = new FormatModule(businessync, mainConfigManager.coreConfig.libraryBaseUrl)
-val composition  = formatModule.defaultCompositionRepo.read(inputUrl)
-val tunerModule  = new TunerModule(businessync, formatModule.defaultTrackRepo)
-```
+Smaller building-block JSON formats (`JsonIntervalFormat`, `KeyboardMappingFormat`, `MidiNoteFormat`,
+`PitchClassFormat`, …) and the cross-cutting `RepoSelector` / `UriScheme` helpers round out the module but are reused
+internals rather than its public surface.
 
 ## Dependencies
 
-Per `build.sbt`, the `format` module declares:
+**Depends on** `composition` (the `Composition` model and its plugins this module (de)serializes), `tuner`
+(`TrackSpecs`, the `TrackRepo` trait, and the tuner/tuning-changer plugin families), `common` (the `Plugin` type,
+`Locking`, and shared utilities), and — transitively — `intonation` (`Scale`/`Interval`/`IntonationStandard`) and
+`businessync` (`ScaleContextConverter` publishes `ScaleLossyConversionEvent`). Third-party: Play JSON, Guava, and
+`java.net.http.HttpClient`.
 
-```scala
-lazy val format = (project in file("format"))
-  .dependsOn(
-    common,
-    commonTestUtils % Test,
-    composition,
-    tuner,
-  )
-  // …
-  .settings(libraryDependencies ++= Seq(playJson))
-```
-
-**Depends on:**
-
-- `composition` — the `Composition` domain model and its plugins (`TuningMapper`, `TuningReducer`, `TuningReference`,
-  `TuningSpec`, fill specs) that this module (de)serializes.
-- `tuner` — `TrackSpecs`/`TrackSpec`, the `TrackRepo` trait, and the tuner/tuning-changer plugin families.
-- `intonation` (transitively, via `composition`) — `Scale`, `Interval`, `IntonationStandard`.
-- `common` — the `Plugin` base type, concurrency helpers (`Locking`), and shared utilities.
-- `businessync` (transitively) — `ScaleContextConverter` publishes `ScaleLossyConversionEvent`s.
-- Third-party: Play JSON (encoding), Google Guava (`MediaType`, `Files`), `java.net.http.HttpClient` (HTTP loading).
-
-**Depended on by:**
-
-- `app` — `MicrotonalistApp` constructs a `FormatModule` and uses its default repos to load the composition and tracks
-  at startup.
-
-No module other than `app` depends on `format`; `format` sits in the I/O layer between the domain modules and the
-application entry point.
+**Depended on by** `app` only — `MicrotonalistApp` constructs a `FormatModule` and uses its default repos to load the
+composition and tracks at startup. `format` sits in the I/O layer between the domain modules and the application entry
+point.
 
 ## Future / planned changes
 
-These are signalled directly by the code, not by a specific roadmap issue:
-
-- **Writing is largely unimplemented.** Many `write`/`writeAsync` methods are `???` stubs
-  (`JsonCompositionFormat`, `FileCompositionRepo`, `HttpCompositionRepo`, `FileScaleRepo`, `HttpScaleRepo`,
-  `HuygensFokkerScalaScaleFormat`, `FileTrackRepo`, `HttpTrackRepo`). The read paths and the JSON _writers_ exposed by
-  `JsonScaleFormat`/`JsonTrackFormat` (e.g. `writeAsJsValue`) are implemented; the repo-level persistence plumbing is
-  not yet wired up. Treat write APIs as unstable.
+Signalled directly by the code: **writing is largely unimplemented.** Many `write`/`writeAsync` methods on the
+composition/scale/track repos and on `HuygensFokkerScalaScaleFormat` are `???` stubs. The read paths and the JSON
+_writers_ exposed by `JsonScaleFormat`/`JsonTrackFormat` are implemented; the repo-level persistence plumbing is not yet
+wired up. Treat write APIs as unstable.

--- a/docs/architecture/format/README.md
+++ b/docs/architecture/format/README.md
@@ -1,17 +1,240 @@
 # `format` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `format` module (`format/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+The `format` module is responsible for **all file I/O of persistable domain objects** in Microtonalist. It reads (and,
+where implemented, writes) compositions, scales, and tracks files from local files, HTTP(S) endpoints, and the user's
+Microtonalist scale/track library, translating between on-disk byte streams and the in-memory domain model.
+
+Everything lives in the package `org.calinburloiu.music.microtonalist.format`. The encoding is almost always JSON via
+[Play JSON](https://github.com/playframework/play-json); the one non-JSON encoder is the Huygens-Fokker `.scl` reader.
+
+The module is currently **read-oriented**: read paths are fully implemented, while most write paths are stubbed with
+`???` (see [Future / planned changes](#future--planned-changes)).
+
+## The `*Format` / `*Repo` pattern
+
+Each kind of persistable domain object is handled by a pair of collaborating abstractions that separate _how_ a value is
+encoded from _where_ it is stored:
+
+- A **`*Format`** does pure serialization/deserialization between a byte stream (`InputStream`/`OutputStream`) and a
+  domain object. It knows the encoding but nothing about the data source.
+- A **`*Repo`** follows the repository pattern: it retrieves and persists a domain object identified by a `URI`,
+  abstracting the underlying data source (local file, HTTP, library). Each repo exposes synchronous and asynchronous
+  `read`/`write` methods and delegates the actual encoding/decoding to the matching `*Format`.
+
+This split keeps encoding logic source-agnostic and storage logic encoding-agnostic, so a new data source only requires
+a new `*Repo` (not a new `*Format`), and a new on-disk encoding only requires a new `*Format`.
+
+### Why both sync and async
+
+Repo and format traits each expose a synchronous variant and a `…Async` variant returning a `Future`. The async form
+is primary: scales referenced from a composition are loaded concurrently (see [Deferred reads](#deferred-reads)), the
+synchronous methods are typically thin `Await.result(…, synchronousAwaitTimeout)` wrappers over the async ones
+(e.g. `JsonCompositionFormat.read` at
+`format/src/main/scala/org/calinburloiu/music/microtonalist/format/JsonCompositionFormat.scala:47`). The timeout
+defaults to one minute and is threaded through `FormatModule`.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### Composition (`.mtlist`)
+
+- `CompositionFormat` — trait; (de)serializes a `Composition` to/from a stream.
+  `format/.../CompositionFormat.scala:28`
+- `JsonCompositionFormat` — the JSON implementation; parses an intermediate `CompositionRepr`, resolves deferred
+  scales, then maps the representation to the domain `Composition`. `format/.../JsonCompositionFormat.scala:39`
+- `CompositionRepr` (+ `TuningSpecRepr`, `FillSpecRepr`, `LocalFillSpecRepr`, `CompositionFormatContext`) — DTO-like
+  representation types that mirror the JSON shape before conversion to domain objects.
+  `format/.../CompositionRepr.scala`
+- `CompositionRepo` — trait; `read`/`readAsync`/`write`/`writeAsync` by `URI`. `format/.../CompositionRepo.scala:29`
+- `DefaultCompositionRepo` — dispatches by URI scheme to `FileCompositionRepo` / `HttpCompositionRepo`.
+  `format/.../DefaultCompositionRepo.scala`
+- `FileCompositionRepo`, `HttpCompositionRepo` — source-specific repos delegating to the `CompositionFormat`.
+
+### Scale (`.jscl`, `.json`, `.scl`)
+
+- `ScaleFormat` — trait; (de)serializes a `Scale[Interval]`, taking an optional `ScaleFormatContext` (name +
+  intonation standard) that may supply values omitted from the file. `format/.../ScaleFormat.scala:27`
+- `JsonScaleFormat` — Microtonalist's own JSON scale format (`.jscl` / `.json`). `format/.../JsonScaleFormat.scala:32`
+- `HuygensFokkerScalaScaleFormat` — reader for [Scala application](https://www.huygens-fokker.org/scala/) `.scl` files
+  (read-only; `write` is `???`). `format/.../HuygensFokkerScalaScaleFormat.scala:33`
+- `ScaleFormatRegistry` — selects the right `ScaleFormat` by media type (MIME) or, failing that, by the URI's file
+  extension. `format/.../ScaleFormatRegistry.scala:30`
+- `ScaleFormatMetadata` — declares a format's name, file extensions, and media types for the registry.
+  `format/.../ScaleFormatMetadata.scala:28`
+- `ScaleContextConverter` — applies the `ScaleFormatContext` after a scale is read: renames it and/or converts its
+  intervals to the composition's intonation standard, publishing a `ScaleLossyConversionEvent` via `Businessync` when
+  the conversion loses precision. `format/.../ScaleContextConverter.scala:31`
+- `ScaleRepo` — trait; `read`/`write` (sync + async) by `URI`, with a `ScaleFormatContext` and optional media type.
+  `format/.../ScaleRepo.scala:29`
+- `DefaultScaleRepo` — dispatches by URI scheme and runs the read result through `ScaleContextConverter`.
+  `format/.../DefaultScaleRepo.scala:51`
+- `FileScaleRepo`, `HttpScaleRepo`, `LibraryScaleRepo` — source-specific repos; `LibraryScaleRepo` resolves
+  `microtonalist:` URIs against the configured library base URL, then reuses the file/HTTP repos.
+  `format/.../LibraryScaleRepo.scala:40`
+
+### Tracks (`.mtlist.tracks`)
+
+- `TrackFormat` — trait; (de)serializes `TrackSpecs` (a collection of `TrackSpec`s). `format/.../TrackFormat.scala:32`
+- `JsonTrackFormat` — the JSON implementation. `format/.../JsonTrackFormat.scala:34`
+- `TrackRepo` — the repository trait, which **lives in the `tuner` module**
+  (`tuner/.../tuner/TrackRepo.scala`) because `Track`/`TrackSpecs` are tuner domain types; its formats and concrete
+  repos live here in `format`.
+- `DefaultTrackRepo`, `FileTrackRepo`, `HttpTrackRepo`, `LibraryTrackRepo` — scheme dispatch + source-specific repos,
+  mirroring the scale repos.
+
+### Cross-cutting infrastructure
+
+- `RepoSelector[R]` / `DefaultRepoSelector[R]` — generic URI-scheme-to-repo selector reused by every `Default*Repo`
+  and by `LibraryScaleRepo`. `format/.../RepoSelector.scala:26`, `format/.../DefaultRepoSelector.scala:31`
+- `UriScheme` — the recognised scheme constants: `file`, `http`, `https`, `microtonalist`.
+  `format/.../UriScheme.scala:22`
+- `JsonPreprocessor` (+ `JsonPreprocessorFileRefLoader`, `JsonPreprocessorHttpRefLoader`,
+  `JsonPreprocessorRefLoader`) — resolves `$ref` URIs before parsing. `format/.../JsonPreprocessor.scala:34`
+- `JsonPluginFormat[P]` (+ `JsonPluginFormat.TypeSpec`) — generic Play-JSON (de)serialization of plugin _families_;
+  see [Plugin (de)serialization](#plugin-deserialization). `format/.../JsonPluginFormat.scala:36`
+- `DeferrableRead[V, P]` (`AlreadyRead` / `DeferredRead`) — lazy, async-loadable JSON values; see
+  [Deferred reads](#deferred-reads). `format/.../DeferrableRead.scala:75`
+- `FormatModule` — the composition root that lazily wires every format and repo; inject this rather than constructing
+  components by hand. `format/.../FormatModule.scala:26`
+- Smaller building-block JSON formats reused by the above: `JsonIntervalFormat`, `JsonIntonationStandardPluginFormat`,
+  `KeyboardMappingFormat`, `MidiNoteFormat`, `PitchClassFormat`, `JsonConstraints`, `JsonCommonMidiFormat`, and the
+  `package.scala` helpers (`uint7Format`, `filePathOf`, `resolveBaseUriWithOverride`, `resolveLibraryUrl`).
+
+## URI-scheme dispatch
+
+Every `Default*Repo` resolves a `URI` to a concrete source-specific repo via `DefaultRepoSelector`, keyed purely on the
+URI scheme (`format/.../DefaultRepoSelector.scala:37`):
+
+| URI scheme            | Repo selected        | Notes                                                          |
+| --------------------- | -------------------- | -------------------------------------------------------------- |
+| none (relative) or `file` | `File*Repo`      | Repos have no base URI, so relative URIs are treated as files. |
+| `http`, `https`       | `Http*Repo`          | Loaded over HTTP via a shared `java.net.http.HttpClient`.      |
+| `microtonalist`       | `Library*Repo`       | Resolved against the user-configured library base URL.         |
+| anything else         | none → throws        | `IllegalArgumentException` by default.                         |
+
+Callers are advised to resolve relative URIs against a base URI _before_ calling a repo, so that a relative reference
+inside, say, an HTTP-loaded composition still resolves over HTTP. Base-URI resolution (including the optional
+`baseUrl` override property in a composition file) is handled by `resolveBaseUriWithOverride`
+(`format/.../package.scala:55`).
+
+`microtonalist:///<path>` URIs are mapped to the configured library base URL by `resolveLibraryUrl`
+(`format/.../package.scala:71`); e.g. with base `file:///Users/john/Music/lib/`, `microtonalist:///scales/lydian.scl`
+resolves to `/Users/john/Music/lib/scales/lydian.scl`. `LibraryScaleRepo`/`LibraryTrackRepo` then delegate the resolved
+URL to their file/HTTP repos.
+
+## File formats
+
+| Extension         | Domain object  | Format type                    | Encoding                                              |
+| ----------------- | -------------- | ------------------------------ | ----------------------------------------------------- |
+| `.mtlist`         | `Composition`  | `JsonCompositionFormat`        | Microtonalist JSON.                                   |
+| `.jscl` / `.json` | `Scale`        | `JsonScaleFormat`              | Microtonalist JSON scale (`application/vnd.microtonalist.scale+json`). |
+| `.scl`            | `Scale`        | `HuygensFokkerScalaScaleFormat`| Huygens-Fokker Scala text format (ISO-8859-1).        |
+| `.mtlist.tracks`  | `TrackSpecs`   | `JsonTrackFormat`              | Microtonalist JSON tracks file.                       |
+
+A scale referenced from a composition can be **inlined** in the `.mtlist` file or **referenced by URI** to an external
+`.jscl` / `.json` / `.scl` file. The right `ScaleFormat` for an external scale is chosen by `ScaleFormatRegistry`,
+preferring an explicit media type and falling back to the file extension (`format/.../ScaleFormatRegistry.scala:49`).
+
+## `JsonPreprocessor` and `$ref`
+
+Before any JSON is validated into domain types, `JsonPreprocessor.preprocess` walks the parsed tree and replaces every
+object containing a `$ref` string property with the JSON loaded from that URI; properties already present alongside the
+`$ref` override the loaded ones. References are resolved relative to the current base URI, loaded by an ordered list of
+`JsonPreprocessorRefLoader`s (file then HTTP), and guarded against cycles and excessive nesting (max depth 100). The
+no-op `NoJsonPreprocessor` is available for contexts that should not resolve references.
+`format/.../JsonPreprocessor.scala`
+
+## Plugin (de)serialization
+
+`TuningMapper`, `TuningReducer`, `TuningReference`, `Tuner`, `TuningChanger`, `IntonationStandard`, the track I/O specs,
+and the soft-chromatic-genus mapping are all **plugin families**. Each extends `Plugin` (from `common`) with a
+`familyName` and a `typeName`, and each has a matching `JsonPluginFormat[P]` (e.g. `JsonTuningMapperPluginFormat`,
+`JsonTuningReducerPluginFormat`, `JsonTunerPluginFormat`, `JsonTuningChangerPluginFormat`,
+`JsonTuningReferencePluginFormat`, `JsonIntonationStandardPluginFormat`, `JsonTrackIOPluginFormat`).
+
+How `JsonPluginFormat` works (`format/.../JsonPluginFormat.scala`):
+
+- The plugin's concrete _type_ is identified in JSON by a `"type"` property. A family may declare a `defaultTypeName`,
+  letting users omit `"type"` (and even represent a no-settings plugin as a bare type-name string).
+- Each type is described by a `TypeSpec`, which carries the `typeName`, the Java `Class` (used to pick the writer when
+  serializing), and either a Play `Format` for the type's _settings_ or a singleton plugin value for types that have no
+  settings.
+- A composition file may carry a global `settings` block. On read, effective settings are merged as
+  `defaultSettings ++ globalSettings ++ localSettings` (local wins), where the global slice is looked up by
+  `settings → familyName → typeName`. This lets a user set family/type defaults once per file and override them
+  per usage.
+
+This is why each plugin lives in its domain module but its wire format lives here: `format` owns the JSON contract and
+the settings-merging policy, keeping serialization concerns out of the domain modules.
+
+## Deferred reads
+
+Scales referenced from a composition are not necessarily loaded eagerly. `DeferrableRead[V, P]`
+(`format/.../DeferrableRead.scala`) models a value that is either:
+
+- `AlreadyRead` — inlined in the JSON and immediately available; or
+- `DeferredRead` — represented by a _placeholder_ (typically a `URI`) resolved later by an async `load(loader)` call.
+  `DeferredRead` is thread-safe (read/write-locked), caches its `Future`, and tracks a load `status`.
+
+`JsonCompositionFormat.readAsync` parses the composition into a `CompositionRepr`, calls
+`CompositionRepr.loadDeferredData(scaleRepo)` to load all deferred scales concurrently (with a per-composition cache so
+each distinct scale URI is fetched once), and only then maps the representation to the domain `Composition`. This is the
+main reason the format/repo APIs are async-first.
+
+## `FormatModule` (wiring)
+
+`FormatModule` is the module's composition root. Construct it with a `Businessync`, the library base URL, and an
+optional synchronous-await timeout; it then exposes lazily-initialised, fully-wired repos and formats. Consumers should
+depend on `FormatModule` and read its `defaultCompositionRepo` / `defaultScaleRepo` / `defaultTrackRepo` rather than
+constructing individual components (`format/.../FormatModule.scala:26`). `MicrotonalistApp` does exactly this:
+
+```scala
+val formatModule = new FormatModule(businessync, mainConfigManager.coreConfig.libraryBaseUrl)
+val composition  = formatModule.defaultCompositionRepo.read(inputUrl)
+val tunerModule  = new TunerModule(businessync, formatModule.defaultTrackRepo)
+```
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Per `build.sbt`, the `format` module declares:
+
+```scala
+lazy val format = (project in file("format"))
+  .dependsOn(
+    common,
+    commonTestUtils % Test,
+    composition,
+    tuner,
+  )
+  // …
+  .settings(libraryDependencies ++= Seq(playJson))
+```
+
+**Depends on:**
+
+- `composition` — the `Composition` domain model and its plugins (`TuningMapper`, `TuningReducer`, `TuningReference`,
+  `TuningSpec`, fill specs) that this module (de)serializes.
+- `tuner` — `TrackSpecs`/`TrackSpec`, the `TrackRepo` trait, and the tuner/tuning-changer plugin families.
+- `intonation` (transitively, via `composition`) — `Scale`, `Interval`, `IntonationStandard`.
+- `common` — the `Plugin` base type, concurrency helpers (`Locking`), and shared utilities.
+- `businessync` (transitively) — `ScaleContextConverter` publishes `ScaleLossyConversionEvent`s.
+- Third-party: Play JSON (encoding), Google Guava (`MediaType`, `Files`), `java.net.http.HttpClient` (HTTP loading).
+
+**Depended on by:**
+
+- `app` — `MicrotonalistApp` constructs a `FormatModule` and uses its default repos to load the composition and tracks
+  at startup.
+
+No module other than `app` depends on `format`; `format` sits in the I/O layer between the domain modules and the
+application entry point.
+
+## Future / planned changes
+
+These are signalled directly by the code, not by a specific roadmap issue:
+
+- **Writing is largely unimplemented.** Many `write`/`writeAsync` methods are `???` stubs
+  (`JsonCompositionFormat`, `FileCompositionRepo`, `HttpCompositionRepo`, `FileScaleRepo`, `HttpScaleRepo`,
+  `HuygensFokkerScalaScaleFormat`, `FileTrackRepo`, `HttpTrackRepo`). The read paths and the JSON _writers_ exposed by
+  `JsonScaleFormat`/`JsonTrackFormat` (e.g. `writeAsJsValue`) are implemented; the repo-level persistence plumbing is
+  not yet wired up. Treat write APIs as unstable.

--- a/docs/architecture/format/README.md
+++ b/docs/architecture/format/README.md
@@ -75,9 +75,11 @@ should not resolve references.
 
 ## Plugin (de)serialization
 
-`TuningMapper`, `TuningReducer`, `TuningReference`, `Tuner`, `TuningChanger`, `IntonationStandard`, the track I/O specs,
-and the soft-chromatic-genus mapping are all **plugin families** (each extends `Plugin` from `common` with a
-`familyName` and `typeName`). Each has a matching `JsonPluginFormat[P]` that handles the whole family:
+`TuningMapper`, `TuningReducer`, `TuningReference`, `Tuner`, `TuningChanger`, the track I/O specs, and the
+soft-chromatic-genus mapping are all **plugin families** — each extends `Plugin` from `common` with a `familyName` and
+`typeName`. `IntonationStandard` is not a `Plugin` (it lives in `intonation`, which has no `common` dependency) but is
+handled by the same machinery, its `JsonPluginFormat` supplying the `familyName` and keying concrete standards by
+`typeName`. Each family has a matching `JsonPluginFormat[P]` that handles the whole family:
 
 - The concrete _type_ is identified in JSON by a `"type"` property; a family may declare a `defaultTypeName`, letting
   users omit `"type"` (and represent a no-settings plugin as a bare type-name string).

--- a/docs/architecture/format/README.md
+++ b/docs/architecture/format/README.md
@@ -4,12 +4,12 @@
 
 The `format` module is responsible for **all file I/O of persistable domain objects** in Microtonalist. It reads (and,
 where implemented, writes) compositions, scales, and tracks from local files, HTTP(S) endpoints, and the user's
-Microtonalist library, translating between on-disk byte streams and the in-memory domain model.
+Microtonalist library, translating between on-disk/network byte streams and the in-memory domain model.
 
 Everything lives in package `org.calinburloiu.music.microtonalist.format`. The encoding is almost always JSON via [Play
 JSON](https://github.com/playframework/play-json); the one non-JSON encoder is the Huygens-Fokker `.scl` reader. The
-module is currently **read-oriented** — read paths are fully implemented while most write paths are stubbed (see [Future
-/ planned changes](#future--planned-changes)).
+module is currently mostly **read-oriented** — read paths are fully implemented while most write paths are stubbed (see
+[Future / planned changes](#future--planned-changes)).
 
 ## The `*Format` / `*Repo` pattern
 
@@ -23,8 +23,8 @@ encoded from _where_ it is stored:
   `*Format`.
 
 This keeps encoding logic source-agnostic and storage logic encoding-agnostic: a new data source needs only a new
-`*Repo`, and a new on-disk encoding needs only a new `*Format`. Both traits expose a synchronous variant and a `…Async`
-variant returning a `Future`; the async form is primary (scales are loaded concurrently — see [Deferred
+`*Repo`, and a new encoding needs only a new `*Format`. Both traits expose a synchronous variant and a `…Async` variant
+returning a `Future`; the async form is primary (scales are loaded concurrently — see [Deferred
 reads](#deferred-reads)), and the synchronous methods are typically thin `Await.result` wrappers over it.
 
 Three families follow the pattern, one per persistable object:
@@ -82,7 +82,7 @@ handled by the same machinery, its `JsonPluginFormat` supplying the `familyName`
 `typeName`. Each family has a matching `JsonPluginFormat[P]` that handles the whole family:
 
 - The concrete _type_ is identified in JSON by a `"type"` property; a family may declare a `defaultTypeName`, letting
-  users omit `"type"` (and represent a no-settings plugin as a bare type-name string).
+  users omit `"type"`, and represent a no-settings plugin as a bare type-name string.
 - Each type is described by a `TypeSpec` carrying the `typeName`, the Java `Class` (to pick the writer), and either a
   Play `Format` for the type's _settings_ or a singleton value for settings-less types.
 - A composition file may carry a global `settings` block; on read, effective settings are merged as `defaultSettings ++

--- a/docs/architecture/intonation/README.md
+++ b/docs/architecture/intonation/README.md
@@ -32,8 +32,8 @@ interval and exposes:
 - `cents: Double` — the interval in cents (default derives from `realValue`).
 - Logarithmic-space arithmetic: `+`, `-` (`Interval.scala:82`, `:90`), `*(n: Int)` (repeated addition), `invert`
   (octave complement), `reverse` (flip direction).
-- Octave handling: `isNormalized`, `normalize`, `normalizationFactor` / `normalizationLogFactor` — fold an interval into
-  `[unison, octave)`.
+- Octave handling: `isNormalized`, `normalize`, `normalizationFactor` / `normalizationLogFactor` — fold an interval
+  into `[unison, octave)`.
 - `isUnison`, `intonationStandard`, and converters `toRealInterval`, `toCentsInterval`, `toEdoInterval(edo)`.
 
 Four concrete subtypes (sealed — the set is closed), each a `case class`:
@@ -49,7 +49,8 @@ Mixed-type arithmetic follows fixed promotion rules (documented on the trait, `I
 
 - any interval combined with a `CentsInterval` yields a `CentsInterval`;
 - otherwise a `RealInterval` results, except that two same-type non-cents intervals stay in their own type (e.g.
-  `RatioInterval + RatioInterval = RatioInterval`, with GCD reduction; `EdoInterval + EdoInterval` requires equal `edo`).
+  `RatioInterval + RatioInterval = RatioInterval`, with GCD reduction; `EdoInterval + EdoInterval` requires equal
+  `edo`).
 
 Companion objects add convenience and DSL helpers:
 
@@ -70,8 +71,8 @@ sorted ascending or descending). Notable members:
 
 - `apply(index)`, `size`, `range`, `direction` (1 ascending / -1 descending / 0 single element).
 - `relativeIntervals` (`:62`) — the steps between adjacent intervals.
-- `entropy(logBase)` and `softness` (`:84`, `:102`) — an entropy-based measure of how evenly spaced a scale's steps are;
-  the softest n-note scale (equal steps) has `softness == 1`, harder scales approach 0.
+- `entropy(logBase)` and `softness` (`:84`, `:102`) — an entropy-based measure of how evenly spaced a scale's steps
+  are; the softest n-note scale (equal steps) has `softness == 1`, harder scales approach 0.
 - `transpose`, `rename`, `indexOfUnison`, `almostEquals(that, centsTolerance)` (cent-tolerant comparison), and
   value-based `equals`/`hashCode`.
 - `intonationStandard: Option[IntonationStandard]` (`:111`) — `Some` only if all intervals share one standard.
@@ -102,7 +103,7 @@ Each provides a `unison` interval and `conversionQualityTo(that)` (`:35`), which
 conversion. Conversion to cents is always lossless; conversion to just intonation is impossible (you cannot recover a
 ratio from cents/EDO); EDO-to-EDO is lossless when the target EDO is a multiple of the source, otherwise lossy.
 
-### `IntonationConversionQuality` (`intonation/src/main/scala/org/calinburloiu/music/intonation/IntonationConversionQuality.scala`)
+### `IntonationConversionQuality` (`intonation/.../IntonationConversionQuality.scala`)
 
 A Scala 3 `enum` (`IntonationConversionQuality.scala:22`) ranking a conversion, ordered by ordinal from best to worst:
 `NoConversion`, `Lossless`, `Lossy`, `Impossible`. `Scale.convertToIntonationStandard` takes the maximum (worst)
@@ -120,10 +121,11 @@ The package object holds the unit-conversion math shared across the module:
 
 ### Supporting registries (sub-packages)
 
-- `intervals.SagittalInterval` (`intonation/src/main/scala/org/calinburloiu/music/intonation/intervals/SagittalInterval.scala`)
-  — a registry of named just-intonation comma/diesis constants (schismas, kleismas, commas, dieses) as `RatioInterval`s.
+- `intervals.SagittalInterval` (`intonation/.../intervals/SagittalInterval.scala`)
+  — a registry of named just-intonation comma/diesis constants (schismas, kleismas, commas, dieses) as
+  `RatioInterval`s.
   It contains no logic and is excluded from coverage in `build.sbt`.
-- `instruments.StringInstrumentModel` (`intonation/src/main/scala/org/calinburloiu/music/intonation/instruments/StringInstrumentModel.scala`)
+- `instruments.StringInstrumentModel` (`intonation/.../instruments/StringInstrumentModel.scala`)
   — computes fret placement (`fretSize`) on a string of a given length from intervals; a small, standalone utility.
 
 ## Interval arithmetic in logarithmic / cents space

--- a/docs/architecture/intonation/README.md
+++ b/docs/architecture/intonation/README.md
@@ -4,170 +4,102 @@
 
 The `intonation` module is the lowest-level domain module of Microtonalist. It provides the pure mathematics of
 microtonal pitch: musical **intervals**, **scales** built from them, and the **intonation standards** that describe how
-those intervals are expressed (cents, just-intonation ratios, or EDO divisions). It also exposes a set of free functions
-for converting between cents, frequency ratios, EDO counts, and frequencies in Hz.
+those intervals are expressed (cents, just-intonation ratios, or EDO divisions). It also exposes free functions for
+converting between cents, frequency ratios, EDO counts, and frequencies in Hz.
 
 Its role in the layered architecture:
 
-- It sits at the bottom of the domain stack and has **no application dependencies** — it does not know about MIDI,
+- It sits at the bottom of the domain stack and has **no application dependencies** — it knows nothing about MIDI,
   tunings, compositions, file formats, the GUI, or threading. It is reusable, side-effect-free value math.
-- Higher modules build on it: `composition` models a microtonal piece in terms of `Scale`s and `IntonationStandard`s,
-  and `format` (de)serializes those scales; `tuner` ultimately consumes the resulting cent offsets. See
-  [Dependencies](#dependencies).
+- Higher modules build on it: `composition` models a piece in terms of `Scale`s and `IntonationStandard`s, `format`
+  (de)serializes scales, and `tuner` ultimately consumes the resulting cent offsets.
 
-Everything here is expressed in the **musical logarithmic space** (where an octave is a doubling of frequency and
-intervals add/subtract rather than multiply/divide). The public API of `Interval` performs all arithmetic in that space;
+Everything here is expressed in **musical logarithmic space** (where an octave is a doubling of frequency and intervals
+add/subtract rather than multiply/divide). The public API of `Interval` performs all arithmetic in that space;
 frequency-ratio multiplication is an internal detail.
 
 Package: `org.calinburloiu.music.intonation` (sub-packages `.intervals` and `.instruments`).
 
 ## Key types
 
-### `Interval` and its subtypes (`intonation/src/main/scala/org/calinburloiu/music/intonation/Interval.scala`)
+### `Interval`
 
-`Interval` (`Interval.scala:41`) is a `sealed trait` extending `Ordered[Interval]`. It models a single musical
-interval and exposes:
+`Interval` is a `sealed trait` (extending `Ordered[Interval]`) modelling a single musical interval. It exposes
+`realValue` (decimal frequency ratio) and `cents`, logarithmic-space arithmetic (`+`, `-`, `*(n)`, `invert`, `reverse`),
+octave handling (`normalize` and friends, folding an interval into `[unison, octave)`), and converters to the concrete
+subtypes. The four concrete subtypes form a closed set:
 
-- `realValue: Double` — the interval as a decimal frequency ratio.
-- `cents: Double` — the interval in cents (default derives from `realValue`).
-- Logarithmic-space arithmetic: `+`, `-` (`Interval.scala:82`, `:90`), `*(n: Int)` (repeated addition), `invert`
-  (octave complement), `reverse` (flip direction).
-- Octave handling: `isNormalized`, `normalize`, `normalizationFactor` / `normalizationLogFactor` — fold an interval
-  into `[unison, octave)`.
-- `isUnison`, `intonationStandard`, and converters `toRealInterval`, `toCentsInterval`, `toEdoInterval(edo)`.
+| Subtype | Representation | Use | `intonationStandard` |
+| ------- | -------------- | --- | -------------------- |
+| `RatioInterval` | Just-intonation fraction | Exact ratios; cannot express temperaments | `JustIntonationStandard` |
+| `CentsInterval` | Decimal cents | Approximates anything; allows fractions of a cent | `CentsIntonationStandard` |
+| `EdoInterval` | `count` steps of an EDO | Exact within an EDO; integer steps only | `EdoIntonationStandard(edo)` |
+| `RealInterval` | Generic decimal ratio | Most generic fallback; no JI/EDO precision | `CentsIntonationStandard` |
 
-Four concrete subtypes (sealed — the set is closed), each a `case class`:
+Mixed-type arithmetic follows fixed promotion rules documented on the trait: anything combined with a `CentsInterval`
+yields a `CentsInterval`; otherwise the result is a `RealInterval`, except that two same-type non-cents intervals stay
+in their own type (`RatioInterval + RatioInterval` reduces by GCD; `EdoInterval + EdoInterval` requires equal `edo`).
 
-| Type | Representation | Precision / use | `intonationStandard` |
-| ---- | -------------- | --------------- | -------------------- |
-| `RatioInterval(numerator, denominator)` (`:250`) | Just-intonation fraction | Exact ratios; cannot express temperaments | `JustIntonationStandard` |
-| `CentsInterval(cents)` (`:372`) | Decimal cents | Approximates anything; allows fractions of a cent | `CentsIntonationStandard` |
-| `EdoInterval(edo, count)` (`:459`) | `count` steps of an `edo`-equal division of the octave | Exact within an EDO; integer steps only | `EdoIntonationStandard(edo)` |
-| `RealInterval(realValue)` (`:177`) | Generic decimal ratio | Most generic fallback; no JI/EDO precision | `CentsIntonationStandard` |
+The companions add DSL helpers used across the codebase — `Unison`/`Octave` constants, the right-associative `/:` ratio
+operator (e.g. `3 /: 2` is a perfect fifth), the postfix `.cents` operator on `Double`, and `EdoIntervalFactory(edo)`.
+`Interval.fromRatioString` / `fromScalaTuningInterval` parse Scala-app `.scl` interval syntax.
 
-Mixed-type arithmetic follows fixed promotion rules (documented on the trait, `Interval.scala:25`):
+### `Scale`
 
-- any interval combined with a `CentsInterval` yields a `CentsInterval`;
-- otherwise a `RealInterval` results, except that two same-type non-cents intervals stay in their own type (e.g.
-  `RatioInterval + RatioInterval = RatioInterval`, with GCD reduction; `EdoInterval + EdoInterval` requires equal
-  `edo`).
+`Scale[+I <: Interval]` is an ordered, non-empty, covariant sequence of intervals validated to be sorted (ascending or
+descending). Beyond sequence access it offers `relativeIntervals` (steps between adjacent intervals), an entropy-based
+`softness` measure (equal-step scales score 1, harder scales approach 0), cent-tolerant comparison (`almostEquals`), and
+conversion: `intonationStandard` is `Some` only when all intervals share one standard, and `convertToIntonationStandard`
+returns a `ScaleConversionResult` (the converted scale plus the worst-case `IntonationConversionQuality`).
 
-Companion objects add convenience and DSL helpers:
-
-- `RatioInterval` (`:333`): `Unison`/`Octave` constants, an implicit `(Int, Int) => RatioInterval`, the
-  right-associative `/:` infix operator (e.g. `3 /: 2` is a perfect fifth), and `harmonicSeriesOf(...)`.
-- `CentsInterval` (`:439`): `Unison`/`Octave` and the postfix `.cent` / `.cents` operators on `Double`.
-- `RealInterval` (`:237`) and `EdoInterval` (`:544`): `Unison`/`Octave` (`unisonFor`/`octaveFor` for EDO), plus an
-  `EdoInterval.apply(edo, countRelativeToStandard)` that expresses a count relative to the nearest 12-EDO semitone;
-  `EdoInterval.countRelativeToStandard` is the inverse (`Interval.scala:535`).
-- `EdoIntervalFactory(edo)` (`:583`) — a small factory that fixes `edo` so callers only supply `count`.
-- `Interval.fromRatioString` / `Interval.fromScalaTuningInterval` (`:135`, `:159`) — parse Scala-app `.scl` interval
-  syntax (an integer/fraction is a ratio; a number with a dot is cents).
-
-### `Scale` and its subtypes (`intonation/src/main/scala/org/calinburloiu/music/intonation/Scale.scala`)
-
-`Scale[+I <: Interval]` (`Scale.scala:23`) is an ordered, non-empty, covariant sequence of intervals (validated to be
-sorted ascending or descending). Notable members:
-
-- `apply(index)`, `size`, `range`, `direction` (1 ascending / -1 descending / 0 single element).
-- `relativeIntervals` (`:62`) — the steps between adjacent intervals.
-- `entropy(logBase)` and `softness` (`:84`, `:102`) — an entropy-based measure of how evenly spaced a scale's steps
-  are; the softest n-note scale (equal steps) has `softness == 1`, harder scales approach 0.
-- `transpose`, `rename`, `indexOfUnison`, `almostEquals(that, centsTolerance)` (cent-tolerant comparison), and
-  value-based `equals`/`hashCode`.
-- `intonationStandard: Option[IntonationStandard]` (`:111`) — `Some` only if all intervals share one standard.
-- `convertToIntonationStandard(newIntonationStandard)` (`:143`) — returns a `ScaleConversionResult` (the converted
-  `Option[Scale]` plus the worst-case `IntonationConversionQuality`).
-- Predicates `isCentsScale` / `isRatiosScale` / `isEdoScale`.
-
-Typed subtypes (`case class`es) carry a known element type and refine the API (e.g. typed `transpose`, a definite
-`intonationStandard`): `RatiosScale` (`:285`), `CentsScale` (`:318`), `EdoScale` (`:356`, which requires all intervals
-to share the same `edo` and exposes `edo`). Their companions offer ergonomic varargs constructors (e.g.
-`CentsScale("name", 0.0, 200.0, 400.0)`, `EdoScale("name", edo, counts...)`).
-
-The `Scale` companion (`:216`) is the smart-constructor entry point: `Scale.create(name, intervals)` picks the most
+Typed `case class` subtypes — `RatiosScale`, `CentsScale`, `EdoScale` — carry a known element type, refine the API, and
+offer varargs constructors. The `Scale` companion is the smart-constructor entry point: `Scale.create` picks the most
 specific subtype from the interval types present (falling back to the generic `Scale` over `RealInterval` for mixed
-input), `Scale.create(name, intervals, intonationStandard)` forces a target standard, and `createUnisonScale` builds a
-single-unison scale. The private `processIntervals` ensures a unison is present and sorts the intervals.
+input), ensures a unison is present, and sorts the intervals.
 
-### Intonation standards (`intonation/src/main/scala/org/calinburloiu/music/intonation/IntonationStandard.scala`)
+### Intonation standards
 
-`IntonationStandard` (`IntonationStandard.scala:25`) is a `sealed abstract class` (each carries a `typeName` used for
-JSON serialization in the `format` module) describing how intervals are expressed:
+`IntonationStandard` is a `sealed abstract class` describing how intervals are expressed — `CentsIntonationStandard`,
+`JustIntonationStandard`, `EdoIntonationStandard(countPerOctave)` — each carrying a `typeName` used for JSON
+serialization in `format`. Its `conversionQualityTo(that)` classifies a standard-to-standard conversion: conversion to
+cents is always lossless; conversion to just intonation is impossible (a ratio cannot be recovered from cents/EDO);
+EDO-to-EDO is lossless only when the target EDO is a multiple of the source. The result is an
+`IntonationConversionQuality` enum (`NoConversion` < `Lossless` < `Lossy` < `Impossible`), and a whole-scale conversion
+takes the worst per-interval value.
 
-- `CentsIntonationStandard` (`typeName = "cents"`),
-- `JustIntonationStandard` (`typeName = "justIntonation"`),
-- `EdoIntonationStandard(countPerOctave)` (`typeName = "edo"`).
+### Free functions and supporting registries
 
-Each provides a `unison` interval and `conversionQualityTo(that)` (`:35`), which classifies a standard-to-standard
-conversion. Conversion to cents is always lossless; conversion to just intonation is impossible (you cannot recover a
-ratio from cents/EDO); EDO-to-EDO is lossless when the target EDO is a multiple of the source, otherwise lossy.
-
-### `IntonationConversionQuality` (`intonation/.../IntonationConversionQuality.scala`)
-
-A Scala 3 `enum` (`IntonationConversionQuality.scala:22`) ranking a conversion, ordered by ordinal from best to worst:
-`NoConversion`, `Lossless`, `Lossy`, `Impossible`. `Scale.convertToIntonationStandard` takes the maximum (worst)
-per-interval ordinal to score a whole-scale conversion.
-
-### Free functions and constants (`intonation/src/main/scala/org/calinburloiu/music/intonation/package.scala`)
-
-The package object holds the unit-conversion math shared across the module:
-
-- `ConcertPitchFreq = 440.0` Hz (A4).
-- Cents/ratio/EDO conversions: `fromRealValueToCents`, `fromRatioToCents`, `fromEdoToCents`, `fromCentsToRealValue`,
-  `fromEdoToRealValue`.
-- Frequency conversions: `fromCentsToHz`, `fromHzToCents`.
-- Numeric helpers: `mod` (always-non-negative modulus), `gcd`, `lcm` over integer sequences.
-
-### Supporting registries (sub-packages)
-
-- `intervals.SagittalInterval` (`intonation/.../intervals/SagittalInterval.scala`)
-  — a registry of named just-intonation comma/diesis constants (schismas, kleismas, commas, dieses) as
-  `RatioInterval`s.
-  It contains no logic and is excluded from coverage in `build.sbt`.
-- `instruments.StringInstrumentModel` (`intonation/.../instruments/StringInstrumentModel.scala`)
-  — computes fret placement (`fretSize`) on a string of a given length from intervals; a small, standalone utility.
+The package object holds the shared unit-conversion math (cents/ratio/EDO/Hz conversions such as `fromRatioToCents` and
+`fromCentsToHz`, plus numeric helpers `mod`/`gcd`/`lcm`) and `ConcertPitchFreq = 440.0` Hz. The sub-packages add small
+standalone utilities: `intervals.SagittalInterval` (a registry of named JI comma/diesis constants, no logic) and
+`instruments.StringInstrumentModel` (fret placement on a string).
 
 ## Interval arithmetic in logarithmic / cents space
 
 A few conventions are worth internalizing before working in this module:
 
-- **Addition is musical, not arithmetic on ratios.** `a + b` means "stack interval `b` on top of `a`", which is
-  multiplication of frequency ratios — but the public API hides that: callers always think additively in log space.
-  `*(n)` repeats an interval `n` times.
+- **Addition is musical, not arithmetic on ratios.** `a + b` means "stack interval `b` on top of `a`" — multiplication
+  of frequency ratios — but the public API hides that, so callers always think additively in log space.
 - **Type promotion is deliberate.** Cents is the universal lossy fallback; combining anything with cents stays in cents.
-  Same-type non-cents combinations stay precise (ratios reduce by GCD; EDO requires matching `edo`). Cross-type
-  non-cents combinations fall back to `RealInterval`. This mirrors the `IntonationStandard.conversionQualityTo` lattice.
-- **`CentsInterval` is not 1200-EDO.** Cents allow fractional values; `EdoInterval(1200, n)` only allows integer steps.
-- **Normalization** folds an interval into one octave `[unison, octave)`; `invert` (octave complement) requires a
-  normalized interval and will throw otherwise.
-- **`EdoInterval` and 12-EDO.** `countRelativeToStandard` / `EdoInterval(edo, (semitones, offset))` let callers reason
-  about an EDO step as "the nearest 12-EDO semitone plus an offset", which is how tunings relate microtonal pitches back
-  to the familiar 12-note keyboard.
+  Same-type non-cents combinations stay precise; cross-type non-cents combinations fall back to `RealInterval`. This
+  mirrors the `IntonationStandard.conversionQualityTo` lattice.
+- **`CentsInterval` is not 1200-EDO.** Cents allow fractional values; `EdoInterval(1200, n)` allows only integer steps.
+- **`EdoInterval` and 12-EDO.** Expressing an EDO step relative to the nearest 12-EDO semitone (plus an offset) is how
+  tunings relate microtonal pitches back to the familiar 12-note keyboard.
 
 ## Dependencies
 
-Verified against `build.sbt` (the `intonation` project block at `build.sbt:204`).
+`intonation` has **no `dependsOn`** — by design, it is the foundation of the domain stack. Externally it uses Guava
+(log/GCD/EDO math and index checks) plus the project-wide common dependencies (logging and, in `Test` scope,
+ScalaTest/ScalaMock).
 
-**Upstream (what `intonation` depends on):**
-
-- No other Microtonalist modules — `intonation` has no `dependsOn`, by design (it is the foundation of the domain
-  stack).
-- External libraries: **Guava** (`com.google.common.math.{DoubleMath, IntMath}`, `com.google.common.base.Preconditions`)
-  for log/GCD/EDO math and index checks, plus the project-wide `commonDependencies` (Logback, scala-logging, and
-  ScalaTest/ScalaMock in `Test` scope).
-
-**Downstream (what depends on `intonation`):**
-
-- `composition` (`dependsOn(intonation, tuner)`) — models compositions in terms of `Scale` and `IntonationStandard`.
-- `experiments` (`dependsOn(intonation)`) — research executables (e.g. the soft-chromatic-genus study) over scales.
-- `app` (lists `intonation` among its direct `dependsOn`).
-- Transitively, `format`, `tuner`, and `ui` reach `intonation` through `composition`.
+It is depended on by `composition` (models compositions in terms of `Scale`/`IntonationStandard`), `experiments`
+(research executables over scales), and `app` directly; `format`, `tuner`, and `ui` reach it transitively through
+`composition`.
 
 ## Notes / subject to change
 
-- The `Scale` family mixes a covariant generic base (`Scale[+I]`) with concrete `case class` subtypes and uses
-  `asInstanceOf` casts internally (e.g. in `relativeIntervals` and `processIntervals`) to preserve element types; treat
-  the typed subtypes as the supported public surface.
-- `SagittalInterval` is currently a flat constant registry (no Sagittal notation parsing/rendering yet); it is excluded
+- The `Scale` family mixes a covariant generic base (`Scale[+I]`) with concrete `case class` subtypes and uses internal
+  `asInstanceOf` casts to preserve element types; treat the typed subtypes as the supported public surface.
+- `SagittalInterval` is currently a flat constant registry (no Sagittal notation parsing/rendering yet) and is excluded
   from coverage.

--- a/docs/architecture/intonation/README.md
+++ b/docs/architecture/intonation/README.md
@@ -1,17 +1,171 @@
 # `intonation` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `intonation` module (`intonation/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+The `intonation` module is the lowest-level domain module of Microtonalist. It provides the pure mathematics of
+microtonal pitch: musical **intervals**, **scales** built from them, and the **intonation standards** that describe how
+those intervals are expressed (cents, just-intonation ratios, or EDO divisions). It also exposes a set of free functions
+for converting between cents, frequency ratios, EDO counts, and frequencies in Hz.
+
+Its role in the layered architecture:
+
+- It sits at the bottom of the domain stack and has **no application dependencies** — it does not know about MIDI,
+  tunings, compositions, file formats, the GUI, or threading. It is reusable, side-effect-free value math.
+- Higher modules build on it: `composition` models a microtonal piece in terms of `Scale`s and `IntonationStandard`s,
+  and `format` (de)serializes those scales; `tuner` ultimately consumes the resulting cent offsets. See
+  [Dependencies](#dependencies).
+
+Everything here is expressed in the **musical logarithmic space** (where an octave is a doubling of frequency and
+intervals add/subtract rather than multiply/divide). The public API of `Interval` performs all arithmetic in that space;
+frequency-ratio multiplication is an internal detail.
+
+Package: `org.calinburloiu.music.intonation` (sub-packages `.intervals` and `.instruments`).
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### `Interval` and its subtypes (`intonation/src/main/scala/org/calinburloiu/music/intonation/Interval.scala`)
+
+`Interval` (`Interval.scala:41`) is a `sealed trait` extending `Ordered[Interval]`. It models a single musical
+interval and exposes:
+
+- `realValue: Double` — the interval as a decimal frequency ratio.
+- `cents: Double` — the interval in cents (default derives from `realValue`).
+- Logarithmic-space arithmetic: `+`, `-` (`Interval.scala:82`, `:90`), `*(n: Int)` (repeated addition), `invert`
+  (octave complement), `reverse` (flip direction).
+- Octave handling: `isNormalized`, `normalize`, `normalizationFactor` / `normalizationLogFactor` — fold an interval into
+  `[unison, octave)`.
+- `isUnison`, `intonationStandard`, and converters `toRealInterval`, `toCentsInterval`, `toEdoInterval(edo)`.
+
+Four concrete subtypes (sealed — the set is closed), each a `case class`:
+
+| Type | Representation | Precision / use | `intonationStandard` |
+| ---- | -------------- | --------------- | -------------------- |
+| `RatioInterval(numerator, denominator)` (`:250`) | Just-intonation fraction | Exact ratios; cannot express temperaments | `JustIntonationStandard` |
+| `CentsInterval(cents)` (`:372`) | Decimal cents | Approximates anything; allows fractions of a cent | `CentsIntonationStandard` |
+| `EdoInterval(edo, count)` (`:459`) | `count` steps of an `edo`-equal division of the octave | Exact within an EDO; integer steps only | `EdoIntonationStandard(edo)` |
+| `RealInterval(realValue)` (`:177`) | Generic decimal ratio | Most generic fallback; no JI/EDO precision | `CentsIntonationStandard` |
+
+Mixed-type arithmetic follows fixed promotion rules (documented on the trait, `Interval.scala:25`):
+
+- any interval combined with a `CentsInterval` yields a `CentsInterval`;
+- otherwise a `RealInterval` results, except that two same-type non-cents intervals stay in their own type (e.g.
+  `RatioInterval + RatioInterval = RatioInterval`, with GCD reduction; `EdoInterval + EdoInterval` requires equal `edo`).
+
+Companion objects add convenience and DSL helpers:
+
+- `RatioInterval` (`:333`): `Unison`/`Octave` constants, an implicit `(Int, Int) => RatioInterval`, the
+  right-associative `/:` infix operator (e.g. `3 /: 2` is a perfect fifth), and `harmonicSeriesOf(...)`.
+- `CentsInterval` (`:439`): `Unison`/`Octave` and the postfix `.cent` / `.cents` operators on `Double`.
+- `RealInterval` (`:237`) and `EdoInterval` (`:544`): `Unison`/`Octave` (`unisonFor`/`octaveFor` for EDO), plus an
+  `EdoInterval.apply(edo, countRelativeToStandard)` that expresses a count relative to the nearest 12-EDO semitone;
+  `EdoInterval.countRelativeToStandard` is the inverse (`Interval.scala:535`).
+- `EdoIntervalFactory(edo)` (`:583`) — a small factory that fixes `edo` so callers only supply `count`.
+- `Interval.fromRatioString` / `Interval.fromScalaTuningInterval` (`:135`, `:159`) — parse Scala-app `.scl` interval
+  syntax (an integer/fraction is a ratio; a number with a dot is cents).
+
+### `Scale` and its subtypes (`intonation/src/main/scala/org/calinburloiu/music/intonation/Scale.scala`)
+
+`Scale[+I <: Interval]` (`Scale.scala:23`) is an ordered, non-empty, covariant sequence of intervals (validated to be
+sorted ascending or descending). Notable members:
+
+- `apply(index)`, `size`, `range`, `direction` (1 ascending / -1 descending / 0 single element).
+- `relativeIntervals` (`:62`) — the steps between adjacent intervals.
+- `entropy(logBase)` and `softness` (`:84`, `:102`) — an entropy-based measure of how evenly spaced a scale's steps are;
+  the softest n-note scale (equal steps) has `softness == 1`, harder scales approach 0.
+- `transpose`, `rename`, `indexOfUnison`, `almostEquals(that, centsTolerance)` (cent-tolerant comparison), and
+  value-based `equals`/`hashCode`.
+- `intonationStandard: Option[IntonationStandard]` (`:111`) — `Some` only if all intervals share one standard.
+- `convertToIntonationStandard(newIntonationStandard)` (`:143`) — returns a `ScaleConversionResult` (the converted
+  `Option[Scale]` plus the worst-case `IntonationConversionQuality`).
+- Predicates `isCentsScale` / `isRatiosScale` / `isEdoScale`.
+
+Typed subtypes (`case class`es) carry a known element type and refine the API (e.g. typed `transpose`, a definite
+`intonationStandard`): `RatiosScale` (`:285`), `CentsScale` (`:318`), `EdoScale` (`:356`, which requires all intervals
+to share the same `edo` and exposes `edo`). Their companions offer ergonomic varargs constructors (e.g.
+`CentsScale("name", 0.0, 200.0, 400.0)`, `EdoScale("name", edo, counts...)`).
+
+The `Scale` companion (`:216`) is the smart-constructor entry point: `Scale.create(name, intervals)` picks the most
+specific subtype from the interval types present (falling back to the generic `Scale` over `RealInterval` for mixed
+input), `Scale.create(name, intervals, intonationStandard)` forces a target standard, and `createUnisonScale` builds a
+single-unison scale. The private `processIntervals` ensures a unison is present and sorts the intervals.
+
+### Intonation standards (`intonation/src/main/scala/org/calinburloiu/music/intonation/IntonationStandard.scala`)
+
+`IntonationStandard` (`IntonationStandard.scala:25`) is a `sealed abstract class` (each carries a `typeName` used for
+JSON serialization in the `format` module) describing how intervals are expressed:
+
+- `CentsIntonationStandard` (`typeName = "cents"`),
+- `JustIntonationStandard` (`typeName = "justIntonation"`),
+- `EdoIntonationStandard(countPerOctave)` (`typeName = "edo"`).
+
+Each provides a `unison` interval and `conversionQualityTo(that)` (`:35`), which classifies a standard-to-standard
+conversion. Conversion to cents is always lossless; conversion to just intonation is impossible (you cannot recover a
+ratio from cents/EDO); EDO-to-EDO is lossless when the target EDO is a multiple of the source, otherwise lossy.
+
+### `IntonationConversionQuality` (`intonation/src/main/scala/org/calinburloiu/music/intonation/IntonationConversionQuality.scala`)
+
+A Scala 3 `enum` (`IntonationConversionQuality.scala:22`) ranking a conversion, ordered by ordinal from best to worst:
+`NoConversion`, `Lossless`, `Lossy`, `Impossible`. `Scale.convertToIntonationStandard` takes the maximum (worst)
+per-interval ordinal to score a whole-scale conversion.
+
+### Free functions and constants (`intonation/src/main/scala/org/calinburloiu/music/intonation/package.scala`)
+
+The package object holds the unit-conversion math shared across the module:
+
+- `ConcertPitchFreq = 440.0` Hz (A4).
+- Cents/ratio/EDO conversions: `fromRealValueToCents`, `fromRatioToCents`, `fromEdoToCents`, `fromCentsToRealValue`,
+  `fromEdoToRealValue`.
+- Frequency conversions: `fromCentsToHz`, `fromHzToCents`.
+- Numeric helpers: `mod` (always-non-negative modulus), `gcd`, `lcm` over integer sequences.
+
+### Supporting registries (sub-packages)
+
+- `intervals.SagittalInterval` (`intonation/src/main/scala/org/calinburloiu/music/intonation/intervals/SagittalInterval.scala`)
+  — a registry of named just-intonation comma/diesis constants (schismas, kleismas, commas, dieses) as `RatioInterval`s.
+  It contains no logic and is excluded from coverage in `build.sbt`.
+- `instruments.StringInstrumentModel` (`intonation/src/main/scala/org/calinburloiu/music/intonation/instruments/StringInstrumentModel.scala`)
+  — computes fret placement (`fretSize`) on a string of a given length from intervals; a small, standalone utility.
+
+## Interval arithmetic in logarithmic / cents space
+
+A few conventions are worth internalizing before working in this module:
+
+- **Addition is musical, not arithmetic on ratios.** `a + b` means "stack interval `b` on top of `a`", which is
+  multiplication of frequency ratios — but the public API hides that: callers always think additively in log space.
+  `*(n)` repeats an interval `n` times.
+- **Type promotion is deliberate.** Cents is the universal lossy fallback; combining anything with cents stays in cents.
+  Same-type non-cents combinations stay precise (ratios reduce by GCD; EDO requires matching `edo`). Cross-type
+  non-cents combinations fall back to `RealInterval`. This mirrors the `IntonationStandard.conversionQualityTo` lattice.
+- **`CentsInterval` is not 1200-EDO.** Cents allow fractional values; `EdoInterval(1200, n)` only allows integer steps.
+- **Normalization** folds an interval into one octave `[unison, octave)`; `invert` (octave complement) requires a
+  normalized interval and will throw otherwise.
+- **`EdoInterval` and 12-EDO.** `countRelativeToStandard` / `EdoInterval(edo, (semitones, offset))` let callers reason
+  about an EDO step as "the nearest 12-EDO semitone plus an offset", which is how tunings relate microtonal pitches back
+  to the familiar 12-note keyboard.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Verified against `build.sbt` (the `intonation` project block at `build.sbt:204`).
+
+**Upstream (what `intonation` depends on):**
+
+- No other Microtonalist modules — `intonation` has no `dependsOn`, by design (it is the foundation of the domain
+  stack).
+- External libraries: **Guava** (`com.google.common.math.{DoubleMath, IntMath}`, `com.google.common.base.Preconditions`)
+  for log/GCD/EDO math and index checks, plus the project-wide `commonDependencies` (Logback, scala-logging, and
+  ScalaTest/ScalaMock in `Test` scope).
+
+**Downstream (what depends on `intonation`):**
+
+- `composition` (`dependsOn(intonation, tuner)`) — models compositions in terms of `Scale` and `IntonationStandard`.
+- `experiments` (`dependsOn(intonation)`) — research executables (e.g. the soft-chromatic-genus study) over scales.
+- `app` (lists `intonation` among its direct `dependsOn`).
+- Transitively, `format`, `tuner`, and `ui` reach `intonation` through `composition`.
+
+## Notes / subject to change
+
+- The `Scale` family mixes a covariant generic base (`Scale[+I]`) with concrete `case class` subtypes and uses
+  `asInstanceOf` casts internally (e.g. in `relativeIntervals` and `processIntervals`) to preserve element types; treat
+  the typed subtypes as the supported public surface.
+- `SagittalInterval` is currently a flat constant registry (no Sagittal notation parsing/rendering yet); it is excluded
+  from coverage.

--- a/docs/architecture/intonation/README.md
+++ b/docs/architecture/intonation/README.md
@@ -46,11 +46,12 @@ operator (e.g. `3 /: 2` is a perfect fifth), the postfix `.cents` operator on `D
 
 ### `Scale`
 
-`Scale[+I <: Interval]` is an ordered, non-empty, covariant sequence of intervals validated to be sorted (ascending or
-descending). Beyond sequence access it offers `relativeIntervals` (steps between adjacent intervals), an entropy-based
-`softness` measure (equal-step scales score 1, harder scales approach 0), cent-tolerant comparison (`almostEquals`), and
-conversion: `intonationStandard` is `Some` only when all intervals share one standard, and `convertToIntonationStandard`
-returns a `ScaleConversionResult` (the converted scale plus the worst-case `IntonationConversionQuality`).
+`Scale[+I <: Interval]` models a **musical scale**: an ordered, non-empty, covariant sequence of intervals validated to
+be sorted (ascending or descending). Beyond sequence access it offers `relativeIntervals` (steps between adjacent
+intervals), an entropy-based `softness` measure (equal-step scales score 1, harder scales approach 0), cent-tolerant
+comparison (`almostEquals`), and conversion: `intonationStandard` is `Some` only when all intervals share one standard,
+and `convertToIntonationStandard` returns a `ScaleConversionResult` (the converted scale plus the worst-case
+`IntonationConversionQuality`).
 
 Typed `case class` subtypes — `RatiosScale`, `CentsScale`, `EdoScale` — carry a known element type, refine the API, and
 offer varargs constructors. The `Scale` companion is the smart-constructor entry point: `Scale.create` picks the most

--- a/docs/architecture/module-overview.md
+++ b/docs/architecture/module-overview.md
@@ -1,0 +1,19 @@
+# Module overview
+
+The project uses a layered module structure; dependency direction flows from `app` downward:
+
+```
+app
+├── ui            (GUI, depends on tuner)
+├── composition   (domain model, depends on intonation + tuner)
+├── format        (JSON/file I/O, depends on composition + tuner)
+├── tuner         (MIDI tuning, depends on sc-midi + businessync)
+├── sc-midi       (Scala-idiomatic MIDI API, depends on businessync)
+├── intonation    (interval math, no application deps)
+├── businessync   (event bus + threading, no application deps)
+├── common        (shared utilities)
+└── config        (HOCON config, depends on common)
+```
+
+`cli` is a separate executable (a utility tool, e.g. listing MIDI devices) that depends only on `sc-midi`;
+`experiments` is a separate executable for ad-hoc research studies that depends on `intonation`.

--- a/docs/architecture/sc-midi/README.md
+++ b/docs/architecture/sc-midi/README.md
@@ -1,17 +1,295 @@
 # `scMidi` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `scMidi` module (`sc-midi/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
-
 ## Responsibility
 
-TODO: what this module does and why it exists.
+The `scMidi` module (SBT project `scMidi`, directory `sc-midi/`) is a **Scala-idiomatic MIDI API layered over
+`javax.sound.midi`**. The standard Java Sound MIDI API is verbose, mutable, byte-oriented, and awkward on macOS; this
+module wraps it to give the rest of Microtonalist:
+
+- **Device handling** — enumeration, connection tracking, and reference-counted opening/closing of MIDI devices,
+  publishing device lifecycle events on the [Businessync](../businessync/README.md) bus.
+- **An immutable, typed message model** — a sealed `ScMidiMessage` hierarchy of `case class`es with validated,
+  named fields, plus bidirectional converters to/from Java's `MidiMessage`.
+- **MIDI plumbing** — composable receivers/transmitters and a `MidiProcessor` chain that intercepts and rewrites the
+  MIDI stream (the foundation on which the `tuner` module builds its tuning processors).
+- **MIDI domain helpers** — `MidiNote`, `PitchClass`, `PitchBendSensitivity`, CC/RPN/NRPN constants, and a per-channel
+  state tracker.
+
+Its role in the layered architecture:
+
+- It is a low-level infrastructure module. It does **not** know about scales, tunings, compositions, or the GUI; it
+  deals only with MIDI devices and messages.
+- It depends only on `businessync` (for the device-event bus) and `common` (for the `Locking` concurrency helper). See
+  [Dependencies](#dependencies).
+- The `tuner` module builds tuning logic on top of `MidiProcessor` and `MidiManager`, and the `cli` utility uses it to
+  enumerate MIDI devices. `scMidi` is the only Microtonalist module that touches `javax.sound.midi` directly.
+
+Package: `org.calinburloiu.music.scmidi`, with a `message` sub-package
+(`org.calinburloiu.music.scmidi.message`) holding the message model and its converters/constants. macOS support comes
+from the **CoreMIDI4J** library, which replaces the default Java Sound MIDI device provider (see
+[CoreMIDI4J and device naming](#coremidi4j-and-device-naming)).
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### Device handling
+
+#### `MidiManager` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiManager.scala:35`)
+
+The entry point for device discovery and connection. Constructed with a `Businessync`, it is `AutoCloseable` and
+maintains two private `MidiEndpoint` instances — one for inputs, one for outputs — because the Java/CoreMIDI4J API
+exposes a physical bidirectional device as two separate `MidiDevice` instances (input and output) that nonetheless
+share a single `MidiDeviceId`.
+
+- `refresh()` (`:60`) rescans the environment via `CoreMidiDeviceProvider.getMidiDeviceInfo`, diffs against the known
+  set, and updates both endpoints. A `CoreMidiNotification` listener (`:42`) calls `refresh()` automatically whenever
+  the MIDI environment changes (and publishes `MidiEnvironmentChangedEvent`).
+- Per-direction API (mirrored for input and output): `is{Input,Output}Available`, `{input,output}DeviceIds`,
+  `{input,output}DevicesInfo`, `open{Input,Output}(deviceId)`, `openFirstAvailable{Input,Output}(deviceIds)`,
+  `{input,output}DeviceHandleOf`, `{input,output}OpenedDevices`, `close{Input,Output}(deviceId)`.
+- The private nested `MidiManager.MidiEndpoint` (`:169`) holds two `ConcurrentHashMap`s (id → `MidiDevice.Info` for
+  connected devices, id → `MidiDeviceHandle` for opened devices) and is responsible for emitting the connect /
+  disconnect / open / close events as it reconciles state (see [Device lifecycle and events](#device-lifecycle-and-events)).
+
+#### `MidiDeviceHandle` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiDeviceHandle.scala:53`)
+
+A thread-safe (`@ThreadSafe`, `Locking`) handle to a single MIDI device, identified by a `MidiDeviceId`. Created and
+kept up to date by `MidiManager`. A handle can exist for a device that is **not currently connected**; `info` and
+`device` (the underlying `javax.sound.midi.MidiDevice`) are `Option`s that become defined only once the device is
+physically connected.
+
+- Reference-counted lifecycle: `open()` / `close()` track an `openRefCount`; the device opens only on the first `open`
+  and closes on the last `close`. `open()` may be called before the device is connected — the handle moves to
+  `WaitingToOpen` and opens automatically once `onConnect` fires.
+- State machine via the `MidiDeviceHandle.State` enum (`:320`): `Closed`, `Connected`, `WaitingToOpen`, `Open` (each
+  carrying `isConnected` / `isOpen` flags). The companion's ScalaDoc draws the transition diagram.
+- I/O accessors: `receiver: Receiver` (`:261`, a private `HandleReceiver` forwarding to the device's receiver) lets
+  callers **send** to an output device; `multiTransmitter: MultiTransmitter` (`:269`) lets callers **subscribe** to
+  messages from an input device. Both are wired through an internal `MidiSplitter`, so they keep working across
+  reconnects without re-wiring.
+- `endpointType`, `isInputDevice`, `isOutputDevice`, `isConnected`, `isOpen` query capabilities and status.
+- `private[scmidi]` hooks `onConnect(info)` / `onDisconnect()` are driven by `MidiManager`.
+
+#### `MidiDeviceId` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiDeviceId.scala:30`)
+
+Value identifier of a device, a `case class(name, vendor)`. `apply(MidiDevice.Info)` derives one from Java device info;
+`correspondsToInfo` checks the match; `sanitizedName` strips the CoreMIDI4J `"CoreMIDI4J - "` name prefix for display.
+
+#### `MidiEndpointType` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiEndpointType.scala:26`)
+
+`enum` describing input/output capability: `None`, `Input`, `Output`, `InputOutput`. The companion's `apply(isInput,
+isOutput)` builds the right case from two booleans.
+
+#### `MidiEvent` and subtypes (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiEvent.scala:24`)
+
+A sealed `MidiEvent extends BusinessyncEvent` hierarchy — all events `MidiManager` publishes on the Businessync bus. The
+environment event plus matched success/failure pairs for each lifecycle transition:
+
+| Event | Meaning |
+| ----- | ------- |
+| `MidiEnvironmentChangedEvent` (`:34`) | The MIDI environment changed (devices added/removed/reconfigured). |
+| `MidiDeviceConnectedEvent` / `MidiDeviceFailedToConnectEvent(cause)` | A device became available / failed to connect. |
+| `MidiDeviceDisconnectedEvent` / `MidiDeviceFailedToDisconnectEvent(cause)` | A device was removed / failed to disconnect. |
+| `MidiDeviceOpenedEvent` / `MidiDeviceFailedToOpenEvent(cause)` | A device was opened / failed to open. |
+| `MidiDeviceClosedEvent` / `MidiDeviceFailedToCloseEvent(cause)` | A device was closed / failed to close. |
+
+All carry the `MidiDeviceId`; failure variants also carry the causing `Exception`. Note that "connected" means
+*available to the system*, not *opened by the application*.
+
+### MIDI message model (`message` sub-package)
+
+#### `ScMidiMessage` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/ScMidiMessage.scala:32`)
+
+The sealed base trait for the immutable message model — the Scala-idiomatic counterpart to Java's mutable, byte-oriented
+`MidiMessage`/`ShortMessage`. Sub-hierarchies:
+
+- `ChannelScMidiMessage(channel)` (`:40`) — channel voice/mode messages with a validated `channel` (0–15) and a
+  `mapChannel(map)` that returns a same-typed copy with a rewritten channel. Concrete cases: `NoteOnScMidiMessage`,
+  `NoteOffScMidiMessage` (both via abstract `NoteScMidiMessage`), `PolyPressureScMidiMessage`, `CcScMidiMessage`,
+  `ProgramChangeScMidiMessage`, `ChannelPressureScMidiMessage`, and `PitchBendScMidiMessage`.
+- `SysCommonScMidiMessage` (`:54`) — `MidiTimeCodeScMidiMessage`, `SongPositionPointerScMidiMessage`,
+  `SongSelectScMidiMessage`, `TuneRequestScMidiMessage`.
+- `SysRealTimeScMidiMessage` (`:57`) — `TimingClock`, `Start`, `Continue`, `Stop`, `ActiveSensing`, `SystemReset`
+  (all `case object`s).
+- `MetaScMidiMessage` (`:60`) — Standard MIDI File meta events (`SequenceNumber`, the text-bearing family `Text` /
+  `CopyrightNotice` / `TrackName` / `InstrumentName` / `Lyric` / `Marker` / `CuePoint` / `ProgramName` / `DeviceName`,
+  `MidiChannelPrefix`, `MidiPort`, `EndOfTrack`, `SetTempo`, `SmpteOffset`, `TimeSignature`, `KeySignature`,
+  `SequencerSpecific`). Each carries its SMF `MetaType` byte in its companion.
+- `SysExScMidiMessage` (`:376`) — System Exclusive, storing the full byte sequence as an `ArraySeq[Byte]` so
+  `case class` structural equality works.
+- `UnsupportedScMidiMessage` (`:632`) — fallback wrapping raw bytes of any Java message with no dedicated counterpart;
+  it round-trips back to the correct Java type (Short/Sysex/Meta, detected from the status byte).
+
+`PitchBendScMidiMessage` (`:203`) is notable: it normalises Java's two raw LSB/MSB data bytes into a single signed
+14-bit `value` (−8192…8191) and offers cents conversion (`centsFor` / `cents`) against a `PitchBendSensitivity`. Its
+companion holds the byte ↔ value ↔ cents conversion math (`convertDataBytesToValue`, `convertValueToDataBytes`,
+`convertCentsToValue`, `convertValueToCents`, `fromCents`).
+
+#### `JavaMidiConverters` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/JavaMidiConverters.scala:40`)
+
+Bidirectional converters modelled after `scala.jdk.CollectionConverters`. Importing its members enables the extension
+methods `scMessage.asJava` and `javaMessage.asScala`. Both directions dispatch through lookup tables rather than large
+pattern matches: `asJava` keys on the concrete subtype `Class`, `asScala` keys on the MIDI command / status byte
+(short messages) or meta-type byte (meta messages), defaulting to `UnsupportedScMidiMessage`. It also reconstructs
+SMF meta payloads using big-endian and variable-length-quantity (VLQ) helpers.
+
+#### `MidiRequirements` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/MidiRequirements.scala:22`)
+
+Centralised value validation (`require…`) used by message constructors: `requireChannel` (0–15) and
+unsigned/signed bit-width checks (3/4/7/8/14/16/24-bit and signed 14-bit). It defines `MinSigned14BitValue` /
+`MaxSigned14BitValue` (±8192/8191) used by pitch bend.
+
+#### CC / RPN / NRPN constants
+
+- `ScMidiCc` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/ScMidiCc.scala:22`) — Control Change
+  controller numbers: RPN/NRPN MSB/LSB, Data Entry/Increment/Decrement, All Sound/Notes Off, Reset All Controllers,
+  Bank Select, Modulation, Volume, Pan, Expression, the pedals, and `MpeSlide` (#74).
+- `ScMidiRpn` (`.../message/ScMidiRpn.scala:22`) — Registered Parameter Numbers: Null, Pitch Bend Sensitivity,
+  Coarse/Fine Tuning, Tuning Bank/Program Select, and the MPE Configuration Message (MCM).
+- `ScMidiNrpn` (`.../message/ScMidiNrpn.scala:22`) — Null NRPN MSB/LSB (NRPNs are otherwise vendor-specific).
+
+### MIDI plumbing (receivers, transmitters, processors)
+
+#### `MidiSplitter` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiSplitter.scala:27`)
+
+A `Receiver` that fans every incoming message out to a configurable set of receivers, exposed via its `receiver`
+(input) and `multiTransmitter` (output). Used inside `MidiDeviceHandle` to broadcast a device's incoming stream.
+
+#### `MultiTransmitter` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MultiTransmitter.scala:29`)
+
+A thread-safe (`Locking`) transmitter abstraction allowing **multiple** receivers, unlike Java's `Transmitter` which
+permits only one. Manage the set with `receivers` (getter/setter), `addReceiver(s)`, `removeReceiver`, `clearReceivers`.
+
+#### `ScMidiReceiver` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/ScMidiReceiver.scala:28`)
+
+A Scala-idiomatic `AutoCloseable` counterpart of `javax.sound.midi.Receiver` that consumes `ScMidiMessage` directly
+(`send(message, timeStamp = -1L)`), so callers avoid wrapping/unwrapping Java messages. After `close()`, `send` should
+be a no-op.
+
+#### `MidiProcessor` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiProcessor.scala:37`)
+
+A MIDI interceptor that can filter, modify, or synthesise messages as they pass through. It owns a nested
+`MidiProcessorReceiver` (input) and `MidiProcessorTransmitter` (output); subclasses implement the abstract
+`process(message, timeStamp): Seq[MidiMessage]`. It is "connected" once a receiver is set on its transmitter, which
+triggers the `onConnect()` / `onDisconnect()` callbacks (used to leave the downstream device in a consistent state when
+the processor is rewired). The transmitter offers Scala-idiomatic `receiver: Option[Receiver]` getter/setter. This is
+the abstraction the `tuner` module extends to implement tuning of the MIDI stream.
+
+#### `MidiSerialProcessor` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiSerialProcessor.scala:35`)
+
+A `MidiProcessor` that chains a mutable, thread-safe sequence of `MidiProcessor`s end to end, terminating in the
+receiver set on its own transmitter:
+
+```
+MidiProcessor -> MidiProcessor -> ... -> MidiProcessor -> output receiver
+```
+
+It rewires the chain automatically on every mutation: `processors` (get/set), `insert`, `append`, `update`, `remove`,
+`removeAt`, `clear`, `size`. When the chain is empty it simply forwards input to the output receiver.
+
+#### `ScMidiChannelStateTracker` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/ScMidiChannelStateTracker.scala:41`)
+
+A `ScMidiReceiver` (explicitly `@NotThreadSafe`, intended for a single track thread) that derives and exposes
+**per-channel MIDI state** from the messages sent to it: active notes (with velocity and Polyphonic Key Pressure),
+CC values, RPN/NRPN values, Channel Pressure, Pitch Bend, and Program Change. It implements the full RPN/NRPN Data
+Entry / Increment / Decrement protocol and the relevant Channel Mode messages (All Sound/Notes Off, Reset All
+Controllers, modelled per MIDI 1.0 RP-015). Getters fall back through a documented lookup chain (recorded value →
+per-call override → constructor defaults → companion defaults). The companion provides MIDI-1.0 default tables
+(`DefaultCcValues`, `DefaultRpnValues`, empty `DefaultNrpnValues`) and the `RpnSelector` enum (`None` / `Rpn` / `Nrpn`).
+
+### MIDI domain helpers (package object and value types)
+
+#### Package object (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/package.scala`)
+
+- `MidiNote` (`:29`) — a value class over an `Int` note number (0–127), with `pitchClass`, `octave`, `freq` (relative
+  to A4 = 440 Hz), `assertValid()`, and a companion full of named constants (`C4`…`C5`, `ConcertPitch = A4`,
+  `Lowest`/`Highest`) plus `apply(pitchClass, octave)`.
+- `DefaultConcertPitchFreq = 440.0` Hz.
+- `isInputDevice` / `isOutputDevice` (`:84`, `:89`) — capability checks based on a device's max transmitters/receivers.
+- `mapShortMessageChannel` (`:94`) — rewrites the channel of a Java `ShortMessage`/`MidiMessage`.
+- `clampValue` (`:104`) — `Int` and `Double` clamping helpers.
+
+#### `PitchClass` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/PitchClass.scala:22`)
+
+A value class over a pitch-class number (0–11) with named constants (`C`, `CSharp`/`DFlat`, …), display names with
+sharps/flats, an implicit conversion to `Int`, and parsing helpers `fromNumber`, `fromName`, `parse`.
+
+#### `PitchBendSensitivity` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/PitchBendSensitivity.scala:44`)
+
+`case class(semitones, cents = 0)` modelling RPN #0 pitch-bend range, exposing `totalCents`; `Default` is ±2 semitones.
+The accompanying `PitchBendSensitivityMessages.create(channel, sensitivity)` (`:61`) builds the RPN message sequence
+(select Pitch Bend Sensitivity RPN, set Data Entry MSB/LSB, then null the RPN) as Java `MidiMessage`s.
+
+## How MIDI devices are opened, enumerated, and used
+
+1. Construct a single `MidiManager(businessync)`. Its `init()` runs an initial `refresh()` and registers a
+   `CoreMidiNotification` listener so the device list stays current.
+2. Enumerate with `inputDeviceIds` / `outputDeviceIds` (or the `…DevicesInfo` variants). IDs are `MidiDeviceId`s;
+   `sanitizedName` gives a UI-friendly name.
+3. Open a device with `openInput(id)` / `openOutput(id)`, or try a prioritised list with
+   `openFirstAvailable{Input,Output}(ids)` (returns the first that ends up open). Each returns a `MidiDeviceHandle`.
+4. Use the handle: send via `handle.receiver` (outputs) and subscribe via `handle.multiTransmitter` (inputs). Because
+   wiring goes through an internal `MidiSplitter`, it survives disconnect/reconnect cycles.
+5. `closeInput` / `closeOutput` (reference-counted) release a device; `MidiManager.close()` closes everything and
+   removes the notification listener.
+
+A device need not be connected when its handle is opened: `MidiDeviceHandle` enters `WaitingToOpen` and opens
+automatically once the physical device appears.
+
+## Device lifecycle and events
+
+`MidiManager.MidiEndpoint` reconciles the scanned device set against its known state and publishes Businessync events as
+side effects:
+
+- On `refresh()`/`updateDevices`: newly seen devices emit `MidiDeviceConnectedEvent`; vanished devices emit
+  `MidiDeviceDisconnectedEvent`. Any environment change first emits `MidiEnvironmentChangedEvent`.
+- `purgeDisconnectedDevices()` closes and forgets handles whose devices were disconnected, emitting
+  `MidiDeviceClosedEvent`.
+- `openDevice` emits `MidiDeviceOpenedEvent` on success. Failures during connect/disconnect/open/close emit the
+  corresponding `…Failed…Event` carrying the exception (see [`MidiEvent`](#midievent-and-subtypes)).
+
+Consumers (notably the `tuner` module's track lifecycle) subscribe to these events through Businessync rather than
+polling. "Connected" is about system availability; "opened" is about this application actively using the device — they
+are distinct, separately-evented states.
+
+## Message conversion model
+
+The boundary with Java Sound MIDI is the `ScMidiMessage` ↔ `MidiMessage` pair handled by `JavaMidiConverters`:
+
+- Inbound: a device's raw `MidiMessage` is turned into a typed, validated `ScMidiMessage` via `.asScala` (anything
+  unrecognised becomes `UnsupportedScMidiMessage`, never lost).
+- Outbound: an `ScMidiMessage` is rendered to a Java `MidiMessage` via `.asJava` for transmission.
+
+Within `scMidi`, message-producing/processing code prefers the typed model and validated constructors; the raw byte
+layer is confined to the converters and the few places that talk to `javax.sound.midi` directly.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Verified against `build.sbt` (the `scMidi` project block at `build.sbt:217`).
+
+**Upstream (what `scMidi` depends on):**
+
+- `businessync` — the event bus used to publish `MidiEvent`s about device state.
+- `common` — the `Locking` concurrency mixin (`org.calinburloiu.music.microtonalist.common.concurrency.Locking`) used
+  by the thread-safe device/transmitter/processor classes.
+- External library **CoreMIDI4J** (`uk.co.xfactory-librarians % coremidi4j`) for reliable MIDI device enumeration and
+  notifications on macOS (and Windows), plus the project-wide `commonDependencies` (Logback, scala-logging, and
+  ScalaTest/ScalaMock in `Test` scope).
+
+**Downstream (what depends on `scMidi`):**
+
+- `tuner` (`dependsOn(businessync, common, scMidi)`) — builds `MidiProcessor`-based tuning pipelines and uses
+  `MidiManager` for device I/O.
+- `cli` (`dependsOn(scMidi)`) — the standalone utility that, e.g., lists connected MIDI devices.
+- Transitively, `app`, `composition`, `format`, and `ui` reach `scMidi` through `tuner`.
+
+## Notes / subject to change
+
+- Coverage targets are currently below the project-wide 80% goal (`coverageSettings(stmt = 62, branch = 44)`, with
+  **TODO #177** to raise them); device-handling code that requires real MIDI hardware is hard to cover with unit tests.
+- `MidiProcessorReceiver.close()` / `MidiProcessorTransmitter.close()` are intentionally minimal stubs ("Nothing to do
+  for the moment") and may gain real cleanup logic later.
+- The `ScMidiMessage` model is broad (channel voice/mode, system common/real-time, SysEx, and a full set of SMF meta
+  events) even though Microtonalist itself does not yet exercise every meta event; treat the typed model as the
+  supported surface and `UnsupportedScMidiMessage` as the lossless escape hatch.
+</content>
+</invoke>

--- a/docs/architecture/sc-midi/README.md
+++ b/docs/architecture/sc-midi/README.md
@@ -67,7 +67,7 @@ offers cents conversion against a `PitchBendSensitivity`.
 **`JavaMidiConverters`** is the boundary with Java Sound MIDI, modelled after `scala.jdk.CollectionConverters`:
 importing its members enables `scMessage.asJava` / `javaMessage.asScala`. Both directions dispatch through lookup tables
 (by concrete subtype `Class` outbound, by status/meta-type byte inbound) rather than large pattern matches. Value
-validation for message constructors is centralised in `MidiRequirements` (channel and bit-width `require…` checks), and
+validation for message constructors is centralized in `MidiRequirements` (channel and bit-width `require…` checks), and
 the controller/parameter numbers live in `ScMidiCc` / `ScMidiRpn` / `ScMidiNrpn` (including the MPE Configuration
 Message and the MPE Slide CC).
 
@@ -114,19 +114,20 @@ sequence). Smaller helpers (`isInputDevice`/`isOutputDevice`, `mapShortMessageCh
 
 ## Device lifecycle and events
 
-`MidiManager`'s internal endpoints reconcile the scanned device set against known state and publish Businessync events
-as side effects: newly seen devices emit `MidiDeviceConnectedEvent`, vanished ones `MidiDeviceDisconnectedEvent` (with
-`MidiEnvironmentChangedEvent` first), opening emits `MidiDeviceOpenedEvent`, and failures emit the corresponding
-`…Failed…Event` carrying the exception. Consumers (notably the `tuner` track lifecycle) subscribe through Businessync
-rather than polling.
+`MidiManager`'s internal endpoints reconcile the scanned device set against known state on every `refresh()` and
+publish the [`MidiEvent`s](#device-handling) as side effects of that diff: a newly seen device is reported
+*connected*, a vanished one *disconnected* (preceded by `MidiEnvironmentChangedEvent`), opening and closing emit
+*opened*/*closed*, and any failed transition emits the matching `…Failed…Event` carrying the exception. Consumers —
+notably the `tuner` track lifecycle — react by subscribing through Businessync rather than polling.
 
 ## Message conversion model
 
-The boundary with Java Sound MIDI is the `ScMidiMessage` ↔ `MidiMessage` pair handled by `JavaMidiConverters`: inbound,
-a device's raw message becomes a typed, validated `ScMidiMessage` via `.asScala` (anything unrecognised becomes
-`UnsupportedScMidiMessage`, never lost); outbound, an `ScMidiMessage` is rendered via `.asJava`. Within `scMidi`,
-message code prefers the typed model and validated constructors; the raw byte layer is confined to the converters and
-the few places that talk to `javax.sound.midi` directly.
+The `ScMidiMessage` ↔ `MidiMessage` conversion provided by
+[`JavaMidiConverters`](#midi-message-model-message-sub-package) runs in two directions. Inbound, a device's raw
+message becomes a typed, validated `ScMidiMessage` via `.asScala`, with anything unrecognised falling back to
+`UnsupportedScMidiMessage` so nothing is lost; outbound, an `ScMidiMessage` is rendered back to a Java `MidiMessage`
+via `.asJava`. Within `scMidi`, message code prefers the typed model and validated constructors; the raw byte layer
+stays confined to the converters and the few places that talk to `javax.sound.midi` directly.
 
 ## Dependencies
 

--- a/docs/architecture/sc-midi/README.md
+++ b/docs/architecture/sc-midi/README.md
@@ -8,287 +8,139 @@ module wraps it to give the rest of Microtonalist:
 
 - **Device handling** — enumeration, connection tracking, and reference-counted opening/closing of MIDI devices,
   publishing device lifecycle events on the [Businessync](../businessync/README.md) bus.
-- **An immutable, typed message model** — a sealed `ScMidiMessage` hierarchy of `case class`es with validated,
-  named fields, plus bidirectional converters to/from Java's `MidiMessage`.
+- **An immutable, typed message model** — a sealed `ScMidiMessage` hierarchy of `case class`es with validated, named
+  fields, plus bidirectional converters to/from Java's `MidiMessage`.
 - **MIDI plumbing** — composable receivers/transmitters and a `MidiProcessor` chain that intercepts and rewrites the
-  MIDI stream (the foundation on which the `tuner` module builds its tuning processors).
+  MIDI stream (the foundation on which `tuner` builds its tuning processors).
 - **MIDI domain helpers** — `MidiNote`, `PitchClass`, `PitchBendSensitivity`, CC/RPN/NRPN constants, and a per-channel
   state tracker.
 
-Its role in the layered architecture:
+It is low-level infrastructure: it knows nothing about scales, tunings, compositions, or the GUI, and depends only on
+`businessync` (the device-event bus) and `common` (the `Locking` helper). `scMidi` is the only Microtonalist module that
+touches `javax.sound.midi` directly; the `tuner` module builds tuning logic on top of `MidiProcessor`/`MidiManager` and
+the `cli` utility uses it to enumerate devices.
 
-- It is a low-level infrastructure module. It does **not** know about scales, tunings, compositions, or the GUI; it
-  deals only with MIDI devices and messages.
-- It depends only on `businessync` (for the device-event bus) and `common` (for the `Locking` concurrency helper). See
-  [Dependencies](#dependencies).
-- The `tuner` module builds tuning logic on top of `MidiProcessor` and `MidiManager`, and the `cli` utility uses it to
-  enumerate MIDI devices. `scMidi` is the only Microtonalist module that touches `javax.sound.midi` directly.
-
-Package: `org.calinburloiu.music.scmidi`, with a `message` sub-package
-(`org.calinburloiu.music.scmidi.message`) holding the message model and its converters/constants. macOS support comes
-from the **CoreMIDI4J** library, which replaces the default Java Sound MIDI device provider (see
-[CoreMIDI4J and device naming](#coremidi4j-and-device-naming)).
+Package: `org.calinburloiu.music.scmidi`, with a `message` sub-package holding the message model and its converters and
+constants. macOS support comes from **CoreMIDI4J**, which replaces the default Java Sound MIDI device provider and
+prefixes device names with `"CoreMIDI4J - "` (stripped for display by `MidiDeviceId.sanitizedName`).
 
 ## Key types
 
 ### Device handling
 
-#### `MidiManager` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiManager.scala:35`)
+**`MidiManager`** is the entry point for device discovery and connection. Constructed with a `Businessync`, it is
+`AutoCloseable` and keeps two internal endpoints — one for inputs, one for outputs — because the Java/CoreMIDI4J API
+exposes a physical bidirectional device as two separate `MidiDevice` instances that nonetheless share one
+`MidiDeviceId`. Its `refresh()` rescans the environment and diffs against the known set; a `CoreMidiNotification`
+listener calls it automatically whenever the MIDI environment changes. It offers a per-direction API mirrored for input
+and output (availability, id/info enumeration, `open*`/`close*`, `openFirstAvailable*`, handle lookup), emitting the
+device events described in [Device lifecycle and events](#device-lifecycle-and-events) as it reconciles state.
 
-The entry point for device discovery and connection. Constructed with a `Businessync`, it is `AutoCloseable` and
-maintains two private `MidiEndpoint` instances — one for inputs, one for outputs — because the Java/CoreMIDI4J API
-exposes a physical bidirectional device as two separate `MidiDevice` instances (input and output) that nonetheless
-share a single `MidiDeviceId`.
+**`MidiDeviceHandle`** is a thread-safe handle to a single device identified by a `MidiDeviceId`, created and kept up to
+date by `MidiManager`. A handle can exist for a device that is **not currently connected** (its `info`/`device` are
+`Option`s defined only once physically connected), and its lifecycle is **reference-counted**: the device opens on the
+first `open()` and closes on the last `close()`. `open()` may be called before the device is connected — the handle
+moves to `WaitingToOpen` and opens automatically when the device appears (a small `State` enum captures the
+Closed/Connected/WaitingToOpen/Open transitions, drawn in the companion's ScalaDoc). Callers **send** to an output via
+`handle.receiver` and **subscribe** to an input via `handle.multiTransmitter`; both are wired through an internal
+`MidiSplitter`, so they survive disconnect/reconnect without re-wiring.
 
-- `refresh()` (`:60`) rescans the environment via `CoreMidiDeviceProvider.getMidiDeviceInfo`, diffs against the known
-  set, and updates both endpoints. A `CoreMidiNotification` listener (`:42`) calls `refresh()` automatically whenever
-  the MIDI environment changes (and publishes `MidiEnvironmentChangedEvent`).
-- Per-direction API (mirrored for input and output): `is{Input,Output}Available`, `{input,output}DeviceIds`,
-  `{input,output}DevicesInfo`, `open{Input,Output}(deviceId)`, `openFirstAvailable{Input,Output}(deviceIds)`,
-  `{input,output}DeviceHandleOf`, `{input,output}OpenedDevices`, `close{Input,Output}(deviceId)`.
-- The private nested `MidiManager.MidiEndpoint` (`:169`) holds two `ConcurrentHashMap`s (id → `MidiDevice.Info` for
-  connected devices, id → `MidiDeviceHandle` for opened devices) and is responsible for emitting the connect /
-  disconnect / open / close events as it reconciles state
-  (see [Device lifecycle and events](#device-lifecycle-and-events)).
+Supporting value types: `MidiDeviceId` (`case class(name, vendor)` derived from Java device info) and `MidiEndpointType`
+(an `enum` of `None`/`Input`/`Output`/`InputOutput`).
 
-#### `MidiDeviceHandle` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiDeviceHandle.scala:53`)
-
-A thread-safe (`@ThreadSafe`, `Locking`) handle to a single MIDI device, identified by a `MidiDeviceId`. Created and
-kept up to date by `MidiManager`. A handle can exist for a device that is **not currently connected**; `info` and
-`device` (the underlying `javax.sound.midi.MidiDevice`) are `Option`s that become defined only once the device is
-physically connected.
-
-- Reference-counted lifecycle: `open()` / `close()` track an `openRefCount`; the device opens only on the first `open`
-  and closes on the last `close`. `open()` may be called before the device is connected — the handle moves to
-  `WaitingToOpen` and opens automatically once `onConnect` fires.
-- State machine via the `MidiDeviceHandle.State` enum (`:320`): `Closed`, `Connected`, `WaitingToOpen`, `Open` (each
-  carrying `isConnected` / `isOpen` flags). The companion's ScalaDoc draws the transition diagram.
-- I/O accessors: `receiver: Receiver` (`:261`, a private `HandleReceiver` forwarding to the device's receiver) lets
-  callers **send** to an output device; `multiTransmitter: MultiTransmitter` (`:269`) lets callers **subscribe** to
-  messages from an input device. Both are wired through an internal `MidiSplitter`, so they keep working across
-  reconnects without re-wiring.
-- `endpointType`, `isInputDevice`, `isOutputDevice`, `isConnected`, `isOpen` query capabilities and status.
-- `private[scmidi]` hooks `onConnect(info)` / `onDisconnect()` are driven by `MidiManager`.
-
-#### `MidiDeviceId` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiDeviceId.scala:30`)
-
-Value identifier of a device, a `case class(name, vendor)`. `apply(MidiDevice.Info)` derives one from Java device info;
-`correspondsToInfo` checks the match; `sanitizedName` strips the CoreMIDI4J `"CoreMIDI4J - "` name prefix for display.
-
-#### `MidiEndpointType` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiEndpointType.scala:26`)
-
-`enum` describing input/output capability: `None`, `Input`, `Output`, `InputOutput`. The companion's `apply(isInput,
-isOutput)` builds the right case from two booleans.
-
-#### `MidiEvent` and subtypes (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiEvent.scala:24`)
-
-A sealed `MidiEvent extends BusinessyncEvent` hierarchy — all events `MidiManager` publishes on the Businessync bus. The
-environment event plus matched success/failure pairs for each lifecycle transition:
-
-| Event | Meaning |
-| ----- | ------- |
-| `MidiEnvironmentChangedEvent` (`:34`) | The MIDI environment changed (devices added/removed/reconfigured). |
-| `MidiDeviceConnectedEvent` / `MidiDeviceFailedToConnectEvent(cause)` | A device became available / failed to connect. |
-| `MidiDeviceDisconnectedEvent` / `MidiDeviceFailedToDisconnectEvent(cause)` | A device was removed / failed to disconnect. |
-| `MidiDeviceOpenedEvent` / `MidiDeviceFailedToOpenEvent(cause)` | A device was opened / failed to open. |
-| `MidiDeviceClosedEvent` / `MidiDeviceFailedToCloseEvent(cause)` | A device was closed / failed to close. |
-
-All carry the `MidiDeviceId`; failure variants also carry the causing `Exception`. Note that "connected" means
-*available to the system*, not *opened by the application*.
+**`MidiEvent`** is a sealed `BusinessyncEvent` hierarchy — everything `MidiManager` publishes on the bus.
+`MidiEnvironmentChangedEvent` signals a change to the environment; the rest come as success/failure pairs for each
+lifecycle transition (connected/disconnected/opened/closed, each with a `…FailedTo…Event` carrying the cause). All carry
+the `MidiDeviceId`. Note "connected" means *available to the system*, not *opened by the application* — they are
+distinct, separately-evented states.
 
 ### MIDI message model (`message` sub-package)
 
-#### `ScMidiMessage` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/ScMidiMessage.scala:32`)
+**`ScMidiMessage`** is the sealed base of the immutable message model — the Scala-idiomatic counterpart to Java's
+mutable, byte-oriented `MidiMessage`/`ShortMessage`. Its sub-hierarchies cover channel voice/mode messages
+(`ChannelScMidiMessage`, with a `mapChannel` that rewrites the channel), system-common and system-real-time messages,
+the full set of Standard MIDI File meta events, and System Exclusive (`SysExScMidiMessage`). Anything with no dedicated
+counterpart becomes `UnsupportedScMidiMessage`, a lossless escape hatch that round-trips back to the right Java type.
+`PitchBendScMidiMessage` is notable: it normalises Java's two raw LSB/MSB bytes into a single signed 14-bit value and
+offers cents conversion against a `PitchBendSensitivity`.
 
-The sealed base trait for the immutable message model — the Scala-idiomatic counterpart to Java's mutable, byte-oriented
-`MidiMessage`/`ShortMessage`. Sub-hierarchies:
-
-- `ChannelScMidiMessage(channel)` (`:40`) — channel voice/mode messages with a validated `channel` (0–15) and a
-  `mapChannel(map)` that returns a same-typed copy with a rewritten channel. Concrete cases: `NoteOnScMidiMessage`,
-  `NoteOffScMidiMessage` (both via abstract `NoteScMidiMessage`), `PolyPressureScMidiMessage`, `CcScMidiMessage`,
-  `ProgramChangeScMidiMessage`, `ChannelPressureScMidiMessage`, and `PitchBendScMidiMessage`.
-- `SysCommonScMidiMessage` (`:54`) — `MidiTimeCodeScMidiMessage`, `SongPositionPointerScMidiMessage`,
-  `SongSelectScMidiMessage`, `TuneRequestScMidiMessage`.
-- `SysRealTimeScMidiMessage` (`:57`) — `TimingClock`, `Start`, `Continue`, `Stop`, `ActiveSensing`, `SystemReset`
-  (all `case object`s).
-- `MetaScMidiMessage` (`:60`) — Standard MIDI File meta events (`SequenceNumber`, the text-bearing family `Text` /
-  `CopyrightNotice` / `TrackName` / `InstrumentName` / `Lyric` / `Marker` / `CuePoint` / `ProgramName` / `DeviceName`,
-  `MidiChannelPrefix`, `MidiPort`, `EndOfTrack`, `SetTempo`, `SmpteOffset`, `TimeSignature`, `KeySignature`,
-  `SequencerSpecific`). Each carries its SMF `MetaType` byte in its companion.
-- `SysExScMidiMessage` (`:376`) — System Exclusive, storing the full byte sequence as an `ArraySeq[Byte]` so
-  `case class` structural equality works.
-- `UnsupportedScMidiMessage` (`:632`) — fallback wrapping raw bytes of any Java message with no dedicated counterpart;
-  it round-trips back to the correct Java type (Short/Sysex/Meta, detected from the status byte).
-
-`PitchBendScMidiMessage` (`:203`) is notable: it normalises Java's two raw LSB/MSB data bytes into a single signed
-14-bit `value` (−8192…8191) and offers cents conversion (`centsFor` / `cents`) against a `PitchBendSensitivity`. Its
-companion holds the byte ↔ value ↔ cents conversion math (`convertDataBytesToValue`, `convertValueToDataBytes`,
-`convertCentsToValue`, `convertValueToCents`, `fromCents`).
-
-#### `JavaMidiConverters` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/JavaMidiConverters.scala:40`)
-
-Bidirectional converters modelled after `scala.jdk.CollectionConverters`. Importing its members enables the extension
-methods `scMessage.asJava` and `javaMessage.asScala`. Both directions dispatch through lookup tables rather than large
-pattern matches: `asJava` keys on the concrete subtype `Class`, `asScala` keys on the MIDI command / status byte
-(short messages) or meta-type byte (meta messages), defaulting to `UnsupportedScMidiMessage`. It also reconstructs
-SMF meta payloads using big-endian and variable-length-quantity (VLQ) helpers.
-
-#### `MidiRequirements` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/MidiRequirements.scala:22`)
-
-Centralised value validation (`require…`) used by message constructors: `requireChannel` (0–15) and
-unsigned/signed bit-width checks (3/4/7/8/14/16/24-bit and signed 14-bit). It defines `MinSigned14BitValue` /
-`MaxSigned14BitValue` (±8192/8191) used by pitch bend.
-
-#### CC / RPN / NRPN constants
-
-- `ScMidiCc` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/message/ScMidiCc.scala:22`) — Control Change
-  controller numbers: RPN/NRPN MSB/LSB, Data Entry/Increment/Decrement, All Sound/Notes Off, Reset All Controllers,
-  Bank Select, Modulation, Volume, Pan, Expression, the pedals, and `MpeSlide` (#74).
-- `ScMidiRpn` (`.../message/ScMidiRpn.scala:22`) — Registered Parameter Numbers: Null, Pitch Bend Sensitivity,
-  Coarse/Fine Tuning, Tuning Bank/Program Select, and the MPE Configuration Message (MCM).
-- `ScMidiNrpn` (`.../message/ScMidiNrpn.scala:22`) — Null NRPN MSB/LSB (NRPNs are otherwise vendor-specific).
+**`JavaMidiConverters`** is the boundary with Java Sound MIDI, modelled after `scala.jdk.CollectionConverters`:
+importing its members enables `scMessage.asJava` / `javaMessage.asScala`. Both directions dispatch through lookup tables
+(by concrete subtype `Class` outbound, by status/meta-type byte inbound) rather than large pattern matches. Value
+validation for message constructors is centralised in `MidiRequirements` (channel and bit-width `require…` checks), and
+the controller/parameter numbers live in `ScMidiCc` / `ScMidiRpn` / `ScMidiNrpn` (including the MPE Configuration
+Message and the MPE Slide CC).
 
 ### MIDI plumbing (receivers, transmitters, processors)
 
-#### `MidiSplitter` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiSplitter.scala:27`)
+These are the composable pieces `tuner` builds its tuning pipeline from:
 
-A `Receiver` that fans every incoming message out to a configurable set of receivers, exposed via its `receiver`
-(input) and `multiTransmitter` (output). Used inside `MidiDeviceHandle` to broadcast a device's incoming stream.
+- **`MidiSplitter`** — a `Receiver` that fans every incoming message out to a configurable set of receivers; used inside
+  `MidiDeviceHandle` to broadcast a device's stream.
+- **`MultiTransmitter`** — a thread-safe transmitter allowing **multiple** receivers, unlike Java's single-receiver
+  `Transmitter`.
+- **`ScMidiReceiver`** — an `AutoCloseable` counterpart of `javax.sound.midi.Receiver` that consumes `ScMidiMessage`
+  directly, so callers avoid wrapping/unwrapping Java messages.
+- **`MidiProcessor`** — a MIDI interceptor that can filter, modify, or synthesise messages as they pass through.
+  Subclasses implement `process(message, timeStamp): Seq[MidiMessage]`; `onConnect`/`onDisconnect` callbacks let a
+  processor leave the downstream device consistent when rewired. **This is the abstraction `tuner` extends** to tune the
+  MIDI stream.
+- **`MidiSerialProcessor`** — a `MidiProcessor` that chains a mutable, thread-safe sequence of `MidiProcessor`s end to
+  end, rewiring the chain automatically on every mutation (and forwarding input straight to the output when empty).
+- **`ScMidiChannelStateTracker`** — an explicitly `@NotThreadSafe` `ScMidiReceiver` (for a single track thread) that
+  derives **per-channel MIDI state** (active notes, CC/RPN/NRPN/pressure/pitch-bend/program values) from the messages
+  sent to it, implementing the RPN/NRPN Data Entry protocol and the relevant Channel Mode messages.
+  `MonophonicPitchBendTuner` uses it to track held-note state.
 
-#### `MultiTransmitter` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MultiTransmitter.scala:29`)
+### MIDI domain helpers
 
-A thread-safe (`Locking`) transmitter abstraction allowing **multiple** receivers, unlike Java's `Transmitter` which
-permits only one. Manage the set with `receivers` (getter/setter), `addReceiver(s)`, `removeReceiver`, `clearReceivers`.
-
-#### `ScMidiReceiver` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/ScMidiReceiver.scala:28`)
-
-A Scala-idiomatic `AutoCloseable` counterpart of `javax.sound.midi.Receiver` that consumes `ScMidiMessage` directly
-(`send(message, timeStamp = -1L)`), so callers avoid wrapping/unwrapping Java messages. After `close()`, `send` should
-be a no-op.
-
-#### `MidiProcessor` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiProcessor.scala:37`)
-
-A MIDI interceptor that can filter, modify, or synthesise messages as they pass through. It owns a nested
-`MidiProcessorReceiver` (input) and `MidiProcessorTransmitter` (output); subclasses implement the abstract
-`process(message, timeStamp): Seq[MidiMessage]`. It is "connected" once a receiver is set on its transmitter, which
-triggers the `onConnect()` / `onDisconnect()` callbacks (used to leave the downstream device in a consistent state when
-the processor is rewired). The transmitter offers Scala-idiomatic `receiver: Option[Receiver]` getter/setter. This is
-the abstraction the `tuner` module extends to implement tuning of the MIDI stream.
-
-#### `MidiSerialProcessor` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiSerialProcessor.scala:35`)
-
-A `MidiProcessor` that chains a mutable, thread-safe sequence of `MidiProcessor`s end to end, terminating in the
-receiver set on its own transmitter:
-
-```
-MidiProcessor -> MidiProcessor -> ... -> MidiProcessor -> output receiver
-```
-
-It rewires the chain automatically on every mutation: `processors` (get/set), `insert`, `append`, `update`, `remove`,
-`removeAt`, `clear`, `size`. When the chain is empty it simply forwards input to the output receiver.
-
-#### `ScMidiChannelStateTracker` (`sc-midi/.../ScMidiChannelStateTracker.scala:41`)
-
-A `ScMidiReceiver` (explicitly `@NotThreadSafe`, intended for a single track thread) that derives and exposes
-**per-channel MIDI state** from the messages sent to it: active notes (with velocity and Polyphonic Key Pressure),
-CC values, RPN/NRPN values, Channel Pressure, Pitch Bend, and Program Change. It implements the full RPN/NRPN Data
-Entry / Increment / Decrement protocol and the relevant Channel Mode messages (All Sound/Notes Off, Reset All
-Controllers, modelled per MIDI 1.0 RP-015). Getters fall back through a documented lookup chain (recorded value →
-per-call override → constructor defaults → companion defaults). The companion provides MIDI-1.0 default tables
-(`DefaultCcValues`, `DefaultRpnValues`, empty `DefaultNrpnValues`) and the `RpnSelector` enum (`None` / `Rpn` / `Nrpn`).
-
-### MIDI domain helpers (package object and value types)
-
-#### Package object (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/package.scala`)
-
-- `MidiNote` (`:29`) — a value class over an `Int` note number (0–127), with `pitchClass`, `octave`, `freq` (relative
-  to A4 = 440 Hz), `assertValid()`, and a companion full of named constants (`C4`…`C5`, `ConcertPitch = A4`,
-  `Lowest`/`Highest`) plus `apply(pitchClass, octave)`.
-- `DefaultConcertPitchFreq = 440.0` Hz.
-- `isInputDevice` / `isOutputDevice` (`:84`, `:89`) — capability checks based on a device's max transmitters/receivers.
-- `mapShortMessageChannel` (`:94`) — rewrites the channel of a Java `ShortMessage`/`MidiMessage`.
-- `clampValue` (`:104`) — `Int` and `Double` clamping helpers.
-
-#### `PitchClass` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/PitchClass.scala:22`)
-
-A value class over a pitch-class number (0–11) with named constants (`C`, `CSharp`/`DFlat`, …), display names with
-sharps/flats, an implicit conversion to `Int`, and parsing helpers `fromNumber`, `fromName`, `parse`.
-
-#### `PitchBendSensitivity` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/PitchBendSensitivity.scala:44`)
-
-`case class(semitones, cents = 0)` modelling RPN #0 pitch-bend range, exposing `totalCents`; `Default` is ±2 semitones.
-The accompanying `PitchBendSensitivityMessages.create(channel, sensitivity)` (`:61`) builds the RPN message sequence
-(select Pitch Bend Sensitivity RPN, set Data Entry MSB/LSB, then null the RPN) as Java `MidiMessage`s.
+The package object and a few value types provide `MidiNote` (a value class over a 0–127 note number, with `pitchClass`,
+`octave`, `freq`, and named constants), `PitchClass` (a value class over 0–11 with sharp/flat names and parsing), and
+`PitchBendSensitivity` (RPN #0 pitch-bend range, default ±2 semitones, with a helper that builds the RPN message
+sequence). Smaller helpers (`isInputDevice`/`isOutputDevice`, `mapShortMessageChannel`, clamping) round out the object.
 
 ## How MIDI devices are opened, enumerated, and used
 
-1. Construct a single `MidiManager(businessync)`. Its `init()` runs an initial `refresh()` and registers a
+1. Construct a single `MidiManager(businessync)`; its initialization runs a first `refresh()` and registers a
    `CoreMidiNotification` listener so the device list stays current.
-2. Enumerate with `inputDeviceIds` / `outputDeviceIds` (or the `…DevicesInfo` variants). IDs are `MidiDeviceId`s;
-   `sanitizedName` gives a UI-friendly name.
-3. Open a device with `openInput(id)` / `openOutput(id)`, or try a prioritised list with
-   `openFirstAvailable{Input,Output}(ids)` (returns the first that ends up open). Each returns a `MidiDeviceHandle`.
-4. Use the handle: send via `handle.receiver` (outputs) and subscribe via `handle.multiTransmitter` (inputs). Because
+2. Enumerate with `inputDeviceIds` / `outputDeviceIds` (or the `…DevicesInfo` variants); `sanitizedName` gives a
+   UI-friendly name.
+3. Open a device with `openInput`/`openOutput`, or try a prioritised list with `openFirstAvailable*`; each returns a
+   `MidiDeviceHandle`.
+4. Use the handle: send via `handle.receiver` (outputs), subscribe via `handle.multiTransmitter` (inputs). Because the
    wiring goes through an internal `MidiSplitter`, it survives disconnect/reconnect cycles.
-5. `closeInput` / `closeOutput` (reference-counted) release a device; `MidiManager.close()` closes everything and
-   removes the notification listener.
-
-A device need not be connected when its handle is opened: `MidiDeviceHandle` enters `WaitingToOpen` and opens
-automatically once the physical device appears.
+5. `closeInput`/`closeOutput` (reference-counted) release a device; `MidiManager.close()` closes everything and removes
+   the listener.
 
 ## Device lifecycle and events
 
-`MidiManager.MidiEndpoint` reconciles the scanned device set against its known state and publishes Businessync events as
-side effects:
-
-- On `refresh()`/`updateDevices`: newly seen devices emit `MidiDeviceConnectedEvent`; vanished devices emit
-  `MidiDeviceDisconnectedEvent`. Any environment change first emits `MidiEnvironmentChangedEvent`.
-- `purgeDisconnectedDevices()` closes and forgets handles whose devices were disconnected, emitting
-  `MidiDeviceClosedEvent`.
-- `openDevice` emits `MidiDeviceOpenedEvent` on success. Failures during connect/disconnect/open/close emit the
-  corresponding `…Failed…Event` carrying the exception (see [`MidiEvent`](#midievent-and-subtypes)).
-
-Consumers (notably the `tuner` module's track lifecycle) subscribe to these events through Businessync rather than
-polling. "Connected" is about system availability; "opened" is about this application actively using the device — they
-are distinct, separately-evented states.
+`MidiManager`'s internal endpoints reconcile the scanned device set against known state and publish Businessync events
+as side effects: newly seen devices emit `MidiDeviceConnectedEvent`, vanished ones `MidiDeviceDisconnectedEvent` (with
+`MidiEnvironmentChangedEvent` first), opening emits `MidiDeviceOpenedEvent`, and failures emit the corresponding
+`…Failed…Event` carrying the exception. Consumers (notably the `tuner` track lifecycle) subscribe through Businessync
+rather than polling.
 
 ## Message conversion model
 
-The boundary with Java Sound MIDI is the `ScMidiMessage` ↔ `MidiMessage` pair handled by `JavaMidiConverters`:
-
-- Inbound: a device's raw `MidiMessage` is turned into a typed, validated `ScMidiMessage` via `.asScala` (anything
-  unrecognised becomes `UnsupportedScMidiMessage`, never lost).
-- Outbound: an `ScMidiMessage` is rendered to a Java `MidiMessage` via `.asJava` for transmission.
-
-Within `scMidi`, message-producing/processing code prefers the typed model and validated constructors; the raw byte
-layer is confined to the converters and the few places that talk to `javax.sound.midi` directly.
+The boundary with Java Sound MIDI is the `ScMidiMessage` ↔ `MidiMessage` pair handled by `JavaMidiConverters`: inbound,
+a device's raw message becomes a typed, validated `ScMidiMessage` via `.asScala` (anything unrecognised becomes
+`UnsupportedScMidiMessage`, never lost); outbound, an `ScMidiMessage` is rendered via `.asJava`. Within `scMidi`,
+message code prefers the typed model and validated constructors; the raw byte layer is confined to the converters and
+the few places that talk to `javax.sound.midi` directly.
 
 ## Dependencies
 
-Verified against `build.sbt` (the `scMidi` project block at `build.sbt:217`).
+**Depends on** `businessync` (the bus used to publish `MidiEvent`s) and `common` (the `Locking` mixin used by the
+thread-safe device/transmitter/processor classes), plus the external **CoreMIDI4J** library and the inherited common
+logging/test stack.
 
-**Upstream (what `scMidi` depends on):**
-
-- `businessync` — the event bus used to publish `MidiEvent`s about device state.
-- `common` — the `Locking` concurrency mixin (`org.calinburloiu.music.microtonalist.common.concurrency.Locking`) used
-  by the thread-safe device/transmitter/processor classes.
-- External library **CoreMIDI4J** (`uk.co.xfactory-librarians % coremidi4j`) for reliable MIDI device enumeration and
-  notifications on macOS (and Windows), plus the project-wide `commonDependencies` (Logback, scala-logging, and
-  ScalaTest/ScalaMock in `Test` scope).
-
-**Downstream (what depends on `scMidi`):**
-
-- `tuner` (`dependsOn(businessync, common, scMidi)`) — builds `MidiProcessor`-based tuning pipelines and uses
-  `MidiManager` for device I/O.
-- `cli` (`dependsOn(scMidi)`) — the standalone utility that, e.g., lists connected MIDI devices.
-- Transitively, `app`, `composition`, `format`, and `ui` reach `scMidi` through `tuner`.
+**Depended on by** `tuner` (builds `MidiProcessor`-based pipelines and uses `MidiManager` for device I/O) and `cli`
+(lists connected devices); `app`, `composition`, `format`, and `ui` reach it transitively through `tuner`.
 
 ## Notes / subject to change
 
-- Coverage targets are currently below the project-wide 80% goal (`coverageSettings(stmt = 62, branch = 44)`, with
-  **TODO #177** to raise them); device-handling code that requires real MIDI hardware is hard to cover with unit tests.
-- `MidiProcessorReceiver.close()` / `MidiProcessorTransmitter.close()` are intentionally minimal stubs ("Nothing to do
-  for the moment") and may gain real cleanup logic later.
-- The `ScMidiMessage` model is broad (channel voice/mode, system common/real-time, SysEx, and a full set of SMF meta
-  events) even though Microtonalist itself does not yet exercise every meta event; treat the typed model as the
-  supported surface and `UnsupportedScMidiMessage` as the lossless escape hatch.
+- Coverage targets are currently below the project-wide 80% goal (TODO #177); device-handling code that needs real MIDI
+  hardware is hard to cover with unit tests.
+- The `ScMidiMessage` model is broad (it covers the full set of SMF meta events) even though Microtonalist does not yet
+  exercise every one; treat the typed model as the supported surface and `UnsupportedScMidiMessage` as the lossless
+  escape hatch.

--- a/docs/architecture/sc-midi/README.md
+++ b/docs/architecture/sc-midi/README.md
@@ -48,7 +48,8 @@ share a single `MidiDeviceId`.
   `{input,output}DeviceHandleOf`, `{input,output}OpenedDevices`, `close{Input,Output}(deviceId)`.
 - The private nested `MidiManager.MidiEndpoint` (`:169`) holds two `ConcurrentHashMap`s (id → `MidiDevice.Info` for
   connected devices, id → `MidiDeviceHandle` for opened devices) and is responsible for emitting the connect /
-  disconnect / open / close events as it reconciles state (see [Device lifecycle and events](#device-lifecycle-and-events)).
+  disconnect / open / close events as it reconciles state
+  (see [Device lifecycle and events](#device-lifecycle-and-events)).
 
 #### `MidiDeviceHandle` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/MidiDeviceHandle.scala:53`)
 
@@ -186,7 +187,7 @@ MidiProcessor -> MidiProcessor -> ... -> MidiProcessor -> output receiver
 It rewires the chain automatically on every mutation: `processors` (get/set), `insert`, `append`, `update`, `remove`,
 `removeAt`, `clear`, `size`. When the chain is empty it simply forwards input to the output receiver.
 
-#### `ScMidiChannelStateTracker` (`sc-midi/src/main/scala/org/calinburloiu/music/scmidi/ScMidiChannelStateTracker.scala:41`)
+#### `ScMidiChannelStateTracker` (`sc-midi/.../ScMidiChannelStateTracker.scala:41`)
 
 A `ScMidiReceiver` (explicitly `@NotThreadSafe`, intended for a single track thread) that derives and exposes
 **per-channel MIDI state** from the messages sent to it: active notes (with velocity and Polyphonic Key Pressure),

--- a/docs/architecture/sc-midi/README.md
+++ b/docs/architecture/sc-midi/README.md
@@ -291,5 +291,3 @@ Verified against `build.sbt` (the `scMidi` project block at `build.sbt:217`).
 - The `ScMidiMessage` model is broad (channel voice/mode, system common/real-time, SysEx, and a full set of SMF meta
   events) even though Microtonalist itself does not yet exercise every meta event; treat the typed model as the
   supported surface and `UnsupportedScMidiMessage` as the lossless escape hatch.
-</content>
-</invoke>

--- a/docs/architecture/tuner/README.md
+++ b/docs/architecture/tuner/README.md
@@ -43,10 +43,11 @@ messages it requires now, and `process(message)` rewrites each message flowing t
   protocols](#supported-tuning-protocols) and the linked design docs.
 
 **Tuning-change detection.** `TuningChanger` (`@NotThreadSafe` plugin) inspects messages and returns a `TuningChange`;
-`PedalTuningChanger` triggers on a pedal-like CC crossing a threshold. `TuningChange` splits into
-`EffectiveTuningChange` (`PreviousTuningChange` / `NextTuningChange` / `IndexTuningChange`, which actually change the
-tuning) and `IneffectiveTuningChange` (no change, or "part of a trigger pattern but nothing yet" — e.g. a held pedal's
-CC stream).
+`PedalTuningChanger` triggers on a pedal-like CC crossing a threshold, reading its trigger map from a
+`TuningChangeTriggers[T]` that binds trigger values (CC numbers here) to previous/next/index changes. `TuningChange`
+splits into `EffectiveTuningChange` (`PreviousTuningChange` / `NextTuningChange` / `IndexTuningChange`, which actually
+change the tuning) and `IneffectiveTuningChange` (no change, or "part of a trigger pattern but nothing yet" — e.g. a
+held pedal's CC stream).
 
 **The processor pipeline.** Each `Tuner`/`TuningChanger` is wrapped in a `MidiProcessor` (from `sc-midi`) so it can be
 chained. `TuningChangeProcessor` asks its `TuningChanger`s in order (first effective decision wins) and, on an effective

--- a/docs/architecture/tuner/README.md
+++ b/docs/architecture/tuner/README.md
@@ -54,13 +54,14 @@ declares a `familyName` (the family, e.g. `"tuner"`) and a `typeName` (the concr
   Pitch Bend is channel-wide it enforces monophony, folding all input onto one `outputChannel`, tracking the held note
   via `ScMidiChannelStateTracker`, and combining the performer's expressive bend with the tuning bend. Handles pedal
   interruption to preserve monophony and reacts to Pitch Bend Sensitivity RPN changes.
-- `MpeTuner` — `tuner/.../MpeTuner.scala:62`. The polyphonic tuner; see [Supported tuning protocols](#supported-tuning-protocols)
-  and the linked design paper. Distributes notes across MPE Member Channels so each can carry an independent
-  pitch-class Pitch Bend offset, supports `NonMpe`/`Mpe` input modes (`MpeInputMode`), and reconfigures zones on
-  receiving an MPE Configuration Message (MCM). Supporting types: `MpeZone`/`MpeZones`/`MpeZoneStructure`/`MpeZoneType`
-  (`tuner/.../MpeZone.scala`) model the Lower/Upper zones and their channel layout with overlap resolution;
-  `MpeChannelAllocator` (`tuner/.../MpeChannelAllocator.scala`) partitions Member Channels into a Pitch Class Group and
-  an Expression Group and decides note→channel allocation (and note drops on exhaustion / large expressive bend).
+- `MpeTuner` — `tuner/.../MpeTuner.scala:62`. The polyphonic tuner; see
+  [Supported tuning protocols](#supported-tuning-protocols) and the linked design paper. Distributes notes across MPE
+  Member Channels so each can carry an independent pitch-class Pitch Bend offset, supports `NonMpe`/`Mpe` input modes
+  (`MpeInputMode`), and reconfigures zones on receiving an MPE Configuration Message (MCM). Supporting types:
+  `MpeZone`/`MpeZones`/`MpeZoneStructure`/`MpeZoneType` (`tuner/.../MpeZone.scala`) model the Lower/Upper zones and
+  their channel layout with overlap resolution; `MpeChannelAllocator` (`tuner/.../MpeChannelAllocator.scala`)
+  partitions Member Channels into a Pitch Class Group and an Expression Group and decides note→channel allocation
+  (and note drops on exhaustion / large expressive bend).
 
 ### Tuning change detection
 

--- a/docs/architecture/tuner/README.md
+++ b/docs/architecture/tuner/README.md
@@ -1,140 +1,79 @@
 # `tuner` module architecture
 
-The `tuner` module (directory `tuner/`, package `org.calinburloiu.music.microtonalist.tuner`) is the low-level
-MIDI tuning engine. It turns a 12-pitch-class [`Tuning`](#tuning) into the MIDI messages an output instrument needs to
-play microtonally, and it manages the per-instrument processing pipelines (tracks) that route MIDI from input to output
+The `tuner` module (directory `tuner/`, package `org.calinburloiu.music.microtonalist.tuner`) is the low-level MIDI
+tuning engine. It turns a 12-pitch-class `Tuning` into the MIDI messages an output instrument needs to play
+microtonally, and it manages the per-instrument processing pipelines (*tracks*) that route MIDI from input to output
 while applying tuning and reacting to tuning-change triggers.
 
 ## Responsibility
 
-- Convert a `Tuning` (cent offsets per pitch class) into protocol-specific MIDI messages: MIDI Tuning Standard (MTS,
-  all four octave variants), MIDI Polyphonic Expression (MPE), and monophonic Pitch Bend.
+- Convert a `Tuning` (cent offsets per pitch class) into protocol-specific MIDI messages: MIDI Tuning Standard (MTS, all
+  four octave variants), MIDI Polyphonic Expression (MPE), and monophonic Pitch Bend.
 - Process the live MIDI stream of an instrument: detect tuning-change triggers (e.g. piano pedals), apply the current
   tuning to passing notes, and forward the result to the output device or another track.
-- Hold and mutate the application's runtime tuning/track state on the business thread, and expose thread-safe services
-  to the UI and application layers.
+- Hold the application's runtime tuning/track state on the business thread and expose thread-safe services to the UI and
+  application layers.
 
 It does **not** decide *which* tunings exist or how scales map to them — that is the `composition` module, which builds
-a `TuningList` and hands the resulting `Seq[Tuning]` to this module. It also does **not** read/write `.mtlist.tracks`
-files itself; the `TrackRepo` trait lives here but its formats and concrete repos live in `format` (see
-[Persistence](#persistence-trackrepo)).
+a `TuningList` and hands the resulting `Seq[Tuning]` to this module. It also does **not** read/write tracks files: the
+`TrackRepo` trait lives here but its formats and concrete repos live in `format`.
 
 ## Key types
 
-### Plugin pattern
+**Plugin pattern.** `Tuner`, `TuningChanger`, `TrackInputSpec`, and `TrackOutputSpec` extend `Plugin` (from `common`),
+declaring a `familyName` (e.g. `"tuner"`) and a `typeName` (e.g. `"mpe"`). The `format` module keys JSON
+(de)serialization off these names, so adding a variant means adding a `typeName` here and a serializer there.
 
-`Tuner`, `TuningChanger`, `TrackInputSpec`, and `TrackOutputSpec` all extend `Plugin` (from `common`). Each plugin
-declares a `familyName` (the family, e.g. `"tuner"`) and a `typeName` (the concrete variant, e.g. `"mpe"`). The
-`format` module uses these names for JSON (de)serialization, so adding a tuner/changer variant means adding a
-`typeName` here and a serializer there. Family names are defined as constants on the companion objects (e.g.
-`Tuner.FamilyName = "tuner"`, `TuningChanger.FamilyName = "tuningChanger"`).
+**`Tuning`** wraps 12 optional cent offsets, one per pitch class (`None` marks a key with no offset). It carries
+named-note accessors and combinators — notably `fill`, `overwrite`, and `merge` (which yields `None` on a conflict
+beyond tolerance) — that the `composition` reducer uses when combining tunings. `Tuning.Standard` is 12-EDO.
 
-### Tuning
+**Tuners.** `Tuner` (the `@NotThreadSafe` plugin trait) is the protocol abstraction; its three methods define the
+contract the pipeline drives: `reset()` configures the output device, `tune(tuning)` stores a tuning and emits the
+messages it requires now, and `process(message)` rewrites each message flowing through the track. Implementations:
 
-- `Tuning` — `tuner/.../Tuning.scala:36`. A `case class` wrapping `Seq[Option[Double]]` of exactly 12 cent offsets, one
-  per pitch class (C..B); `None` marks a key with no offset (treated as `0.0` by `apply`). Named-note accessors
-  (`c`, `cSharp`/`dFlat`, …) and rich combinators: `fill` (complete empty keys from another), `overwrite`, `merge`
-  (returns `None` on a conflict beyond `DefaultCentsTolerance`), `almostEquals`, plus `isComplete`/`completedCount`.
-  `Tuning.Standard` (`:282`) is 12-EDO (all zeros); `Tuning.Empty` is all-`None`; `Tuning.Size = 12`.
+- `MtsTuner` and its four octave variants (`MtsOctave{1,2}Byte{Non,}RealTimeTuner`) retune the instrument's pitch table
+  in advance via a single MTS SysEx, so notes pass through untouched. The SysEx bytes are built by `MtsMessageGenerator`
+  / `MtsOctaveMessageGenerator`.
+- `MonophonicPitchBendTuner` tunes via per-channel Pitch Bend; because Pitch Bend is channel-wide it enforces monophony,
+  folding all input onto one output channel and combining the performer's expressive bend with the tuning bend.
+- `MpeTuner` is the polyphonic tuner: it distributes notes across MPE Member Channels so each can carry an independent
+  pitch-class bend, and reconfigures zones on an MPE Configuration Message. Its supporting types (`MpeZone*`,
+  `MpeChannelAllocator`) model the zone layout and note→channel allocation. See [Supported tuning
+  protocols](#supported-tuning-protocols) and the linked design docs.
 
-### Tuners (the protocol implementations)
+**Tuning-change detection.** `TuningChanger` (`@NotThreadSafe` plugin) inspects messages and returns a `TuningChange`;
+`PedalTuningChanger` triggers on a pedal-like CC crossing a threshold. `TuningChange` splits into
+`EffectiveTuningChange` (`PreviousTuningChange` / `NextTuningChange` / `IndexTuningChange`, which actually change the
+tuning) and `IneffectiveTuningChange` (no change, or "part of a trigger pattern but nothing yet" — e.g. a held pedal's
+CC stream).
 
-- `Tuner` (trait, Plugin) — `tuner/.../Tuner.scala:48`, `@NotThreadSafe`. The protocol abstraction with three methods:
-  - `reset(): Seq[MidiMessage]` — initialize/configure the output device (e.g. set Pitch Bend Sensitivity); must be
-    sent before first use.
-  - `tune(tuning): Seq[MidiMessage]` — store the tuning and emit any messages it requires now.
-  - `process(message): Seq[MidiMessage]` — transform every MIDI message flowing through the track.
-  - `altTuningOutput: Option[MidiDeviceId]` — optional separate device for tuning SysEx (meaningful only for tuners
-    where tuning data stands alone, i.e. MTS — not Pitch Bend based ones).
-- `MtsTuner` (abstract) + 4 case-class variants — `tuner/.../MtsTuner.scala`. `MtsOctave{1,2}Byte{Non,}RealTimeTuner`
-  cover the octave-based MTS protocol in 1-/2-byte and real-time/non-real-time forms. `tune` emits a single MTS SysEx;
-  `process` only forwards messages when `thru` is set (the instrument is retuned in advance, notes are untouched).
-  SysEx bytes are built by `MtsMessageGenerator` / `MtsOctaveMessageGenerator` (`tuner/.../MtsMessageGenerator.scala`).
-- `MonophonicPitchBendTuner` — `tuner/.../MonophonicPitchBendTuner.scala:36`. Tunes by per-channel Pitch Bend; because
-  Pitch Bend is channel-wide it enforces monophony, folding all input onto one `outputChannel`, tracking the held note
-  via `ScMidiChannelStateTracker`, and combining the performer's expressive bend with the tuning bend. Handles pedal
-  interruption to preserve monophony and reacts to Pitch Bend Sensitivity RPN changes.
-- `MpeTuner` — `tuner/.../MpeTuner.scala:62`. The polyphonic tuner; see
-  [Supported tuning protocols](#supported-tuning-protocols) and the linked design paper. Distributes notes across MPE
-  Member Channels so each can carry an independent pitch-class Pitch Bend offset, supports `NonMpe`/`Mpe` input modes
-  (`MpeInputMode`), and reconfigures zones on receiving an MPE Configuration Message (MCM). Supporting types:
-  `MpeZone`/`MpeZones`/`MpeZoneStructure`/`MpeZoneType` (`tuner/.../MpeZone.scala`) model the Lower/Upper zones and
-  their channel layout with overlap resolution; `MpeChannelAllocator` (`tuner/.../MpeChannelAllocator.scala`)
-  partitions Member Channels into a Pitch Class Group and an Expression Group and decides note→channel allocation
-  (and note drops on exhaustion / large expressive bend).
+**The processor pipeline.** Each `Tuner`/`TuningChanger` is wrapped in a `MidiProcessor` (from `sc-midi`) so it can be
+chained. `TuningChangeProcessor` asks its `TuningChanger`s in order (first effective decision wins) and, on an effective
+change, calls `TuningService.changeTuning`. `TunerProcessor` wraps a `Tuner`, forwarding `tune`/`process`, sending
+`reset()` on connect, and restoring 12-EDO on disconnect.
 
-### Tuning change detection
+**Track and lifecycle.** `Track` (`@ThreadSafe`) is one instrument pipeline built from a `TrackSpec`: it opens the
+input/output MIDI devices via `MidiManager` and assembles the processor chain (see [Track pipeline](#track-pipeline)).
+`TrackSpec` / `TrackSpecs` are the declarative description of a track and an immutable, id-keyed ordered collection of
+them. `TrackIO` holds the input/output spec plugins, including inter-track routing (`FromTrackInputSpec` /
+`ToTrackOutputSpec`). `TrackManager` (`@NotThreadSafe`) builds and replaces the live tracks from `TrackSpecs`, wires
+inter-track connections, and re-tunes every track when the tuning changes (it subscribes to `TuningEvent`).
 
-- `TuningChanger` (abstract, Plugin) — `tuner/.../TuningChanger.scala:30`, `@NotThreadSafe`. `decide(message)` returns a
-  `TuningChange`; `triggersThru` controls whether the trigger MIDI message is forwarded; `reset()` clears state.
-- `PedalTuningChanger` — `tuner/.../PedalTuningChanger.scala:49`. Triggers a change on a configured pedal-like CC
-  crossing a `threshold` (released→pressed edge). Triggers are described by
-  `TuningChangeTriggers[CcNumber]` (`tuner/.../TuningChangeTriggers.scala`), which map a trigger to previous/next/index.
-- `TuningChange` (sealed) — `tuner/.../TuningChange.scala`. `EffectiveTuningChange` (`PreviousTuningChange`,
-  `NextTuningChange`, `IndexTuningChange(index)`) actually changes the tuning; `IneffectiveTuningChange`
-  (`NoTuningChange`, `MayTriggerTuningChange`) does not. `mayTrigger` distinguishes "part of a trigger pattern but no
-  change yet" (e.g. the continuous CC stream from a held pedal) from a real change.
+**Sessions, services, and events.** Mutable state lives in `@NotThreadSafe` `*Session` objects (business-thread only)
+and is exposed through `@ThreadSafe` `*Service` facades that marshal calls onto the business thread via `Businessync`:
 
-### The processor pipeline
+- `TuningSession` holds the `Seq[Tuning]` and current `tuningIndex`; mutating either publishes a `TuningEvent`
+  (`TuningIndexUpdatedEvent` / `TuningsUpdatedEvent`). `TuningService.changeTuning` runs the matching session mutation
+  on the business thread.
+- `TrackSession` loads tracks from a URI via `TrackRepo` and offers add/update/move/remove editing, pushing changes to
+  `TrackManager` and publishing `TrackEvent`s; `TrackService` is its thread-safe facade.
+- `TunerModule` is the composition root that lazily wires the sessions, services, an internal `MidiManager`, and the
+  `TrackManager`. The `app` layer injects this rather than constructing the pieces individually.
 
-Each `Tuner`/`TuningChanger` is wrapped in a `MidiProcessor` (from `sc-midi`) so it can be chained:
-
-- `TuningChangeProcessor` — `tuner/.../TuningChangeProcessor.scala:36`, `@NotThreadSafe`. Holds the track's
-  `TuningChanger`s and, for each message, asks them in order (first effective decision wins — an OR). On an
-  `EffectiveTuningChange` it calls `TuningService.changeTuning`. It forwards the message unless it `mayTrigger` and the
-  effective changer is not `triggersThru` (i.e. trigger messages are filtered out by default).
-- `TunerProcessor` — `tuner/.../TunerProcessor.scala:46`, `@NotThreadSafe`. Wraps a `Tuner`: `tune` forwards the
-  tuner's messages to the receiver; `process` delegates to `tuner.process`; on connect it sends `tuner.reset()`; on
-  disconnect/close it restores `Tuning.Standard` (12-EDO). Send failures become `TunerException`.
-
-### Track and lifecycle
-
-- `Track` — `tuner/.../Track.scala:31`, `@ThreadSafe`. One instrument pipeline. From a `TrackSpec` it opens the input
-  and output MIDI devices (via `MidiManager`) and builds a `MidiSerialProcessor` chain:
-  **input device → `TuningChangeProcessor` → `TunerProcessor` → output (`MidiSplitter`) → output device**. `tune`
-  delegates to the `TunerProcessor`; `close` reverts the instrument to 12-EDO and closes the devices. `multiTransmitter`
-  exposes the output for track-to-track wiring. (`Track#run` is a stub — see [Future](#subject-to-change).)
-- `TrackSpec` / `TrackSpecs` — `tuner/.../TrackSpecs.scala`. `TrackSpec` (`:36`) is the declarative description of a
-  track: `id`, `name` (with `#` → 1-based index substitution), optional `input`/`output` specs, `tuningChangers`,
-  optional `tuner`, `muted`. `TrackSpecs` (`:60`) is an immutable ordered collection keyed by id with `O(1)` lookup and
-  add/update/move/remove operations.
-- `TrackIO` — `tuner/.../TrackIO.scala`. Input/output spec plugins. `DeviceTrackInputSpec`/`DeviceTrackOutputSpec` bind
-  to a MIDI device (and optional channel: filter on input, remap on output); `FromTrackInputSpec`/`ToTrackOutputSpec`
-  wire one track's output into another track's input (inter-track routing).
-- `TrackManager` — `tuner/.../TrackManager.scala:33`, `@NotThreadSafe`. Lifecycle manager: builds/replaces the live
-  `Track`s from `TrackSpecs` (skipping muted ones), wires inter-track connections, and fans the current tuning out to
-  every track. It subscribes (`@Subscribe onTuningChanged(TuningEvent)`) so a tuning change re-tunes all tracks. Owns a
-  custom cached thread pool that names track threads `Track-<id>` (see [Future](#subject-to-change)).
-
-### Sessions, services, and events
-
-State lives in `*Session` objects (business-thread only) and is exposed through thread-safe `*Service` facades that
-marshal calls onto the business thread via `Businessync`.
-
-- `TuningSession` — `tuner/.../TuningSession.scala:32`, `@NotThreadSafe`. Holds the `Seq[Tuning]` and the current
-  `tuningIndex`. `tunings_=` publishes `TuningsUpdatedEvent`; `tuningIndex_=`/`next`/`previous`/`nextBy` (wrap-around)
-  publish `TuningIndexUpdatedEvent`. `currentTuning` falls back to `Tuning.Standard` when the index is out of range.
-- `TuningService` — `tuner/.../TuningService.scala:33`, `@ThreadSafe`. `changeTuning(EffectiveTuningChange)` runs the
-  corresponding session mutation on the business thread. **Note:** its `tunings` accessor is `@deprecated` as
-  not thread-safe (TODO #99, to be removed once the UI moves to JavaFX) — do not rely on it.
-- `TrackSession` — `tuner/.../TrackSession.scala:37`, `@NotThreadSafe`, an `OpenableSession`. Loads tracks from a URI
-  via `TrackRepo`, holds the current `TrackSpecs`, and offers add/update/move/remove editing; mutations push the new
-  specs to `TrackManager` and publish `TrackEvent`s.
-- `TrackService` — `tuner/.../TrackService.scala:34`, `@ThreadSafe`. `open(uri)` (async) and `replaceAllTracks` on the
-  business thread.
-- Events — `TuningEvent` (`TuningIndexUpdatedEvent`, `TuningsUpdatedEvent`) in `tuner/.../TuningEvent.scala` and
-  `TrackEvent` (`TracksOpened/Closed/Replaced`, `TrackAdded/Updated/Moved/Removed`) in `tuner/.../TrackEvent.scala`.
-  All extend `BusinessyncEvent` and are published through `Businessync`.
-- `TunerModule` — `tuner/.../TunerModule.scala:22`. Composition root: lazily wires `TuningSession`/`TuningService`,
-  `TrackSession`/`TrackService`, an internal `MidiManager`, and the `TrackManager` (registered with `Businessync`).
-  Inject this from the `app` layer rather than constructing the pieces individually.
-
-### Persistence (`TrackRepo`)
-
-- `TrackRepo` (trait) — `tuner/.../TrackRepo.scala:29`. Repository-pattern abstraction for reading/writing `TrackSpecs`
-  identified by `URI`, with sync and async `read`/`write` methods plus a small exception hierarchy
-  (`TrackRepoException` and friends). The trait lives here because `tuner` owns the domain types, but its `TrackFormat`
-  and the concrete `File`/`Http`/`Default` repos live in the `format` module (see the `format` architecture doc).
+**Persistence.** `TrackRepo` is the repository-pattern trait for reading/writing `TrackSpecs` by `URI`. It lives here
+because `tuner` owns the domain types, but its `TrackFormat` and the concrete `File`/`Http`/`Default` repos live in the
+`format` module.
 
 ## Supported tuning protocols
 
@@ -159,11 +98,11 @@ input device ──▶ TuningChangeProcessor ──▶ TunerProcessor ──▶ 
   (MidiManager)   (TuningChanger plugins)   (Tuner plugin)     (multiTransmitter)   (MidiManager)
 ```
 
-- Either processor stage is optional: if a `TrackSpec` has no `tuningChangers`, that stage is omitted; same for the
+- Either processor stage is optional: a `TrackSpec` with no `tuningChangers` omits that stage, and likewise for the
   `tuner`.
 - Input/output can be a MIDI device or another track (`FromTrackInputSpec` / `ToTrackOutputSpec`); `TrackManager` wires
   these inter-track connections after constructing the tracks, using each track's `multiTransmitter`.
-- Optional channel config on a device spec means *filter incoming messages by channel* (input) or *remap outgoing
+- A device spec's optional channel config means *filter incoming messages by channel* (input) or *remap outgoing
   messages to a channel* (output).
 
 ## Tuning-change flow
@@ -176,60 +115,46 @@ MIDI trigger message (e.g. CC pedal)
   → TuningService.changeTuning(effectiveChange)   [marshalled onto the business thread via Businessync]
   → TuningSession.{next,previous,index}           (updates tuningIndex)
   → TuningIndexUpdatedEvent (published via Businessync)
-  → TrackManager.onTuningChanged (@Subscribe)
+  → TrackManager.onTuningChanged
   → Track.tune(currentTuning) for every track
   → TunerProcessor.tune → Tuner.tune → protocol MIDI messages
   → output device
 ```
 
-The reverse, application-driven path (loading a composition) sets the available tunings:
-
-```
-TuningList.tunings (from composition module)
-  → TunerModule.tuningSession.tunings = …   (publishes TuningsUpdatedEvent)
-  → TrackManager re-tunes all tracks to currentTuning
-```
+The reverse, application-driven path (loading a composition) sets the available tunings: a `TuningList` from the
+`composition` module is assigned to `TunerModule.tuningSession.tunings`, which publishes `TuningsUpdatedEvent` and makes
+`TrackManager` re-tune all tracks.
 
 ## Threading model
 
-The module follows the Businessync two-thread model (see the project
-[Threading Model](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model) wiki page):
+The module follows the Businessync two-thread model (see the [`businessync` doc](../businessync/README.md) and the
+project [Threading Model](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model) wiki page):
 
 - All mutable domain state (`TuningSession`, `TrackSession`, `TrackManager`, every `Tuner`/`TuningChanger` and the
   processors that wrap them) is `@NotThreadSafe` and must be touched only on the **business thread**.
-- `TuningService` and `TrackService` are `@ThreadSafe` facades: callers from the UI or application layer go through
-  them, and they marshal the work onto the business thread via `businessync.run` / `businessync.callAsync`.
-- `Track` itself is `@ThreadSafe` (its internal processors run under external synchronization on the track/business
-  threads).
-- State changes are broadcast as `BusinessyncEvent`s; the `@Subscribe`-annotated `TrackManager.onTuningChanged` is the
-  link between a tuning change and the instruments being retuned.
+- `TuningService` and `TrackService` are `@ThreadSafe` facades: UI and application callers go through them, and they
+  marshal work onto the business thread via `Businessync`.
+- State changes are broadcast as `BusinessyncEvent`s; `TrackManager`'s subscription to `TuningEvent` is the link between
+  a tuning change and the instruments being retuned.
 
 ## Dependencies
 
-Declared in `build.sbt` (`lazy val tuner`): the module **depends on**
+The module **depends on** `sc-midi` (the Scala-idiomatic MIDI API: `MidiManager`, `MidiProcessor`/`MidiSerialProcessor`,
+`MidiSplitter`, message types, `MidiNote`, `PitchClass`, …), `businessync` (the event bus and `BusinessyncEvent`), and
+`common` (the `Plugin` trait and `OpenableSession`).
 
-- `sc-midi` — the Scala-idiomatic MIDI API: `MidiManager`, `MidiProcessor`/`MidiSerialProcessor`, `MidiSplitter`,
-  `MultiTransmitter`, message types (`ScMidiMessage` and conversions), `PitchBendSensitivity`, `MidiNote`,
-  `PitchClass`, `ScMidiChannelStateTracker`.
-- `businessync` — `Businessync` event bus + threading, and `BusinessyncEvent`.
-- `common` — the `Plugin` trait and `OpenableSession`.
-
-It also uses Guava (`IntMath`, `DoubleMath`, `Preconditions`) and scala-logging, inherited from the common build
-settings.
-
-**Depended on by** (`dependsOn(tuner)`): `app`, `ui`, `composition`, and `format`. So `tuner` sits below the
-domain/format/UI layers but above `sc-midi`/`businessync`/`common`. In particular `composition` produces the
-`Seq[Tuning]` consumed here, and `format` provides the `TrackFormat`/`*TrackRepo` implementations of this module's
-`TrackRepo` trait. See the top-level [architecture overview](../README.md) for the full module graph.
+It is **depended on by** `app`, `ui`, `composition`, and `format`, so `tuner` sits below the domain/format/UI layers but
+above `sc-midi`/`businessync`/`common`. In particular `composition` produces the `Seq[Tuning]` consumed here, and
+`format` provides the `TrackFormat`/`*TrackRepo` implementations of this module's `TrackRepo` trait. See the top-level
+[architecture overview](../README.md) for the full module graph.
 
 ## Subject to change
 
 These are signalled directly in the code:
 
-- `Track#run` is an unimplemented stub (TODO #121); `TrackManager` already provisions a per-track thread pool, but
-  track threads are not yet driven.
+- `Track#run` is an unimplemented stub (TODO #121); `TrackManager` already provisions a per-track thread pool, but track
+  threads are not yet driven.
 - `TuningService.tunings` is `@deprecated` (TODO #99) and slated for removal once the UI migrates to JavaFX.
-- `MpeTuner` warns/forbids are still TODO for the non-MPE-input-with-both-zones case (TODO #154), and per-note MPE
-  expression is not yet updated continuously (TODO #154).
-- `TrackManager.onTuningChanged` still relies on a Guava `@Subscribe` annotation pending fuller Businessync
-  integration (TODO #90).
+- `MpeTuner` warns/forbids are still TODO for the non-MPE-input-with-both-zones case, and per-note MPE expression is not
+  yet updated continuously (TODO #154).
+- `TrackManager` still relies on a Guava `@Subscribe` annotation pending fuller Businessync integration (TODO #90).

--- a/docs/architecture/tuner/README.md
+++ b/docs/architecture/tuner/README.md
@@ -78,11 +78,11 @@ because `tuner` owns the domain types, but its `TrackFormat` and the concrete `F
 
 ## Supported tuning protocols
 
-| Protocol | Tuner | How it tunes | Polyphony |
-| -------- | ----- | ------------ | --------- |
-| MTS Octave (1/2-byte, real/non-real-time) | `MtsOctave*Tuner` | Sends an MTS SysEx that retunes the instrument's pitch table in advance; notes pass through unchanged. | Polyphonic (instrument-side) |
-| Monophonic Pitch Bend | `MonophonicPitchBendTuner` | Per-channel Pitch Bend, all input folded to one output channel. | Monophonic (enforced) |
-| MPE | `MpeTuner` | Per-note Pitch Bend on dynamically allocated MPE Member Channels. | Polyphonic |
+| Protocol                                       | Tuner                      | How it tunes                                                                                           | Polyphony                    |
+|------------------------------------------------|----------------------------|--------------------------------------------------------------------------------------------------------|------------------------------|
+| MTS Octave (1-byte/2-byte, real/non-real-time) | `MtsOctave*Tuner`          | Sends an MTS SysEx that retunes the instrument's pitch table in advance; notes pass through unchanged. | Polyphonic (instrument-side) |
+| Monophonic Pitch Bend                          | `MonophonicPitchBendTuner` | Per-channel Pitch Bend, all input folded to one output channel.                                        | Monophonic (enforced)        |
+| MPE                                            | `MpeTuner`                 | Per-note Pitch Bend on dynamically allocated MPE Member Channels.                                      | Polyphonic                   |
 
 The MPE design has dedicated references (do not duplicate them here):
 

--- a/docs/architecture/tuner/README.md
+++ b/docs/architecture/tuner/README.md
@@ -1,17 +1,234 @@
 # `tuner` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `tuner` module (`tuner/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
+The `tuner` module (directory `tuner/`, package `org.calinburloiu.music.microtonalist.tuner`) is the low-level
+MIDI tuning engine. It turns a 12-pitch-class [`Tuning`](#tuning) into the MIDI messages an output instrument needs to
+play microtonally, and it manages the per-instrument processing pipelines (tracks) that route MIDI from input to output
+while applying tuning and reacting to tuning-change triggers.
 
 ## Responsibility
 
-TODO: what this module does and why it exists.
+- Convert a `Tuning` (cent offsets per pitch class) into protocol-specific MIDI messages: MIDI Tuning Standard (MTS,
+  all four octave variants), MIDI Polyphonic Expression (MPE), and monophonic Pitch Bend.
+- Process the live MIDI stream of an instrument: detect tuning-change triggers (e.g. piano pedals), apply the current
+  tuning to passing notes, and forward the result to the output device or another track.
+- Hold and mutate the application's runtime tuning/track state on the business thread, and expose thread-safe services
+  to the UI and application layers.
+
+It does **not** decide *which* tunings exist or how scales map to them — that is the `composition` module, which builds
+a `TuningList` and hands the resulting `Seq[Tuning]` to this module. It also does **not** read/write `.mtlist.tracks`
+files itself; the `TrackRepo` trait lives here but its formats and concrete repos live in `format` (see
+[Persistence](#persistence-trackrepo)).
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### Plugin pattern
+
+`Tuner`, `TuningChanger`, `TrackInputSpec`, and `TrackOutputSpec` all extend `Plugin` (from `common`). Each plugin
+declares a `familyName` (the family, e.g. `"tuner"`) and a `typeName` (the concrete variant, e.g. `"mpe"`). The
+`format` module uses these names for JSON (de)serialization, so adding a tuner/changer variant means adding a
+`typeName` here and a serializer there. Family names are defined as constants on the companion objects (e.g.
+`Tuner.FamilyName = "tuner"`, `TuningChanger.FamilyName = "tuningChanger"`).
+
+### Tuning
+
+- `Tuning` — `tuner/.../Tuning.scala:36`. A `case class` wrapping `Seq[Option[Double]]` of exactly 12 cent offsets, one
+  per pitch class (C..B); `None` marks a key with no offset (treated as `0.0` by `apply`). Named-note accessors
+  (`c`, `cSharp`/`dFlat`, …) and rich combinators: `fill` (complete empty keys from another), `overwrite`, `merge`
+  (returns `None` on a conflict beyond `DefaultCentsTolerance`), `almostEquals`, plus `isComplete`/`completedCount`.
+  `Tuning.Standard` (`:282`) is 12-EDO (all zeros); `Tuning.Empty` is all-`None`; `Tuning.Size = 12`.
+
+### Tuners (the protocol implementations)
+
+- `Tuner` (trait, Plugin) — `tuner/.../Tuner.scala:48`, `@NotThreadSafe`. The protocol abstraction with three methods:
+  - `reset(): Seq[MidiMessage]` — initialize/configure the output device (e.g. set Pitch Bend Sensitivity); must be
+    sent before first use.
+  - `tune(tuning): Seq[MidiMessage]` — store the tuning and emit any messages it requires now.
+  - `process(message): Seq[MidiMessage]` — transform every MIDI message flowing through the track.
+  - `altTuningOutput: Option[MidiDeviceId]` — optional separate device for tuning SysEx (meaningful only for tuners
+    where tuning data stands alone, i.e. MTS — not Pitch Bend based ones).
+- `MtsTuner` (abstract) + 4 case-class variants — `tuner/.../MtsTuner.scala`. `MtsOctave{1,2}Byte{Non,}RealTimeTuner`
+  cover the octave-based MTS protocol in 1-/2-byte and real-time/non-real-time forms. `tune` emits a single MTS SysEx;
+  `process` only forwards messages when `thru` is set (the instrument is retuned in advance, notes are untouched).
+  SysEx bytes are built by `MtsMessageGenerator` / `MtsOctaveMessageGenerator` (`tuner/.../MtsMessageGenerator.scala`).
+- `MonophonicPitchBendTuner` — `tuner/.../MonophonicPitchBendTuner.scala:36`. Tunes by per-channel Pitch Bend; because
+  Pitch Bend is channel-wide it enforces monophony, folding all input onto one `outputChannel`, tracking the held note
+  via `ScMidiChannelStateTracker`, and combining the performer's expressive bend with the tuning bend. Handles pedal
+  interruption to preserve monophony and reacts to Pitch Bend Sensitivity RPN changes.
+- `MpeTuner` — `tuner/.../MpeTuner.scala:62`. The polyphonic tuner; see [Supported tuning protocols](#supported-tuning-protocols)
+  and the linked design paper. Distributes notes across MPE Member Channels so each can carry an independent
+  pitch-class Pitch Bend offset, supports `NonMpe`/`Mpe` input modes (`MpeInputMode`), and reconfigures zones on
+  receiving an MPE Configuration Message (MCM). Supporting types: `MpeZone`/`MpeZones`/`MpeZoneStructure`/`MpeZoneType`
+  (`tuner/.../MpeZone.scala`) model the Lower/Upper zones and their channel layout with overlap resolution;
+  `MpeChannelAllocator` (`tuner/.../MpeChannelAllocator.scala`) partitions Member Channels into a Pitch Class Group and
+  an Expression Group and decides note→channel allocation (and note drops on exhaustion / large expressive bend).
+
+### Tuning change detection
+
+- `TuningChanger` (abstract, Plugin) — `tuner/.../TuningChanger.scala:30`, `@NotThreadSafe`. `decide(message)` returns a
+  `TuningChange`; `triggersThru` controls whether the trigger MIDI message is forwarded; `reset()` clears state.
+- `PedalTuningChanger` — `tuner/.../PedalTuningChanger.scala:49`. Triggers a change on a configured pedal-like CC
+  crossing a `threshold` (released→pressed edge). Triggers are described by
+  `TuningChangeTriggers[CcNumber]` (`tuner/.../TuningChangeTriggers.scala`), which map a trigger to previous/next/index.
+- `TuningChange` (sealed) — `tuner/.../TuningChange.scala`. `EffectiveTuningChange` (`PreviousTuningChange`,
+  `NextTuningChange`, `IndexTuningChange(index)`) actually changes the tuning; `IneffectiveTuningChange`
+  (`NoTuningChange`, `MayTriggerTuningChange`) does not. `mayTrigger` distinguishes "part of a trigger pattern but no
+  change yet" (e.g. the continuous CC stream from a held pedal) from a real change.
+
+### The processor pipeline
+
+Each `Tuner`/`TuningChanger` is wrapped in a `MidiProcessor` (from `sc-midi`) so it can be chained:
+
+- `TuningChangeProcessor` — `tuner/.../TuningChangeProcessor.scala:36`, `@NotThreadSafe`. Holds the track's
+  `TuningChanger`s and, for each message, asks them in order (first effective decision wins — an OR). On an
+  `EffectiveTuningChange` it calls `TuningService.changeTuning`. It forwards the message unless it `mayTrigger` and the
+  effective changer is not `triggersThru` (i.e. trigger messages are filtered out by default).
+- `TunerProcessor` — `tuner/.../TunerProcessor.scala:46`, `@NotThreadSafe`. Wraps a `Tuner`: `tune` forwards the
+  tuner's messages to the receiver; `process` delegates to `tuner.process`; on connect it sends `tuner.reset()`; on
+  disconnect/close it restores `Tuning.Standard` (12-EDO). Send failures become `TunerException`.
+
+### Track and lifecycle
+
+- `Track` — `tuner/.../Track.scala:31`, `@ThreadSafe`. One instrument pipeline. From a `TrackSpec` it opens the input
+  and output MIDI devices (via `MidiManager`) and builds a `MidiSerialProcessor` chain:
+  **input device → `TuningChangeProcessor` → `TunerProcessor` → output (`MidiSplitter`) → output device**. `tune`
+  delegates to the `TunerProcessor`; `close` reverts the instrument to 12-EDO and closes the devices. `multiTransmitter`
+  exposes the output for track-to-track wiring. (`Track#run` is a stub — see [Future](#subject-to-change).)
+- `TrackSpec` / `TrackSpecs` — `tuner/.../TrackSpecs.scala`. `TrackSpec` (`:36`) is the declarative description of a
+  track: `id`, `name` (with `#` → 1-based index substitution), optional `input`/`output` specs, `tuningChangers`,
+  optional `tuner`, `muted`. `TrackSpecs` (`:60`) is an immutable ordered collection keyed by id with `O(1)` lookup and
+  add/update/move/remove operations.
+- `TrackIO` — `tuner/.../TrackIO.scala`. Input/output spec plugins. `DeviceTrackInputSpec`/`DeviceTrackOutputSpec` bind
+  to a MIDI device (and optional channel: filter on input, remap on output); `FromTrackInputSpec`/`ToTrackOutputSpec`
+  wire one track's output into another track's input (inter-track routing).
+- `TrackManager` — `tuner/.../TrackManager.scala:33`, `@NotThreadSafe`. Lifecycle manager: builds/replaces the live
+  `Track`s from `TrackSpecs` (skipping muted ones), wires inter-track connections, and fans the current tuning out to
+  every track. It subscribes (`@Subscribe onTuningChanged(TuningEvent)`) so a tuning change re-tunes all tracks. Owns a
+  custom cached thread pool that names track threads `Track-<id>` (see [Future](#subject-to-change)).
+
+### Sessions, services, and events
+
+State lives in `*Session` objects (business-thread only) and is exposed through thread-safe `*Service` facades that
+marshal calls onto the business thread via `Businessync`.
+
+- `TuningSession` — `tuner/.../TuningSession.scala:32`, `@NotThreadSafe`. Holds the `Seq[Tuning]` and the current
+  `tuningIndex`. `tunings_=` publishes `TuningsUpdatedEvent`; `tuningIndex_=`/`next`/`previous`/`nextBy` (wrap-around)
+  publish `TuningIndexUpdatedEvent`. `currentTuning` falls back to `Tuning.Standard` when the index is out of range.
+- `TuningService` — `tuner/.../TuningService.scala:33`, `@ThreadSafe`. `changeTuning(EffectiveTuningChange)` runs the
+  corresponding session mutation on the business thread. **Note:** its `tunings` accessor is `@deprecated` as
+  not thread-safe (TODO #99, to be removed once the UI moves to JavaFX) — do not rely on it.
+- `TrackSession` — `tuner/.../TrackSession.scala:37`, `@NotThreadSafe`, an `OpenableSession`. Loads tracks from a URI
+  via `TrackRepo`, holds the current `TrackSpecs`, and offers add/update/move/remove editing; mutations push the new
+  specs to `TrackManager` and publish `TrackEvent`s.
+- `TrackService` — `tuner/.../TrackService.scala:34`, `@ThreadSafe`. `open(uri)` (async) and `replaceAllTracks` on the
+  business thread.
+- Events — `TuningEvent` (`TuningIndexUpdatedEvent`, `TuningsUpdatedEvent`) in `tuner/.../TuningEvent.scala` and
+  `TrackEvent` (`TracksOpened/Closed/Replaced`, `TrackAdded/Updated/Moved/Removed`) in `tuner/.../TrackEvent.scala`.
+  All extend `BusinessyncEvent` and are published through `Businessync`.
+- `TunerModule` — `tuner/.../TunerModule.scala:22`. Composition root: lazily wires `TuningSession`/`TuningService`,
+  `TrackSession`/`TrackService`, an internal `MidiManager`, and the `TrackManager` (registered with `Businessync`).
+  Inject this from the `app` layer rather than constructing the pieces individually.
+
+### Persistence (`TrackRepo`)
+
+- `TrackRepo` (trait) — `tuner/.../TrackRepo.scala:29`. Repository-pattern abstraction for reading/writing `TrackSpecs`
+  identified by `URI`, with sync and async `read`/`write` methods plus a small exception hierarchy
+  (`TrackRepoException` and friends). The trait lives here because `tuner` owns the domain types, but its `TrackFormat`
+  and the concrete `File`/`Http`/`Default` repos live in the `format` module (see the `format` architecture doc).
+
+## Supported tuning protocols
+
+| Protocol | Tuner | How it tunes | Polyphony |
+| -------- | ----- | ------------ | --------- |
+| MTS Octave (1/2-byte, real/non-real-time) | `MtsOctave*Tuner` | Sends an MTS SysEx that retunes the instrument's pitch table in advance; notes pass through unchanged. | Polyphonic (instrument-side) |
+| Monophonic Pitch Bend | `MonophonicPitchBendTuner` | Per-channel Pitch Bend, all input folded to one output channel. | Monophonic (enforced) |
+| MPE | `MpeTuner` | Per-note Pitch Bend on dynamically allocated MPE Member Channels. | Polyphonic |
+
+The MPE design has dedicated references (do not duplicate them here):
+
+- [`mpe-spec.md`](mpe-spec.md) — the MIDI Polyphonic Expression specification (RP-053 v1.0) notes.
+- [`mpe-tuner-paper.md`](mpe-tuner-paper.md) — the MPE Tuner design paper: dual-group Member Channel partitioning,
+  non-MPE→MPE conversion, and the deliberate departures from the MPE spec needed for stable microtonal intonation.
+
+## Track pipeline
+
+A `Track` is a `MidiSerialProcessor` chain built from its `TrackSpec`:
+
+```
+input device ──▶ TuningChangeProcessor ──▶ TunerProcessor ──▶ MidiSplitter ──▶ output device
+  (MidiManager)   (TuningChanger plugins)   (Tuner plugin)     (multiTransmitter)   (MidiManager)
+```
+
+- Either processor stage is optional: if a `TrackSpec` has no `tuningChangers`, that stage is omitted; same for the
+  `tuner`.
+- Input/output can be a MIDI device or another track (`FromTrackInputSpec` / `ToTrackOutputSpec`); `TrackManager` wires
+  these inter-track connections after constructing the tracks, using each track's `multiTransmitter`.
+- Optional channel config on a device spec means *filter incoming messages by channel* (input) or *remap outgoing
+  messages to a channel* (output).
+
+## Tuning-change flow
+
+A pedal press (or any trigger) flows through the chain as follows:
+
+```
+MIDI trigger message (e.g. CC pedal)
+  → TuningChangeProcessor (asks each TuningChanger.decide; first EffectiveTuningChange wins)
+  → TuningService.changeTuning(effectiveChange)   [marshalled onto the business thread via Businessync]
+  → TuningSession.{next,previous,index}           (updates tuningIndex)
+  → TuningIndexUpdatedEvent (published via Businessync)
+  → TrackManager.onTuningChanged (@Subscribe)
+  → Track.tune(currentTuning) for every track
+  → TunerProcessor.tune → Tuner.tune → protocol MIDI messages
+  → output device
+```
+
+The reverse, application-driven path (loading a composition) sets the available tunings:
+
+```
+TuningList.tunings (from composition module)
+  → TunerModule.tuningSession.tunings = …   (publishes TuningsUpdatedEvent)
+  → TrackManager re-tunes all tracks to currentTuning
+```
+
+## Threading model
+
+The module follows the Businessync two-thread model (see the project
+[Threading Model](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model) wiki page):
+
+- All mutable domain state (`TuningSession`, `TrackSession`, `TrackManager`, every `Tuner`/`TuningChanger` and the
+  processors that wrap them) is `@NotThreadSafe` and must be touched only on the **business thread**.
+- `TuningService` and `TrackService` are `@ThreadSafe` facades: callers from the UI or application layer go through
+  them, and they marshal the work onto the business thread via `businessync.run` / `businessync.callAsync`.
+- `Track` itself is `@ThreadSafe` (its internal processors run under external synchronization on the track/business
+  threads).
+- State changes are broadcast as `BusinessyncEvent`s; the `@Subscribe`-annotated `TrackManager.onTuningChanged` is the
+  link between a tuning change and the instruments being retuned.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+Declared in `build.sbt` (`lazy val tuner`): the module **depends on**
+
+- `sc-midi` — the Scala-idiomatic MIDI API: `MidiManager`, `MidiProcessor`/`MidiSerialProcessor`, `MidiSplitter`,
+  `MultiTransmitter`, message types (`ScMidiMessage` and conversions), `PitchBendSensitivity`, `MidiNote`,
+  `PitchClass`, `ScMidiChannelStateTracker`.
+- `businessync` — `Businessync` event bus + threading, and `BusinessyncEvent`.
+- `common` — the `Plugin` trait and `OpenableSession`.
+
+It also uses Guava (`IntMath`, `DoubleMath`, `Preconditions`) and scala-logging, inherited from the common build
+settings.
+
+**Depended on by** (`dependsOn(tuner)`): `app`, `ui`, `composition`, and `format`. So `tuner` sits below the
+domain/format/UI layers but above `sc-midi`/`businessync`/`common`. In particular `composition` produces the
+`Seq[Tuning]` consumed here, and `format` provides the `TrackFormat`/`*TrackRepo` implementations of this module's
+`TrackRepo` trait. See the top-level [architecture overview](../README.md) for the full module graph.
+
+## Subject to change
+
+These are signalled directly in the code:
+
+- `Track#run` is an unimplemented stub (TODO #121); `TrackManager` already provisions a per-track thread pool, but
+  track threads are not yet driven.
+- `TuningService.tunings` is `@deprecated` (TODO #99) and slated for removal once the UI migrates to JavaFX.
+- `MpeTuner` warns/forbids are still TODO for the non-MPE-input-with-both-zones case (TODO #154), and per-note MPE
+  expression is not yet updated continuously (TODO #154).
+- `TrackManager.onTuningChanged` still relies on a Guava `@Subscribe` annotation pending fuller Businessync
+  integration (TODO #90).

--- a/docs/architecture/ui/README.md
+++ b/docs/architecture/ui/README.md
@@ -1,19 +1,16 @@
 # `ui` module architecture
 
 > **Temporary implementation.** The current GUI is built with **Java Swing**. Architecture-milestone issue
-> [#99](https://github.com/calinburloiu/microtonalist/issues/99) plans to migrate the GUI to **JavaFX**, so most of
-> what is described here (the Swing frame, the `@Subscribe` event wiring) is expected to be replaced. Treat the Swing
-> specifics as transitional; the responsibility and the business-layer contract (`TuningService` / `TuningSession`,
-> Businessync events) are the stable parts.
+> [#99](https://github.com/calinburloiu/microtonalist/issues/99) plans to migrate it to **JavaFX**, so most of what is
+> described here (the Swing frame, the `@Subscribe` event wiring) is expected to be replaced. The stable parts are the
+> responsibility and the business-layer contract (`TuningService` / `TuningSession`, Businessync events).
 
 ## Responsibility
 
-The `ui` module is the desktop graphical user interface of Microtonalist. It is a thin presentation layer on top of the
-`tuner` module: it lets the user see the sequence of tunings derived from the loaded composition and switch the
-currently active tuning, while the actual tuning logic and MIDI output live in `tuner`.
-
-Today the module is intentionally small — a single Swing window. It owns no domain state; it reads tuning state from
-the business layer and forwards user intent (tuning changes) back to it.
+The `ui` module is the desktop graphical user interface of Microtonalist — a thin presentation layer on top of `tuner`.
+It lets the user see the sequence of tunings derived from the loaded composition and switch the active tuning, while the
+actual tuning logic and MIDI output live in `tuner`. It owns no domain state: it reads tuning state from the business
+layer and forwards user intent (tuning changes) back to it. Today it is intentionally small — a single Swing window.
 
 Package: `org.calinburloiu.music.microtonalist.ui`.
 
@@ -21,65 +18,45 @@ Package: `org.calinburloiu.music.microtonalist.ui`.
 
 ### `TuningListFrame`
 
-`ui/src/main/scala/org/calinburloiu/music/microtonalist/ui/TuningListFrame.scala:28`
+The single Swing window — the "Microtuner" frame opened at startup by `app`. It is a `JFrame` constructed with a
+`TuningService` and wired four ways:
 
-The single Swing window of the application — the "Microtuner" frame opened at startup by the `app` module. It is a
-`JFrame` constructed with a `TuningService` and wired as follows:
-
-- **Display.** It renders the tunings as a single-selection `JList[String]` inside a `JScrollPane`
-  (`TuningListFrame.scala:34`–`82`). The list model is backed by `tuningService.tunings`, showing each tuning's `name`.
-- **Selection → business layer.** A `ListSelectionListener` reacts to user selection and calls
-  `tuningService.changeTuning(IndexTuningChange(index))` (`TuningListFrame.scala:43`–`49`), guarding against the
-  adjusting/`-1` transient states so only a settled selection triggers a change.
-- **Keyboard shortcuts.** A `KeyListener` adds quality-of-life navigation (`TuningListFrame.scala:51`–`80`): `Up`/`Down`
-  wrap around at the ends of the list, and number keys `1`–`9` jump to the corresponding tuning index.
-- **Frame setup.** Closing the window exits the JVM (`WindowConstants.EXIT_ON_CLOSE`) and the window is sized 480×640
-  (`TuningListFrame.scala:84`–`86`).
-- **Business → display (event handler).** `onTuningChanged(TuningIndexUpdatedEvent)` (`TuningListFrame.scala:88`–`95`)
-  updates the selected list row when the tuning index changes elsewhere (e.g. a pedal-driven `TuningChanger`), keeping
-  the GUI in sync with the session.
+- **Display.** It renders the tunings as a single-selection `JList[String]`, its model seeded from
+  `tuningService.tunings` and showing each tuning's `name`.
+- **Selection → business layer.** A `ListSelectionListener` reacts to a settled selection (ignoring the adjusting/`-1`
+  transient states) and calls `tuningService.changeTuning(IndexTuningChange(index))`.
+- **Keyboard shortcuts.** A `KeyListener` adds navigation: `Up`/`Down` wrap around at the ends, number keys `1`–`9` jump
+  to the corresponding tuning.
+- **Business → display.** An event handler subscribed to `TuningIndexUpdatedEvent` updates the selected row when the
+  tuning index changes elsewhere (e.g. a pedal-driven `TuningChanger`), keeping the GUI in sync with the session.
 
 ### Collaborators (in `tuner`)
 
-The frame talks only to these `tuner`-module types; they are the stable contract for the planned JavaFX rewrite:
+The frame talks only to these `tuner`-module types — the stable contract for the planned JavaFX rewrite:
 
-- `TuningService` (`tuner/.../TuningService.scala:33`) — `@ThreadSafe` façade the frame is constructed with. The frame
-  uses two members:
-  - `changeTuning(EffectiveTuningChange)` — runs the mutation on the business thread via `businessync.run { … }`; the
-    frame supplies `IndexTuningChange(index)` (`PreviousTuningChange` / `NextTuningChange` also exist).
-  - `tunings: Seq[Tuning]` — **deprecated and not thread-safe** (`TuningService.scala:41`), kept only until the JavaFX
-    migration (`// TODO #99`). The frame still calls it once at construction to seed its list model
-    (`TuningListFrame.scala:30`). New UI code should obtain the list from `TuningsUpdatedEvent` instead.
-- `TuningSession` (`tuner/.../TuningSession.scala`) — holds the mutable `tunings` sequence and current `tuningIndex`;
-  publishes `TuningIndexUpdatedEvent` when the index changes and `TuningsUpdatedEvent` when the sequence changes.
-- `TuningIndexUpdatedEvent` / `TuningsUpdatedEvent` (`tuner/.../TuningEvent.scala`) — Businessync events carrying
-  `tuningIndex` and `currentTuning`. The frame currently subscribes only to `TuningIndexUpdatedEvent`.
-- `IndexTuningChange` (`tuner/.../TuningChange.scala`) — the change command the frame issues on selection.
+- **`TuningService`** — the `@ThreadSafe` façade the frame is constructed with. It uses `changeTuning` (runs the
+  mutation on the business thread) and the **deprecated, not-thread-safe** `tunings` accessor, called once at
+  construction to seed the list model (kept only until the JavaFX migration, `// TODO #99`; new UI code should obtain
+  the list from `TuningsUpdatedEvent` instead).
+- **`TuningSession`** — holds the mutable `tunings` and current `tuningIndex`, publishing `TuningIndexUpdatedEvent` /
+  `TuningsUpdatedEvent`.
+- **`TuningIndexUpdatedEvent`** / **`TuningsUpdatedEvent`** and **`IndexTuningChange`** — the events the frame observes
+  and the change command it issues on selection.
 
 ## UI ↔ business threading boundary
 
-The intended model (see the [`businessync` architecture doc](../businessync/README.md) and the project
-[Threading Model](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model) wiki) separates a **business
-thread** (all domain/MIDI logic) from a **UI/GUI thread** (all widget updates). Under that model the UI should:
-
-- mutate domain state only through services that hop to the business thread (`businessync.run { … }`), never directly;
-- apply widget updates on the UI thread via `businessync.runOnUi { … }`;
-- receive events via `businessync.subscribeOnUi(…)` so handlers land on the UI thread.
+The intended model (see the [`businessync` doc](../businessync/README.md) and the [Threading
+Model](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model) wiki) separates a **business thread** (all
+domain/MIDI logic) from a **UI thread** (all widget updates): the UI should mutate domain state only through services
+that hop to the business thread, apply widget updates via `runOnUi`, and receive events via `subscribeOnUi`.
 
 **Current reality (transitional, tracked by [#90](https://github.com/calinburloiu/microtonalist/issues/90) and #99):**
-
-- `Businessync.runOnUi`, `subscribeOnUi`, `subscribe`, `handleOnUi`, and `callOnUi` are still stubs (`???` / empty
-  bodies) — `businessync/.../Businessync.scala:68`,`80`,`105`. `run` simply invokes the function inline
-  (`Businessync.scala:92`), and `publish` posts straight to a Guava `EventBus` (`Businessync.scala:36`).
-- Because of that, `TuningListFrame` registers with the bus the legacy way: `app` calls
-  `businessync.register(tuningListFrame)` (`app/.../MicrotonalistApp.scala:97`), which delegates to
-  `eventBus.register(obj)` (`Businessync.scala:83`), and the frame's handler is annotated with Guava's own
-  `com.google.common.eventbus.Subscribe` (`TuningListFrame.scala:19`,`89`). The `// TODO #90` on that annotation marks
-  it for replacement by `businessync.subscribe` once Businessync is implemented.
-- Consequently there is **no real UI-thread marshalling yet**: `TuningIndexUpdatedEvent` is delivered on whatever thread
-  calls `publish` (the publisher's thread), and the `JList` is updated from there rather than from the Swing EDT. This
-  is a known gap that the Businessync (#90) and JavaFX (#99) work will close. New UI code should be written against the
-  intended `run`/`runOnUi`/`subscribeOnUi` API so the migration is mechanical.
+the UI-thread methods on `Businessync` are still stubs, and `run` runs inline. So `TuningListFrame` registers with the
+bus the legacy way — `app` calls `businessync.register(frame)` and the handler is annotated with Guava's own
+`@Subscribe` (marked `// TODO #90` for replacement by `businessync.subscribe`). Consequently there is **no real
+UI-thread marshalling yet**: `TuningIndexUpdatedEvent` is delivered on the publisher's thread and the `JList` is updated
+from there rather than the Swing EDT — a known gap that the Businessync (#90) and JavaFX (#99) work will close. New UI
+code should be written against the intended `run`/`runOnUi`/`subscribeOnUi` API so the migration is mechanical.
 
 ## Data flow (this module's slice)
 
@@ -89,25 +66,18 @@ User clicks/keys in JList
   → tuningService.changeTuning(IndexTuningChange(i))   (business thread, via businessync.run)
   → TuningSession.tuningIndex = i
   → publish TuningIndexUpdatedEvent                     (Businessync / Guava EventBus)
-  → TuningListFrame.onTuningChanged(...)                (@Subscribe; today: publisher's thread)
+  → TuningListFrame event handler                       (@Subscribe; today: publisher's thread)
   → listComponent.setSelectedIndex(i)                  (Swing widget update)
 ```
 
-The same `TuningIndexUpdatedEvent` path also feeds non-UI tuning changes (e.g. `PedalTuningChanger`) back into the
-list selection, keeping the displayed selection consistent with the active tuning.
+The same path also feeds non-UI tuning changes (e.g. `PedalTuningChanger`) back into the list selection, keeping the
+displayed selection consistent with the active tuning.
 
 ## Dependencies
 
-From `build.sbt` (`lazy val ui`, `build.sbt:110`–`120`):
+Its only direct dependency is `tuner`; `businessync`, `common`, and `sc-midi` arrive transitively through it (the frame
+uses Businessync types via that path). Externally it uses Java Swing and Guava's `EventBus`/`@Subscribe`. Coverage
+thresholds are currently 0 with `// TODO #182` to raise them — appropriate for code slated for replacement under #99.
 
-- **Direct dependency:** `tuner` only (`.dependsOn(tuner)`).
-- **Transitive:** `businessync`, `common`, and `sc-midi` arrive via `tuner` (`build.sbt:171`–`176`). The frame uses
-  Businessync types through this transitive path; it does not declare a direct `businessync` dependency.
-- **External:** Java Swing (JDK `javax.swing`), Guava's `EventBus`/`@Subscribe` (`com.google.common.eventbus`, pulled in
-  via the dependency graph), and `scala-logging` (`StrictLogging`).
-- `AssemblyPlugin` is disabled for this module (it produces no fat JAR of its own).
-- Coverage thresholds are currently `stmt = 0, branch = 0` with `// TODO #182` to raise them toward 80% — appropriate
-  for code slated for replacement under #99.
-
-**Depended on by:** `app` (`build.sbt:52`–`63`), which constructs `TuningListFrame`, registers it on the event bus, and
-makes it visible (`app/.../MicrotonalistApp.scala:96`–`98`). No other module depends on `ui`.
+**Depended on by** `app`, which constructs the frame, registers it on the bus, and shows it. No other module depends on
+`ui`.

--- a/docs/architecture/ui/README.md
+++ b/docs/architecture/ui/README.md
@@ -1,17 +1,113 @@
 # `ui` module architecture
 
-> **Placeholder.** TODO: document the architecture of the `ui` module (`ui/` directory). Until this is written,
-> the authoritative overview lives in the "Architecture" section of the root
-> [`CLAUDE.md`](../../../CLAUDE.md) / [`AGENTS.md`](../../../AGENTS.md).
+> **Temporary implementation.** The current GUI is built with **Java Swing**. Architecture-milestone issue
+> [#99](https://github.com/calinburloiu/microtonalist/issues/99) plans to migrate the GUI to **JavaFX**, so most of
+> what is described here (the Swing frame, the `@Subscribe` event wiring) is expected to be replaced. Treat the Swing
+> specifics as transitional; the responsibility and the business-layer contract (`TuningService` / `TuningSession`,
+> Businessync events) are the stable parts.
 
 ## Responsibility
 
-TODO: what this module does and why it exists.
+The `ui` module is the desktop graphical user interface of Microtonalist. It is a thin presentation layer on top of the
+`tuner` module: it lets the user see the sequence of tunings derived from the loaded composition and switch the
+currently active tuning, while the actual tuning logic and MIDI output live in `tuner`.
+
+Today the module is intentionally small — a single Swing window. It owns no domain state; it reads tuning state from
+the business layer and forwards user intent (tuning changes) back to it.
+
+Package: `org.calinburloiu.music.microtonalist.ui`.
 
 ## Key types
 
-TODO: the main classes / traits and their roles.
+### `TuningListFrame`
+
+`ui/src/main/scala/org/calinburloiu/music/microtonalist/ui/TuningListFrame.scala:28`
+
+The single Swing window of the application — the "Microtuner" frame opened at startup by the `app` module. It is a
+`JFrame` constructed with a `TuningService` and wired as follows:
+
+- **Display.** It renders the tunings as a single-selection `JList[String]` inside a `JScrollPane`
+  (`TuningListFrame.scala:34`–`82`). The list model is backed by `tuningService.tunings`, showing each tuning's `name`.
+- **Selection → business layer.** A `ListSelectionListener` reacts to user selection and calls
+  `tuningService.changeTuning(IndexTuningChange(index))` (`TuningListFrame.scala:43`–`49`), guarding against the
+  adjusting/`-1` transient states so only a settled selection triggers a change.
+- **Keyboard shortcuts.** A `KeyListener` adds quality-of-life navigation (`TuningListFrame.scala:51`–`80`): `Up`/`Down`
+  wrap around at the ends of the list, and number keys `1`–`9` jump to the corresponding tuning index.
+- **Frame setup.** Closing the window exits the JVM (`WindowConstants.EXIT_ON_CLOSE`) and the window is sized 480×640
+  (`TuningListFrame.scala:84`–`86`).
+- **Business → display (event handler).** `onTuningChanged(TuningIndexUpdatedEvent)` (`TuningListFrame.scala:88`–`95`)
+  updates the selected list row when the tuning index changes elsewhere (e.g. a pedal-driven `TuningChanger`), keeping
+  the GUI in sync with the session.
+
+### Collaborators (in `tuner`)
+
+The frame talks only to these `tuner`-module types; they are the stable contract for the planned JavaFX rewrite:
+
+- `TuningService` (`tuner/.../TuningService.scala:33`) — `@ThreadSafe` façade the frame is constructed with. The frame
+  uses two members:
+  - `changeTuning(EffectiveTuningChange)` — runs the mutation on the business thread via `businessync.run { … }`; the
+    frame supplies `IndexTuningChange(index)` (`PreviousTuningChange` / `NextTuningChange` also exist).
+  - `tunings: Seq[Tuning]` — **deprecated and not thread-safe** (`TuningService.scala:41`), kept only until the JavaFX
+    migration (`// TODO #99`). The frame still calls it once at construction to seed its list model
+    (`TuningListFrame.scala:30`). New UI code should obtain the list from `TuningsUpdatedEvent` instead.
+- `TuningSession` (`tuner/.../TuningSession.scala`) — holds the mutable `tunings` sequence and current `tuningIndex`;
+  publishes `TuningIndexUpdatedEvent` when the index changes and `TuningsUpdatedEvent` when the sequence changes.
+- `TuningIndexUpdatedEvent` / `TuningsUpdatedEvent` (`tuner/.../TuningEvent.scala`) — Businessync events carrying
+  `tuningIndex` and `currentTuning`. The frame currently subscribes only to `TuningIndexUpdatedEvent`.
+- `IndexTuningChange` (`tuner/.../TuningChange.scala`) — the change command the frame issues on selection.
+
+## UI ↔ business threading boundary
+
+The intended model (see the [`businessync` architecture doc](../businessync/README.md) and the project
+[Threading Model](https://github.com/calinburloiu/microtonalist/wiki/Threading-Model) wiki) separates a **business
+thread** (all domain/MIDI logic) from a **UI/GUI thread** (all widget updates). Under that model the UI should:
+
+- mutate domain state only through services that hop to the business thread (`businessync.run { … }`), never directly;
+- apply widget updates on the UI thread via `businessync.runOnUi { … }`;
+- receive events via `businessync.subscribeOnUi(…)` so handlers land on the UI thread.
+
+**Current reality (transitional, tracked by [#90](https://github.com/calinburloiu/microtonalist/issues/90) and #99):**
+
+- `Businessync.runOnUi`, `subscribeOnUi`, `subscribe`, `handleOnUi`, and `callOnUi` are still stubs (`???` / empty
+  bodies) — `businessync/.../Businessync.scala:68`,`80`,`105`. `run` simply invokes the function inline
+  (`Businessync.scala:92`), and `publish` posts straight to a Guava `EventBus` (`Businessync.scala:36`).
+- Because of that, `TuningListFrame` registers with the bus the legacy way: `app` calls
+  `businessync.register(tuningListFrame)` (`app/.../MicrotonalistApp.scala:97`), which delegates to
+  `eventBus.register(obj)` (`Businessync.scala:83`), and the frame's handler is annotated with Guava's own
+  `com.google.common.eventbus.Subscribe` (`TuningListFrame.scala:19`,`89`). The `// TODO #90` on that annotation marks
+  it for replacement by `businessync.subscribe` once Businessync is implemented.
+- Consequently there is **no real UI-thread marshalling yet**: `TuningIndexUpdatedEvent` is delivered on whatever thread
+  calls `publish` (the publisher's thread), and the `JList` is updated from there rather than from the Swing EDT. This
+  is a known gap that the Businessync (#90) and JavaFX (#99) work will close. New UI code should be written against the
+  intended `run`/`runOnUi`/`subscribeOnUi` API so the migration is mechanical.
+
+## Data flow (this module's slice)
+
+```
+User clicks/keys in JList
+  → ListSelectionListener
+  → tuningService.changeTuning(IndexTuningChange(i))   (business thread, via businessync.run)
+  → TuningSession.tuningIndex = i
+  → publish TuningIndexUpdatedEvent                     (Businessync / Guava EventBus)
+  → TuningListFrame.onTuningChanged(...)                (@Subscribe; today: publisher's thread)
+  → listComponent.setSelectedIndex(i)                  (Swing widget update)
+```
+
+The same `TuningIndexUpdatedEvent` path also feeds non-UI tuning changes (e.g. `PedalTuningChanger`) back into the
+list selection, keeping the displayed selection consistent with the active tuning.
 
 ## Dependencies
 
-TODO: which modules this depends on, and what depends on it.
+From `build.sbt` (`lazy val ui`, `build.sbt:110`–`120`):
+
+- **Direct dependency:** `tuner` only (`.dependsOn(tuner)`).
+- **Transitive:** `businessync`, `common`, and `sc-midi` arrive via `tuner` (`build.sbt:171`–`176`). The frame uses
+  Businessync types through this transitive path; it does not declare a direct `businessync` dependency.
+- **External:** Java Swing (JDK `javax.swing`), Guava's `EventBus`/`@Subscribe` (`com.google.common.eventbus`, pulled in
+  via the dependency graph), and `scala-logging` (`StrictLogging`).
+- `AssemblyPlugin` is disabled for this module (it produces no fat JAR of its own).
+- Coverage thresholds are currently `stmt = 0, branch = 0` with `// TODO #182` to raise them toward 80% — appropriate
+  for code slated for replacement under #99.
+
+**Depended on by:** `app` (`build.sbt:52`–`63`), which constructs `TuningListFrame`, registers it on the event bus, and
+makes it visible (`app/.../MicrotonalistApp.scala:96`–`98`). No other module depends on `ui`.

--- a/intonation/src/main/scala/org/calinburloiu/music/intonation/Scale.scala
+++ b/intonation/src/main/scala/org/calinburloiu/music/intonation/Scale.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Calin-Andrei Burloiu
+ * Copyright 2026 Calin-Andrei Burloiu
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,14 +18,35 @@ package org.calinburloiu.music.intonation
 
 import com.google.common.base.Preconditions.checkElementIndex
 import com.google.common.math.DoubleMath
-import org.calinburloiu.music.intonation.IntonationStandard
 
+/**
+ * Models a musical scale: an ordered, non-empty sequence of [[Interval]]s, sorted in either ascending or descending
+ * order, with each interval measured from the scale's base pitch.
+ *
+ * A scale is the high-level musical concept users work with; the application later maps it to low-level tunings. Beyond
+ * plain sequence access it exposes musical queries such as [[direction]], [[relativeIntervals]], the entropy-based
+ * [[softness]] measure, [[range]], cent-tolerant comparison ([[almostEquals]]), and conversion between
+ * [[org.calinburloiu.music.intonation.IntonationStandard]]s.
+ *
+ * Instances are immutable. Prefer the [[Scale.create]] smart constructors to obtain the most specific subtype
+ * ([[RatiosScale]], [[CentsScale]], [[EdoScale]]) for a given set of intervals.
+ *
+ * @tparam I   the type of [[Interval]] this scale is composed of; covariant, so that e.g. a `Scale[RatioInterval]` is a
+ *             `Scale[Interval]`
+ *
+ * @param name the human-readable name of the scale (it may be empty)
+ * @param intervals the ordered, non-empty, sorted intervals composing the scale, each measured from the base pitch
+ */
 class Scale[+I <: Interval](val name: String, val intervals: Seq[I]) {
   require(intervals.nonEmpty, "Expecting a non-empty list of intervals")
   require(areIntervalsSorted, "Expecting intervals to be sorted in ascending or descending order")
 
   import Scale.*
 
+  /**
+   * @param index zero-based position of the interval within the scale
+   * @return the interval at the given position
+   */
   def apply(index: Int): I = {
     checkElementIndex(index, size)
     intervals(index)
@@ -101,8 +122,18 @@ class Scale[+I <: Interval](val name: String, val intervals: Seq[I]) {
    */
   def softness: Double = entropy(size - 1)
 
+  /**
+   * Transposes the scale by stacking the given interval on top of each of its intervals.
+   *
+   * @param interval the interval to add to every interval of the scale
+   * @return a new scale with all intervals transposed
+   */
   def transpose(interval: Interval): Scale[Interval] = new Scale(name, intervals.map(_ + interval))
 
+  /**
+   * @param newName the new name for the scale
+   * @return a copy of this scale with the given name and the same intervals
+   */
   def rename(newName: String): Scale[I] = new Scale(newName, intervals)
 
   /**
@@ -125,10 +156,13 @@ class Scale[+I <: Interval](val name: String, val intervals: Seq[I]) {
     }
   }
 
+  /** @return `true` if all intervals are [[CentsInterval]]s. */
   def isCentsScale: Boolean = intervals.forall(_.isInstanceOf[CentsInterval])
 
+  /** @return `true` if all intervals are [[RatioInterval]]s. */
   def isRatiosScale: Boolean = intervals.forall(_.isInstanceOf[RatioInterval])
 
+  /** @return `true` if all intervals are [[EdoInterval]]s. */
   def isEdoScale: Boolean = intervals.forall(_.isInstanceOf[EdoInterval])
 
   /**
@@ -214,11 +248,33 @@ class Scale[+I <: Interval](val name: String, val intervals: Seq[I]) {
 }
 
 object Scale {
+  /**
+   * Creates a generic [[Scale]] from a name and a sequence of intervals, without selecting a specific subtype.
+   *
+   * @param name    name of the scale
+   * @param pitches the intervals composing the scale
+   * @return the created scale
+   */
   def apply[I <: Interval](name: String, pitches: Seq[I]): Scale[I] = new Scale(name, pitches)
 
+  /**
+   * Creates a generic [[Scale]] from a name and intervals given as varargs.
+   *
+   * @param name        name of the scale
+   * @param headPitch   the first interval
+   * @param tailPitches the remaining intervals
+   * @return the created scale
+   */
   def apply[I <: Interval](name: String, headPitch: I, tailPitches: I*): Scale[I] =
     new Scale(name, headPitch +: tailPitches)
 
+  /**
+   * Creates an unnamed generic [[Scale]] from intervals given as varargs.
+   *
+   * @param headPitch   the first interval
+   * @param tailPitches the remaining intervals
+   * @return the created scale
+   */
   def apply[I <: Interval](headPitch: I, tailPitches: I*): Scale[I] =
     Scale("", headPitch, tailPitches *)
 
@@ -256,6 +312,15 @@ object Scale {
     }
   }
 
+  /**
+   * Creates the [[Scale]] subtype matching the given [[IntonationStandard]], converting the intervals to the
+   * corresponding [[Interval]] type, ensuring a unison is present, and sorting them.
+   *
+   * @param name               name of scale to be created
+   * @param intervals          scale pitches
+   * @param intonationStandard the intonation standard determining the resulting subtype and interval type
+   * @return the created scale
+   */
   def create(name: String, intervals: Seq[Interval], intonationStandard: IntonationStandard): Scale[Interval] = {
     intonationStandard match {
       case CentsIntonationStandard => CentsScale(name, processIntervals(intervals.map(_.toCentsInterval),
@@ -269,6 +334,13 @@ object Scale {
     }
   }
 
+  /**
+   * Creates a single-interval scale containing only the unison of the given [[IntonationStandard]].
+   *
+   * @param name               name of scale to be created
+   * @param intonationStandard the intonation standard whose unison the scale contains
+   * @return the created unison scale
+   */
   def createUnisonScale(name: String, intonationStandard: IntonationStandard): Scale[Interval] =
     Scale.create(name, Seq(intonationStandard.unison), intonationStandard)
 
@@ -279,9 +351,21 @@ object Scale {
 }
 
 
+/**
+ * Result of converting a [[Scale]] to another [[IntonationStandard]] via [[Scale.convertToIntonationStandard]].
+ *
+ * @param scale             [[Some]] converted scale, or [[None]] if the conversion was not possible
+ * @param conversionQuality the worst-case quality among all per-interval conversions
+ */
 case class ScaleConversionResult(scale: Option[Scale[Interval]], conversionQuality: IntonationConversionQuality)
 
 
+/**
+ * A [[Scale]] whose intervals are all [[RatioInterval]]s, i.e. expressed as just-intonation frequency ratios.
+ *
+ * @param name      the human-readable name of the scale (it may be empty)
+ * @param intervals the ordered, non-empty, sorted just-intonation intervals composing the scale
+ */
 case class RatiosScale(override val name: String,
                        override val intervals: Seq[RatioInterval]) extends Scale[RatioInterval](name, intervals) {
 
@@ -315,6 +399,12 @@ object RatiosScale {
 }
 
 
+/**
+ * A [[Scale]] whose intervals are all [[CentsInterval]]s, i.e. expressed in decimal cents.
+ *
+ * @param name      the human-readable name of the scale (it may be empty)
+ * @param intervals the ordered, non-empty, sorted cents intervals composing the scale
+ */
 case class CentsScale(override val name: String,
                       override val intervals: Seq[CentsInterval]) extends Scale[CentsInterval](name, intervals) {
 
@@ -353,10 +443,19 @@ object CentsScale {
     CentsScale("", headCentValue, tailCentValues *)
 }
 
+/**
+ * A [[Scale]] whose intervals are all [[EdoInterval]]s belonging to the same EDO (equal division of the octave).
+ *
+ * All intervals must share the same [[edo]] value.
+ *
+ * @param name      the human-readable name of the scale (may be empty)
+ * @param intervals the ordered, non-empty, sorted EDO intervals composing the scale, all sharing the same `edo`
+ */
 case class EdoScale(override val name: String,
                     override val intervals: Seq[EdoInterval]) extends Scale[EdoInterval](name, intervals) {
   require(intervals.forall(_.edo == edo))
 
+  /** @return the number of equal divisions of the octave (EDO) shared by all intervals of this scale. */
   def edo: Int = intervals.head.edo
 
   def transpose(interval: EdoInterval): EdoScale = {

--- a/issues/00208-agents-rules/architecture-prompt.md
+++ b/issues/00208-agents-rules/architecture-prompt.md
@@ -1,0 +1,38 @@
+# Architecture Documents Prompt
+
+Your task is to factor out the content of the "Architecture" section from `CLAUDE.md`.
+- **Keep**. Crucial architecture information will still need to be loaded in context for each session. But we still want to declutter `CLAUDE.md`, so we are going to only leave a phrase in that section and  use an `@import` from a new file `docs/agents/architecture.md` with the crucial information.
+- **Move**. Context-specific information will not be loaded anymore for each session. We already have a scaffold mechanism for loading architecture documents via subdirectory `CLAUDE.md` files. Check each module `CLAUDE.md` file and how each imports a corresponding document from `docs/architecture/$MODULE/`. Those imported documents are placeholders right now, but you task is to add details to them.
+
+The sections below details what we want to **keep** in context for each session and what we want to **move** to an architecture document.
+
+Architecture documents from `docs/architecture/` are meant to be consumed by both humans and agents. 
+
+You may add generic details for humans to `docs/architecture/README.md`, including things that are currently in `CLAUDE.md`.
+
+Section "Strategy" bellow describes how should this task be implemented.
+
+## Keep
+
+Keep the following subsections:
+- "Module Overview"
+- "Key Domain Concepts"
+- "Data Flow"
+
+## Move
+
+- "Format / Serialization" subsection content goes to `docs/architecture/format/`.
+- "Threading Model (Businessync)" subsection goes to `docs/architecture/businessync/`.
+- "Application Entry Point" subsection content goes to `docs/architecture/app/`.
+
+## Strategy
+
+Use `/superpowers:brainstorming` skill. Use the current branch. When finishing the work, an issue should be created and a PR.
+
+Spawn a subagent with the same model and effort for each module. Each should investigate the architecture of its module by exploring its code and ScalaDocs. It may use Metals MCP to understand relations between classes. It should write architectural information in its module docs directory (`docs/architecture/$MODULE/`) in parallel; there shouldn't be any write conflicts because they use different directories.
+
+When all subagents finish, the main agent ensures that module architecture outputs are consistent and make sense as a whole. It can then update the root `docs/architecture/README.md` for humans and `docs/agents/architecture.md` for agents.
+
+All agents may study the open issues with milestone `Architecture` where appropriate to understand how the architecture is planned to change in the future. They may add details about this stating when some things are temporary and subject to change. The following Wiki pages can also be examined where applicable: https://github.com/calinburloiu/microtonalist/wiki/Threading-Model, https://github.com/calinburloiu/microtonalist/wiki/End%E2%80%90to%E2%80%90end-Flows.
+
+In `CLAUDE.md`, the "Coding Workflow" section needs to updated (see the bullet with "TODO"). We want the coding agent to have a task before coding that explores the architecture documents that are strictly relevant for the prompt. Either `CLAUDE.md` or the imported `docs/agents/architecture.md` should inform the agent how architecture documents are organized to accomplish this initial task.


### PR DESCRIPTION
Resolves #212. Follow-up to #208.

Declutters the root `AGENTS.md` / `CLAUDE.md` **Architecture** section: the crucial overview stays always-in-context
via an `@import`, while context-specific detail moves into the per-module architecture docs (loaded on demand through
each module's `CLAUDE.md`).

## Keep (always loaded)

- New `docs/agents/architecture.md` holds **Module Overview**, **Key Domain Concepts**, and **Data Flow**, plus a
  "How architecture docs are organized" preamble. It is `@import`ed from `AGENTS.md`; the Architecture section there is
  now just a short pointer phrase.

## Move (loaded on demand)

- **Threading Model (Businessync)** → `docs/architecture/businessync/`
- **Format / Serialization** → `docs/architecture/format/`
- **Application Entry Point** → `docs/architecture/app/`

## Per-module docs

- All 12 placeholder `docs/architecture/$MODULE/README.md` files are replaced with code-verified architecture docs
  (responsibility, key types with `path:line` references, dependencies, module-specific concerns). Each was researched
  by a dedicated subagent exploring the module via Metals.
- Areas expected to change are flagged as *subject to change* under the
  [`Architecture`](https://github.com/calinburloiu/microtonalist/milestone/13) milestone (Swing→JavaFX #99,
  module-wiring/DI #100, composition refactor #87, businessync threading/sequential-consistency #90).

## Coding workflow

- The placeholder `TODO task architecture exploration` bullet becomes a real pre-coding step: read the always-loaded
  overview plus the architecture docs strictly relevant to the prompt.

## Other

- `docs/architecture/README.md` (human-facing) refreshed: outdated "placeholder" status banner replaced with a pointer
  to the agent overview and a module dependency overview.

Spec: `issues/00208-agents-rules/architecture-prompt.md`.

> Note: a notable finding while writing the businessync/ui docs — the two-thread Businessync model is still largely
> aspirational (`runOnUi`/`subscribeOnUi`/etc. are `???`/no-op stubs; delivery currently uses Guava `@Subscribe` +
> `register`). The docs describe the intended model and clearly flag what is and isn't implemented yet (#90).