### PR TITLE
[#216] Store the current tuning in the `Tuner` trait

### DIFF
--- a/docs/architecture/tuner/README.md
+++ b/docs/architecture/tuner/README.md
@@ -29,8 +29,9 @@ named-note accessors and combinators — notably `fill`, `overwrite`, and `merge
 beyond tolerance) — that the `composition` reducer uses when combining tunings. `Tuning.Standard` is 12-EDO.
 
 **Tuners.** `Tuner` (the `@NotThreadSafe` plugin trait) is the protocol abstraction; its three methods define the
-contract the pipeline drives: `reset()` configures the output device, `tune(tuning)` stores a tuning and emits the
-messages it requires now, and `process(message)` rewrites each message flowing through the track. Implementations:
+contract the pipeline drives: `reset()` configures the output device, `tune(tuning)` stores the tuning in the trait
+(exposed via the `tuning` getter) and then delegates protocol-specific message generation to each implementation's
+`onTune` hook, and `process(message)` rewrites each message flowing through the track. Implementations:
 
 - `MtsTuner` and its four octave variants (`MtsOctave{1,2}Byte{Non,}RealTimeTuner`) retune the instrument's pitch table
   in advance via a single MTS SysEx, so notes pass through untouched. The SysEx bytes are built by `MtsMessageGenerator`

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTuner.scala
@@ -45,7 +45,6 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   // single tracker slot. `outputChannel` is reused as that slot — it's already a valid 0..15 channel.
   private def trackedChannel: Int = outputChannel
 
-  private var _currTuning: Tuning = Tuning.Standard
   private var _pitchBendSensitivity: PitchBendSensitivity = defaultPitchBendSensitivity
 
   private val tracker: ScMidiChannelStateTracker = ScMidiChannelStateTracker()
@@ -66,7 +65,7 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   }
 
   private def _resetState(): Unit = {
-    _currTuning = Tuning.Standard
+    tuning = Tuning.Standard
     _pitchBendSensitivity = defaultPitchBendSensitivity
     tracker.reset()
     _lastSingleNote = 0
@@ -80,8 +79,12 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   private def _init(): Seq[MidiMessage] = PitchBendSensitivityMessages.create(
     outputChannel, defaultPitchBendSensitivity)
 
-  override def tune(tuning: Tuning): Seq[MidiMessage] = {
-    currTuning = tuning
+  override protected def onTune(previousTuning: Tuning, tuning: Tuning): Seq[MidiMessage] = {
+    // Update currTuningPitchBend if the offset of the current note changed between the previous and new tuning.
+    val newOffset = tuning(lastNote.pitchClass)
+    if (previousTuning(lastNote.pitchClass) != newOffset) {
+      currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(newOffset, pitchBendSensitivity)
+    }
 
     // Update pitch bend for the current sounding note
     if (isAnyNoteOn) applyPitchBend().toSeq else Seq.empty
@@ -145,18 +148,6 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     tracker.send(normalized)
   }
 
-  private def currTuning: Tuning = _currTuning
-
-  private def currTuning_=(newTuning: Tuning): Unit = {
-    // Update currTuningPitchBend
-    val newOffset = newTuning(lastNote.pitchClass)
-    if (currTuning(lastNote.pitchClass) != newOffset) {
-      currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(newOffset, pitchBendSensitivity)
-    }
-
-    _currTuning = newTuning
-  }
-
   private def isSettingPitchBendSensitivity: Boolean =
     tracker.rpnSelector(trackedChannel) == ScMidiChannelStateTracker.RpnSelector.Rpn(
       ScMidiRpn.PitchBendSensitivityMsb, ScMidiRpn.PitchBendSensitivityLsb)
@@ -181,7 +172,7 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     if (_pitchBendSensitivity != value) {
       _pitchBendSensitivity = value
       // Update currTuningPitchBend for the current note using the new sensitivity
-      val offset = currTuning(lastNote.pitchClass)
+      val offset = tuning(lastNote.pitchClass)
       currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(offset, _pitchBendSensitivity)
     }
   }
@@ -200,8 +191,8 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
   private def turnNoteOn(buffer: mutable.Buffer[MidiMessage], note: MidiNote, velocity: Int,
                          prevLastNote: MidiNote): Unit = {
     // Update currTuningPitchBend by comparing against the tuning offset of the previously held note
-    val newOffset = currTuning(note.pitchClass)
-    if (currTuning(prevLastNote.pitchClass) != newOffset) {
+    val newOffset = tuning(note.pitchClass)
+    if (tuning(prevLastNote.pitchClass) != newOffset) {
       currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(newOffset, pitchBendSensitivity)
     }
 
@@ -227,13 +218,13 @@ case class MonophonicPitchBendTuner(outputChannel: Int,
     if (prevNotes.nonEmpty && prevNotes.last == note) {
       applyNoteOff(buffer, note, velocity)
 
-      val oldOffset = currTuning(note.pitchClass)
+      val oldOffset = tuning(note.pitchClass)
       // After tracker.send the released note is gone, so the post-state can be read fresh
       val notesAfter = tracker.orderedActiveNotes(trackedChannel)
       // Play the next note from the previous one held down, if available
       if (notesAfter.nonEmpty) {
         val newLast = notesAfter.last
-        val newOffset = currTuning(newLast.pitchClass)
+        val newOffset = tuning(newLast.pitchClass)
         if (oldOffset != newOffset) {
           currTuningPitchBend = PitchBendScMidiMessage.convertCentsToValue(newOffset, pitchBendSensitivity)
         }

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -69,8 +69,6 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
   private var _zones: MpeZones = initialZones
   private var _inputMode: MpeInputMode = initialInputMode
 
-  private var _tuning: Tuning = Tuning.Standard
-
   private var lowerAllocator: Option[MpeChannelAllocator] = createAllocator(lowerZone)
   private var upperAllocator: Option[MpeChannelAllocator] = createAllocator(upperZone)
 
@@ -97,11 +95,6 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
    */
   def inputMode: MpeInputMode = _inputMode
 
-  /**
-   * @return current tuning
-   */
-  def tuning: Tuning = _tuning
-
   override def reset(): Seq[MidiMessage] = {
     val buffer = mutable.Buffer[MidiMessage]()
     // Emit Note Off for every active note before switching input mode / zone layout,
@@ -114,8 +107,7 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     buffer.toSeq
   }
 
-  override def tune(tuning: Tuning): Seq[MidiMessage] = {
-    _tuning = tuning
+  override protected def onTune(previousTuning: Tuning, tuning: Tuning): Seq[MidiMessage] = {
     val buffer = mutable.Buffer[MidiMessage]()
 
     // Update pitch bend on all occupied member channels
@@ -140,7 +132,7 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
    * Clears internal mutable state and recreates allocators from `currentZones`.
    */
   private def resetState(): Unit = {
-    _tuning = Tuning.Standard
+    tuning = Tuning.Standard
     channelNoteMap.clear()
     tracker.reset()
 
@@ -230,7 +222,7 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
         trackNote(inputChannel, midiNote, outChannel)
 
         // Compute and send control dimensions before Note On
-        val tuningOffset = _tuning(midiNote.pitchClass)
+        val tuningOffset = tuning(midiNote.pitchClass)
         val totalPitchBend = computeOutputPitchBend(outChannel, alloc, zone, tuningOffset)
         buffer += PitchBendScMidiMessage(outChannel, totalPitchBend).asJava
 
@@ -666,7 +658,7 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
                                   alloc: MpeChannelAllocator): Unit = {
     val zone = currentZone(alloc)
     alloc.channelPitchClass(channel).foreach { pc =>
-      val tuningOffset = _tuning(pc)
+      val tuningOffset = tuning(pc)
       val totalPitchBend = computeOutputPitchBend(channel, alloc, zone, tuningOffset)
       buffer += PitchBendScMidiMessage(channel, totalPitchBend).asJava
     }

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MtsTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MtsTuner.scala
@@ -33,7 +33,8 @@ import javax.sound.midi.MidiMessage
 abstract class MtsTuner(val mtsMessageGenerator: MtsMessageGenerator,
                         val thru: Boolean = MtsTuner.DefaultThru) extends Tuner with StrictLogging {
 
-  override def tune(tuning: Tuning): Seq[MidiMessage] = Seq(mtsMessageGenerator.generate(tuning).asJava)
+  override protected def onTune(previousTuning: Tuning, tuning: Tuning): Seq[MidiMessage] =
+    Seq(mtsMessageGenerator.generate(tuning).asJava)
 
   override def process(message: MidiMessage): Seq[MidiMessage] = if (thru) Seq(message) else Seq.empty
 }

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/Tuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/Tuner.scala
@@ -73,15 +73,48 @@ trait Tuner extends Plugin {
    */
   def reset(): Seq[MidiMessage] = Seq.empty
 
+  private var _tuning: Tuning = Tuning.Standard
+
   /**
-   * Generates MIDI messages, if any, for tuning an output instrument by using the specified tuning object and
-   * potentially stores state about the given tuning such that MIDI notes passed via [[process]] method will be
-   * played in that tuning.
+   * The tuning most recently passed to [[tune]]. It is [[Tuning.Standard]] before the first call.
+   *
+   * @return the current tuning stored by this tuner.
+   */
+  def tuning: Tuning = _tuning
+
+  /**
+   * Updates the stored current tuning. Available to implementations e.g. to restore [[Tuning.Standard]] in [[reset]].
+   */
+  protected def tuning_=(newTuning: Tuning): Unit = {
+    _tuning = newTuning
+  }
+
+  /**
+   * Generates MIDI messages, if any, for tuning an output instrument by using the specified tuning object such that
+   * MIDI notes passed via the [[process]] method will be played in that tuning.
+   *
+   * This method stores the given tuning (exposed via [[tuning]]) before delegating the protocol-specific message
+   * generation to [[onTune]], so every implementation can rely on the current tuning being available.
    *
    * @param tuning The tuning instance that specifies the offset in cents for each of the 12 pitch classes in the
    *               octave.
    */
-  def tune(tuning: Tuning): Seq[MidiMessage]
+  def tune(tuning: Tuning): Seq[MidiMessage] = {
+    val previousTuning = _tuning
+    _tuning = tuning
+    onTune(previousTuning, tuning)
+  }
+
+  /**
+   * Hook implemented by each tuner to emit the MIDI messages required for the new tuning. By the time it is called,
+   * the trait has already stored the new tuning (readable via [[tuning]]).
+   *
+   * @param previousTuning The tuning that was in effect before this call, for implementations that need the delta
+   *                       between the previous and the new tuning.
+   * @param tuning         The new tuning being applied (same value now returned by [[tuning]]).
+   * @return the MIDI messages, if any, that apply the new tuning on the output device.
+   */
+  protected def onTune(previousTuning: Tuning, tuning: Tuning): Seq[MidiMessage]
 
   /**
    * Method called with every MIDI message of a [[Track]] that uses this tuner. Its purpose is to do any processing

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTunerTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MonophonicPitchBendTunerTest.scala
@@ -124,6 +124,29 @@ class MonophonicPitchBendTunerTest extends AnyFlatSpec with Matchers with Inside
     )
   }
 
+  behavior of "MonophonicPitchBendTuner current tuning"
+
+  it should "default to the standard tuning before any tune call" in new Fixture {
+    // Then
+    tuner.tuning shouldEqual Tuning.Standard
+  }
+
+  it should "store the tuning passed to tune" in new Fixture {
+    // When
+    tuner.tune(customTuning)
+    // Then
+    tuner.tuning shouldEqual customTuning
+  }
+
+  it should "revert to the standard tuning after reset" in new Fixture {
+    // Given
+    tuner.tune(customTuning)
+    // When
+    tuner.reset()
+    // Then
+    tuner.tuning shouldEqual Tuning.Standard
+  }
+
   behavior of "MonophonicPitchBendTuner after initialization"
 
   it should "tune all notes in 12-EDO by not sending any pitch bend" in new Fixture {

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MtsTunerTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MtsTunerTest.scala
@@ -49,6 +49,18 @@ class MtsTunerTest extends AnyFlatSpec with Matchers with MockFactory {
     result.head.getMessage shouldEqual sysExMessage.asJava.getMessage
   }
 
+  "MtsTuner#tuning" should "default to the standard tuning before any tune call" in new Fixture {
+    // Then
+    tuner.tuning shouldEqual Tuning.Standard
+  }
+
+  it should "store the tuning passed to tune" in new Fixture {
+    // When
+    tuner.tune(TestTunings.justCMaj)
+    // Then
+    tuner.tuning shouldEqual TestTunings.justCMaj
+  }
+
   "MtsTuner#process" should "return the received MIDI message if thru is true" in new Fixture(thru = true) {
     // Given
     val message: MidiMessage = NoteOnScMidiMessage(0, MidiNote.A4).asJava

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/TunerProcessorTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/TunerProcessorTest.scala
@@ -24,6 +24,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import javax.sound.midi.{MidiMessage, Receiver}
+import scala.collection.mutable
 
 class TunerProcessorTest extends AnyFlatSpec with Matchers with MockFactory {
 
@@ -35,12 +36,40 @@ class TunerProcessorTest extends AnyFlatSpec with Matchers with MockFactory {
   val processMessage1: MidiMessage = NoteOnScMidiMessage(0, MidiNote(60), 64).asJava
   val processMessage2: MidiMessage = PitchBendScMidiMessage(0, 101).asJava
 
+  /**
+   * Concrete test double for [[Tuner]]. Because [[Tuner]] now carries mutable state (the stored tuning), it is no
+   * longer a pure interface and cannot be created with ScalaMock's `stub`; this fake records the calls forwarded by
+   * [[TunerProcessor]] and replays canned responses keyed by argument.
+   */
+  class FakeTuner extends Tuner {
+    override val typeName: String = "fake"
+
+    val tuneArgs: mutable.Buffer[Tuning] = mutable.Buffer.empty
+    val processArgs: mutable.Buffer[MidiMessage] = mutable.Buffer.empty
+
+    private val tuneResponses: Map[Tuning, Seq[MidiMessage]] = Map(
+      TestTunings.justCMaj -> Seq(tuneMessage1),
+      Tuning.Standard -> Seq(tuneMessage2)
+    )
+    private val processResponses: Map[MidiMessage, Seq[MidiMessage]] = Map(
+      processMessage1 -> Seq(processMessage1, processMessage2)
+    )
+
+    override def reset(): Seq[MidiMessage] = Seq(initMessage)
+
+    override protected def onTune(previousTuning: Tuning, tuning: Tuning): Seq[MidiMessage] = {
+      tuneArgs += tuning
+      tuneResponses.getOrElse(tuning, Seq.empty)
+    }
+
+    override def process(message: MidiMessage): Seq[MidiMessage] = {
+      processArgs += message
+      processResponses.getOrElse(message, Seq.empty)
+    }
+  }
+
   abstract class Fixture(shouldConnect: Boolean = true) {
-    val tuner: Tuner = stub[Tuner]
-    (() => tuner.reset()).when().returns(Seq(initMessage))
-    tuner.tune.when(TestTunings.justCMaj).returns(Seq(tuneMessage1))
-    tuner.tune.when(Tuning.Standard).returns(Seq(tuneMessage2))
-    tuner.process.when(processMessage1).returns(Seq(processMessage1, processMessage2))
+    val tuner: FakeTuner = FakeTuner()
 
     val receiver: Receiver = stub[Receiver]
     val processor: TunerProcessor = new TunerProcessor(tuner)
@@ -65,7 +94,7 @@ class TunerProcessorTest extends AnyFlatSpec with Matchers with MockFactory {
     // When
     processor.tune(TestTunings.justCMaj)
     // Then
-    tuner.tune.verify(TestTunings.justCMaj).once()
+    tuner.tuneArgs shouldEqual Seq(TestTunings.justCMaj)
     receiver.send.verify(tuneMessage1, -1).once()
   }
 
@@ -75,7 +104,7 @@ class TunerProcessorTest extends AnyFlatSpec with Matchers with MockFactory {
     // When
     processor.receiver.send(processMessage1, timeStamp)
     // Then
-    tuner.process.verify(processMessage1).once()
+    tuner.processArgs shouldEqual Seq(processMessage1)
     receiver.send.verify(processMessage1, timeStamp).once()
     receiver.send.verify(processMessage2, timeStamp).once()
   }
@@ -84,7 +113,7 @@ class TunerProcessorTest extends AnyFlatSpec with Matchers with MockFactory {
     // When
     processor.close()
     // Then
-    tuner.tune.verify(Tuning.Standard).once()
+    tuner.tuneArgs shouldEqual Seq(Tuning.Standard)
     receiver.send.verify(tuneMessage2, -1).once()
   }
 }


### PR DESCRIPTION
Resolves #216

## Summary

Lift the "remember the last tuning" concern out of the individual tuners and into the `Tuner` trait, so every implementation gets a stored, readable current tuning for free.

- `Tuner` gains `private var _tuning`, a public `tuning` getter, and a `protected` setter.
- `tune(tuning)` is now a concrete template method: it stores the tuning and delegates protocol-specific message generation to a new `protected def onTune(previousTuning, tuning)` hook.
- `MtsTuner`, `MpeTuner`, and `MonophonicPitchBendTuner` migrate to `onTune` and use the inherited storage; the monophonic tuner's old→new pitch-bend delta logic uses the `previousTuning` argument.

## Notes

- Adding a `var` to the trait makes it unstubbable by ScalaMock 7 (`AbstractMethodError` on the synthetic field setter), so `TunerProcessorTest` now uses a small concrete `FakeTuner` double instead of `stub[Tuner]`.
- Behavior is preserved; the only new observable behavior is that `MtsTuner` and `MonophonicPitchBendTuner` now also expose a `tuning` getter.

## Verification

- Metals full compile: clean.
- `tuner` module: 308 tests pass (17 pre-existing ignored); full project suite: 871 pass, 0 fail.
- Coverage: `tuner` at 80.5% stmt / 77.4% branch, above its 71/69 floor.
- Architecture doc (`docs/architecture/tuner/README.md`) and ScalaDocs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)