### PR TITLE
[#214] Shrink the always-loaded CLAUDE.md / AGENTS.md context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ Scala 3 and is built by using sbt 1.
   sbt only when it is unavailable (see [`docs/development/build.md`](docs/development/build.md)).
 - Before writing code, create a task to explore the architecture: read the always-loaded overview imported in the
   [Architecture](#architecture) section (from [`docs/agents/architecture.md`](docs/agents/architecture.md)) plus the
-  architecture documents strictly relevant to the prompt — typically the
-  [`docs/architecture/$MODULE/README.md`](docs/architecture/) of each module you will touch and its immediate
-  collaborators. That overview explains how the architecture documents are organized.
+  architecture documents strictly relevant to the prompt — typically the `docs/architecture/$MODULE/README.md` of each
+  module you will touch and its immediate collaborators. That overview explains how the architecture documents are
+  organized.
 - Use strict Test Driven Development (_TDD_) by following the _red/green/refactor_ cycle:
     - **Red**. Write failing tests first. If the compiler requires it, create the thinnest possible stub (`???` bodies,
       no logic) to get them to compile, then confirm the tests fail for the right reason. The tests failure reason
@@ -88,8 +88,7 @@ At the start of every conversation, **once** per session:
 
 1. Detect the running stack with `bin/microtonalist-dev-stack status` (exit 0 if running, 1 if not). If it is not
    running, follow [`docs/agents/dev-stack.md`](docs/agents/dev-stack.md) before continuing.
-2. If the Metals MCP is available, run a full compile via `mcp__metals__compile-full` to warm up the Metals index
-   (populates SemanticDB so symbol resolution and find-usages work from the first query).
+2. If the Metals MCP is available, run a full compile via `mcp__metals__compile-full` to warm up the Metals index.
 
 ## Compiling
 
@@ -118,9 +117,6 @@ when you invoke it — precisely so it does not clutter context up front, since 
 implementation is finished.
 
 # Architecture
-
-The always-loaded architecture overview (module graph, key domain concepts, data flow) is imported below; it also
-explains how the on-demand per-module and per-topic docs under [`docs/architecture/`](docs/architecture/) are organized.
 
 @docs/agents/architecture.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,6 @@ find-usages, source/docs retrieval, compilation, Coursier dependency lookup). Se
 parameters. If Metals MCP is not available, fall back to the usual CLI tools (`sbt`/`sbtn`, `rg`, `find`, `WebFetch`,
 etc.).
 
-Prefer the Metals MCP over calling `sbt` processes for compiling code as detailed in the Build section below (TODO).
-
 Prefer the Metals MCP over textual tools (`rg`, `grep`, `git grep`, `fd`, `find`) for symbol inspection, symbol search,
 finding usages, and understanding class/trait hierarchy — the textual alternatives can't distinguish a class from a
 same-named variable, follow overrides, or resolve imports. Use symbol search to reduce duplicated code by finding
@@ -58,11 +56,9 @@ already implemented functionality. Use the read docs functionality to understand
 
 ## Symbol search file focus
 
-`mcp__metals__glob-search` and `mcp__metals__typed-glob-search` require a `fileInFocus` parameter — they cannot infer
-the build target without it. The search scope is limited to the classpath of the inferred build target, so always use a
-file from a module with the broadest classpath.
-
-The top-level modules and the representative files to use as `fileInFocus` for project-wide symbol searches are:
+`mcp__metals__glob-search` and `mcp__metals__typed-glob-search` require a `fileInFocus` parameter (they cannot infer the
+build target) and search only that target's classpath — so use a file from the module with the broadest classpath. The
+representative files for project-wide searches are:
 
 - `app` — covers `appConfig`, `businessync`, `common`, `composition`, `intonation`, `format`, `scMidi`, `tuner`, `ui`:
   `app/src/main/scala/org/calinburloiu/music/microtonalist/MicrotonalistApp.scala`
@@ -71,43 +67,29 @@ The top-level modules and the representative files to use as `fileInFocus` for p
 - `experiments` — separate executable covering `intonation`; may contain symbols not in `app`:
   `experiments/src/main/scala/org/calinburloiu/music/microtonalist/experiments/SoftChromaticGenusStudy.scala`
 
-For a full project-wide search, query all three in parallel. Only use a lower-level module file when intentionally
-scoping the search to that module's classpath.
+For a project-wide search, query all three in parallel; use a lower-level module file only to intentionally scope to
+that module's classpath.
 
 # Build
 
-The repository is built using SBT 1, Scala 3, and Java 23. It is split into multiple SBT projects that act as modules,
-libraries, or separate executable applications. We will simply call each of those SBT projects modules. Each one is
-located in the repository root. Check `build.sbt` for details. The `root` SBT project aggregates all the other projects.
-The executable application is in `app` SBT project. `cli` is CLI tool application for various utilities, like listing
-the MIDI devices connected to the computer.
+Built with **SBT 1, Scala 3, and Java 23**. The repo is split into multiple SBT projects (we call them modules), all in
+the repo root: `root` aggregates them all, `app` is the executable application, and `cli` is a utility tool (e.g.
+listing connected MIDI devices). See `build.sbt` and [`docs/development/build.md`](docs/development/build.md).
 
 ## sbt invocations: prefer the BSP server via `sbtn`
 
-The development stack started by `bin/microtonalist-dev-stack start` runs a single long-lived sbt JVM that serves two
-clients at once: Metals (via BSP) and the `sbtn` thin client (via the sbt server protocol). Run all sbt commands through
-`sbtn` so they execute in that one JVM rather than spawning a fresh `sbt` JVM each time — spawning duplicates
-compilation work and runs the second JVM with no awareness of the BSP server's incremental state. The per-project
-`target` isolation described below is belt-and-braces protection: it keeps a stray second `sbt` from racing the BSP
-server on the same `classes/` tree (which is what produced the TASTy load concurrency errors in issue #186), but routing
-through `sbtn` is the primary fix.
-
-The BSP-server sbt is launched with `-Dmicrotonalist.build.targetSuffix=-bsp` (see `targetSuffixOverride` in
-`build.sbt`), so its compiled outputs live under `<project>/target-bsp/` rather than `<project>/target/`. CLI sbt
-invocations without that property continue to use `<project>/target/`. The two trees never collide; `sbt clean` and
-`sbtn clean` each clean the active tree.
+Route **all** sbt commands through `sbtn` so they run on the single long-lived BSP-server JVM rather than spawning a
+fresh `sbt` JVM. BSP-server builds write to `<project>/target-bsp/` (not `<project>/target/`), so the two never
+collide. See [`docs/agents/dev-stack.md`](docs/agents/dev-stack.md) for why, and for starting and routing the stack.
 
 ## Warm-up
 
-At the start of every conversation, **once** per session, do the following warm-up actions:
+At the start of every conversation, **once** per session:
 
 1. Detect the running stack with `bin/microtonalist-dev-stack status` (exit 0 if running, 1 if not). If it is not
-running, follow [`docs/agents/dev-stack.md`](docs/agents/dev-stack.md) before continuing. Once the stack is up, every
-subsequent sbt command should just use `sbtn …`. Trust it is up unless a command unexpectedly fails (e.g. with a connect
-error), in which case re-run this check.
-2. If the Metals MCP is available, run a full compile via `mcp__metals__compile-full`
-to warm up the Metals index. This ensures SemanticDB is populated so that symbol resolution, find-usages, and other
-semantic tools work correctly from the first query.
+   running, follow [`docs/agents/dev-stack.md`](docs/agents/dev-stack.md) before continuing.
+2. If the Metals MCP is available, run a full compile via `mcp__metals__compile-full` to warm up the Metals index
+   (populates SemanticDB so symbol resolution and find-usages work from the first query).
 
 ## Compiling
 
@@ -116,10 +98,9 @@ Prefer the Metals MCP for compiling when it is available:
 - Compile the whole project: `mcp__metals__compile-full`
 - Compile a single module `${MODULE}`: `mcp__metals__compile-module` with `module = "${MODULE}"`
 
-Fall back to `sbt`/`sbtn` only when the Metals MCP is not available, or for a final full build or fat JAR assembly. The
-sbt-based compile, single-module, and `assembly` commands are documented in
-[`docs/development/build.md`](docs/development/build.md). Use `sbtn` rather than spawning a fresh `sbt` JVM whenever the
-BSP server is up (see "sbt invocations: prefer the BSP server via `sbtn`" section above).
+Fall back to `sbt`/`sbtn` only when the Metals MCP is unavailable, or for a final full build or fat JAR assembly; the
+sbt-based compile, single-module, and `assembly` commands are in
+[`docs/development/build.md`](docs/development/build.md).
 
 # Test
 
@@ -138,10 +119,8 @@ implementation is finished.
 
 # Architecture
 
-Crucial architecture context — the module dependency graph, the key domain concepts, and the end-to-end data flow — is
-imported below and loads in every session. Deeper, context-specific detail lives in the per-module and per-topic
-documents under [`docs/architecture/`](docs/architecture/), each loaded on demand via its module's `CLAUDE.md`. The
-imported overview also explains how those documents are organized, so you can find the ones relevant to a task.
+The always-loaded architecture overview (module graph, key domain concepts, data flow) is imported below; it also
+explains how the on-demand per-module and per-topic docs under [`docs/architecture/`](docs/architecture/) are organized.
 
 @docs/agents/architecture.md
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -6,9 +6,9 @@ the per-module and per-topic documents under [`docs/architecture/`](../architect
 
 ## How architecture docs are organized
 
-- **This file (`docs/agents/architecture.md`)** — the always-in-context overview. It adds agent-specific guidance (how
-  the docs are organized and what to read before coding), then `@import`s the three shared overview documents below so
-  they stay always-loaded for agents. It holds no architecture content of its own.
+- **This file (`docs/agents/architecture.md`)** — the always-in-context overview: it explains how these docs are
+  organized, says what to read before coding, and `@import`s the three shared overview documents below. It holds no
+  architecture content of its own.
 - **Shared overview documents (`docs/architecture/`)** — the single source of truth for the cross-cutting basics,
   imported here and linked from the human-facing index:
   [`module-overview.md`](../architecture/module-overview.md) (the module dependency graph),
@@ -31,9 +31,8 @@ as the current state of the code.
 
 ## Always-loaded overview
 
-The module dependency graph, the key domain concepts, and the end-to-end data flow are imported below so they remain in
-context for every session. They are maintained under [`docs/architecture/`](../architecture/) as the single source of
-truth — humans read them via the [index](../architecture/README.md); edit them there, not here.
+Imported below so they stay in context every session — maintained under
+[`docs/architecture/`](../architecture/) as the single source of truth, so edit them there, not here:
 
 @../architecture/module-overview.md
 @../architecture/domain-concepts.md

--- a/docs/agents/dev-stack.md
+++ b/docs/agents/dev-stack.md
@@ -8,9 +8,9 @@ Background: the development stack started by `bin/microtonalist-dev-stack start`
 serves two clients at once: Metals (via BSP) and the `sbtn` thin client (via the sbt server protocol). Run all sbt
 commands through `sbtn` so they execute in that one JVM rather than spawning a fresh `sbt` JVM each time — spawning
 duplicates compilation work and runs the second JVM with no awareness of the BSP server's incremental state. The
-per-project `target` isolation (see the Build section of the root `CLAUDE.md`) is belt-and-braces protection: it keeps
-a stray second `sbt` from racing the BSP server on the same `classes/` tree (which is what produced the TASTy load
-errors in issue #186), but routing through `sbtn` is the primary fix.
+per-project `target` isolation (see [Build output directories](../development/build.md)) is belt-and-braces protection:
+it keeps a stray second `sbt` from racing the BSP server on the same `classes/` tree (which is what produced the TASTy
+load errors in issue #186), but routing through `sbtn` is the primary fix.
 
 ## When the stack is not running
 

--- a/docs/architecture/domain-concepts.md
+++ b/docs/architecture/domain-concepts.md
@@ -1,7 +1,8 @@
 # Key domain concepts
 
 The core domain vocabulary of Microtonalist, grouped by the module that owns each type. This is the high-level model the
-rest of the architecture docs assume; each module's own README in this directory goes deeper.
+rest of the architecture docs assume; each module's own README in this directory goes deeper (including the concrete
+implementations of each Plugin family).
 
 **Intonation (`intonation` module, `org.calinburloiu.music.intonation`):**
 
@@ -14,21 +15,14 @@ rest of the architecture docs assume; each module's own README in this directory
 
 **Composition (`composition` module, `org.calinburloiu.music.microtonalist.composition`):**
 
-- `Composition` — top-level container that models a microtonal musical composition with respect to its microtonal
-  scales and how are mapped to tunings: holds an `IntonationStandard`, a `TuningReference`, a sequence of
-  `TuningSpec`, a `TuningReducer`, and fill configuration
+- `Composition` — top-level container for a microtonal composition: holds an `IntonationStandard`,
+  a `TuningReference`, a sequence of `TuningSpec`, a `TuningReducer`, and fill configuration
 - `TuningMapper` (trait, Plugin) — maps a `Scale` to a `Tuning`, deciding which keyboard pitch class each scale pitch
-  occupies (unused keys stay `None`) and throwing a `TuningMapperConflictException` when two pitches collide on one key;
-  `AutoTuningMapper` places pitches automatically (handling quarter tones and the soft chromatic genus),
-  `ManualTuningMapper` uses a user-provided `KeyboardMapping`
-- `TuningReducer` (trait, Plugin) — merges the per-`TuningSpec` `Tuning`s into ideally fewer final tunings to minimize
-  the tuning switches a player must make, producing the `TuningList`; `MergeTuningReducer` (default) merges consecutive
-  non-conflicting tunings and applies local back-/fore-fill, while `DirectTuningReducer` applies only the global fill
-  (no reduction)
+  occupies (unused keys stay `None`) and throwing a `TuningMapperConflictException` when two pitches collide on one key
+- `TuningReducer` (trait, Plugin) — merges the per-`TuningSpec` `Tuning`s into ideally fewer final tunings (minimizing
+  the tuning switches a player must make), producing the `TuningList`
 - `TuningReference` (trait, Plugin) — defines the composition's base pitch: the keyboard pitch class it maps to
-  (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`;
-  `StandardTuningReference` is relative to 12-EDO, `ConcertPitchTuningReference` is relative to a concert-pitch
-  frequency
+  (`basePitchClass`) and that pitch's cents offset from 12-EDO (`baseOffset`), combined as a `baseTuningPitch`
 - `TuningSpec` — pairs a `Scale` with a `TuningMapper` and an optional transposition
 - `TuningList` — the resolved sequence of `Tuning` objects built from a `Composition`
 
@@ -36,9 +30,8 @@ rest of the architecture docs assume; each module's own README in this directory
 
 - `Tuning` — 12 optional cent offsets for pitch classes; `Tuning.Standard` is 12-EDO
 - `Tuner` (trait, Plugin) — processes MIDI messages: `reset()`, `tune(tuning)`, `process(message)`; implementations
-  cover all MTS Octave variants, MPE, and monophonic tuning via Pitch Bend
-- `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages (e.g.,
-  `PedalTuningChanger`)
+  cover the supported tuning protocols (MTS Octave, MPE, monophonic Pitch Bend)
+- `TuningChanger` (trait, Plugin) — decides when to change tuning by inspecting MIDI messages
 - `Track` — one instrument pipeline: input device → `TuningChangeProcessor` → `TunerProcessor` → output device
 - `TuningSession` / `TuningService` — holds current tuning index and exposes thread-safe API for changing it
 - `TrackManager` — lifecycle manager for tracks; reacts to MIDI device events

--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -16,6 +16,14 @@ libraries, or separate executable applications — we simply call each of those 
 in the repository root. Check `build.sbt` for details. The `root` SBT project aggregates all the other projects. The
 executable application is in the `app` SBT project.
 
+## Build output directories
+
+The dev-stack's BSP server is launched with `-Dmicrotonalist.build.targetSuffix=-bsp` (see `targetSuffixOverride` in
+`build.sbt`), so its compiled outputs live under `<project>/target-bsp/` rather than `<project>/target/`. Plain CLI
+`sbt` invocations (without that property) keep using `<project>/target/`. The two trees never collide, which avoids the
+TASTy load concurrency errors that a stray second `sbt` racing the BSP server on the same `classes/` tree once produced
+(issue #186). `sbt clean` and `sbtn clean` each clean only the active tree.
+
 ## Compiling
 
 Compiling the whole `root` SBT project:

--- a/docs/development/coding-conventions.md
+++ b/docs/development/coding-conventions.md
@@ -1,7 +1,7 @@
 # Scala Coding Conventions
 
-This document describes general (mainly production code) coding conventions for this repository. Test-specific
-conventions live in [`test-conventions.md`](test-conventions.md).
+General (mainly production-code) Scala conventions for this repository. Test conventions live in
+[`test-conventions.md`](test-conventions.md).
 
 ## General formatting
 

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -42,6 +42,10 @@ configured threshold still holds and that any new files meet the 80% target. Pic
 Both commands are defined in `project/Coverage.scala`; see its ScalaDoc for the workflow's implementation details.
 There is also a `coverageCheck` command used by CI.
 
+Both `coverageModules` and `coverageAll` bracket the run with `clean` on both sides (clearing stale instrumentation
+before, removing instrumented `.class`/`.tasty` afterward), so do not run `sbt clean` after them or `sbt coverageClean`
+pre-emptively — the latter only forces needless re-instrumentation of unrelated modules.
+
 If a coverage command fails with TASTy/companion-class errors, `Not found: type X`, or `NoClassDefFoundError` at test
 runtime, see [`docs/development/scoverage-issue.md`](scoverage-issue.md) before assuming it is a code defect — the
 typical response is to retry the command, not to change source code.

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -42,10 +42,7 @@ configured threshold still holds and that any new files meet the 80% target. Pic
 Both commands are defined in `project/Coverage.scala`; see its ScalaDoc for the workflow's implementation details.
 There is also a `coverageCheck` command used by CI.
 
-Both `coverageModules` and `coverageAll` begin with `clean` (the workflow is `clean; coverage; test; coverageReport`,
-plus `coverageAggregate` for `coverageAll`), so you need not `sbt clean` beforehand or hand-roll that sequence. They do
-not clean afterward, and there is no need to: with the recommended target-suffix isolation (see above), instrumented
-output lands under `target-scoverage/`, away from your normal `target/`.
+Both `coverageModules` and `coverageAll` begin with `clean`, so you need not `sbt clean` beforehand.
 
 If a coverage command fails with TASTy/companion-class errors, `Not found: type X`, or `NoClassDefFoundError` at test
 runtime, see [`docs/development/scoverage-issue.md`](scoverage-issue.md) before assuming it is a code defect — the

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -42,9 +42,10 @@ configured threshold still holds and that any new files meet the 80% target. Pic
 Both commands are defined in `project/Coverage.scala`; see its ScalaDoc for the workflow's implementation details.
 There is also a `coverageCheck` command used by CI.
 
-Both `coverageModules` and `coverageAll` bracket the run with `clean` on both sides (clearing stale instrumentation
-before, removing instrumented `.class`/`.tasty` afterward), so do not run `sbt clean` after them or `sbt coverageClean`
-pre-emptively — the latter only forces needless re-instrumentation of unrelated modules.
+Both `coverageModules` and `coverageAll` begin with `clean` (the workflow is `clean; coverage; test; coverageReport`,
+plus `coverageAggregate` for `coverageAll`), so you need not `sbt clean` beforehand or hand-roll that sequence. They do
+not clean afterward, and there is no need to: with the recommended target-suffix isolation (see above), instrumented
+output lands under `target-scoverage/`, away from your normal `target/`.
 
 If a coverage command fails with TASTy/companion-class errors, `Not found: type X`, or `NoClassDefFoundError` at test
 runtime, see [`docs/development/scoverage-issue.md`](scoverage-issue.md) before assuming it is a code defect — the

--- a/docs/development/test-conventions.md
+++ b/docs/development/test-conventions.md
@@ -14,11 +14,9 @@ Conventionally, the tests for a given production class use the same package and 
 
 ## Behavior-driven style
 
-The project uses the `scalatest` library for testing and `scalamock` for mocking / stubbing. Tests are written using
-ScalaTest 3. The "behavior-driven" style of development (BDD) is preferred for writing tests by making tests classes
-extend `org.scalatest.flatspec.AnyFlatSpec` and `org.scalatest.matchers.should.Matchers`. When using this style of
-tests, test cases are grouped in behavior sections by using `behavior of`. When adding a new test case to a
-behavior-driven suite consider the following:
+Tests use `scalatest` (ScalaTest 3) with `scalamock` for mocking / stubbing. Prefer the behavior-driven (BDD) style:
+test classes extend `org.scalatest.flatspec.AnyFlatSpec` and `org.scalatest.matchers.should.Matchers`, and group cases
+into `behavior of` sections. When adding a new test case to such a suite:
 
 * **Check the test class ScalaDoc first.** Some test classes carry a ScalaDoc comment that documents
   class-specific conventions — categories, subgroup structure, test-naming rules.
@@ -31,8 +29,8 @@ behavior-driven suite consider the following:
 
 ## Use Given / When / Then comments in tests
 
-Tests cases should be written using the `Given` / `When` / `Then` format. Some tests may not have a `Given` section,
-while others may have multiple instances if the three. It's acceptable to combine two, like `When / Then` in some cases.
+Write test cases in the `Given` / `When` / `Then` format. A test may omit `Given`, repeat any of the three, or combine
+two (e.g. `When / Then`).
 
 Wrong:
 
@@ -66,8 +64,8 @@ Correct:
 
 ## Use fixtures to reduce duplication in test cases setup
 
-Simplify the setup of test cases, typically the `Given` section, by using `trait` or `abstract class` fixtures. They
-should contain code that repeats in many test cases. But be mindful not to sacrifice readability.
+Simplify test setup (typically the `Given` section) with `trait` or `abstract class` fixtures holding code that repeats
+across many cases — but don't sacrifice readability.
 
 ## No `if`s in tests
 


### PR DESCRIPTION
Resolves #214.

Trims the always-loaded agent context — `AGENTS.md` (symlinked as `CLAUDE.md`) plus its `@import` chain — from **27,528 → 24,565 bytes (−10.8%, ~−740 tokens)**, by relocating *rationale* to on-demand docs and cutting *prose/duplication*. No rule the agent must follow, and no fact it needs in context, was dropped.

### Guiding principle
`AGENTS.md` + its imports are the **only** always-loaded place; `build.md`, `dev-stack.md`, per-module READMEs and skills load on demand. So: keep facts terse in `AGENTS.md`, relocate only the *why* — never push a needed fact into an on-demand doc.

### Changes
| File | Before | After |
|------|------:|------:|
| `AGENTS.md` | 10,543 | 8,684 |
| `docs/agents/architecture.md` | 2,958 | 2,741 |
| `docs/architecture/domain-concepts.md` | 3,575 | 3,048 |
| `docs/development/test-conventions.md` | 4,368 | 4,042 |
| `docs/development/coding-conventions.md` | 3,418 | 3,384 |

- **`AGENTS.md`** — collapsed the Build-section duplication (the single-JVM/`sbtn` rationale already lived verbatim in `dev-stack.md`). Kept facts terse: SBT 1 / Scala 3 / Java 23, that BSP builds write to `target-bsp/`, and the three `fileInFocus` files. Removed a stray `(TODO)` line.
- **`build.md`** — now holds the relocated `target-bsp` *mechanism* (`targetSuffixOverride`, issue-#186 history).
- **`dev-stack.md`** — repointed its target-isolation cross-ref from "root `CLAUDE.md`" to `build.md`.
- **`docs/agents/architecture.md`** — removed framing duplicated between its two sections.
- **`domain-concepts.md`** — Plugin entries trimmed to family level; concrete impls left to per-module READMEs.
- **convention docs** — prose-only trims; every wrong/right example kept.
- **`coverage.md`** — absorbed the one unique nuance from a removed agent memory before deletion.

### Out of band (not in this PR — agent memory store under `~/.claude`)
Removed three agent memories now covered by always-loaded docs (`feedback_metals_mcp`, `feedback_tdd_enforcement`, `feedback_coverage_commands`), fixed the resulting wikilinks, and added one memory capturing the keep-fact/relocate-why principle.

### Verification
- Byte trace re-run: 27,528 → 24,565.
- No *added* line exceeds 120 columns (pre-existing em-dash lines untouched).
- All relocated links resolve; no dangling memory wikilinks.
- Docs-only change — no compile/tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)