### PR TITLE
[#221] Bundle microtonalist-gh script in the contributing skill

### DIFF
--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -2,9 +2,10 @@
 name: contributing
 description: >-
   Use when creating a GitHub issue, starting a branch, opening a pull request, or
-  finishing work and deciding whether an issue or PR is needed. Covers applying the
-  repository's labels, assigning the microtonalist GitHub project (Projects v2, via
-  the `gh` CLI fallback since the GitHub MCP can't do it), and setting a milestone.
+  finishing work and deciding whether an issue or PR is needed. Prefer the bundled
+  `microtonalist-gh` script — one call applies the repository's labels, the microtonalist
+  Projects-v2 assignment, the milestone, draft PRs, the `[#issue]` / `[#parent/#child]`
+  title prefix, and the `@me` assignee — falling back to the GitHub MCP and `gh` CLI.
 ---
 
 # Contributing (issues, PRs, branches)
@@ -14,9 +15,45 @@ an issue, start a branch, or open a pull request.
 
 ## Tooling
 
-Use the **GitHub MCP plugin** (`mcp__plugin_github_github__*`) for all GitHub operations
-(issues, PRs, labels, milestones, etc.). Fall back to the `gh` CLI (`/usr/local/bin/gh`)
-only for features not available in the MCP, such as managing GitHub Projects (v2).
+### Scripts (primary path)
+
+Prefer the bundled script for creating issues and PRs — it applies every convention below
+in one non-interactive call (near-zero tokens), so you do not run the multi-step procedure
+by hand. **Invoke it directly from the usage here (or `… --help`); do not read the script's
+source.** It is a self-contained black box — reading its source only burns context and
+defeats the point. Everything you need to call it is below.
+
+```bash
+.claude/skills/contributing/scripts/microtonalist-gh issue <title> [body] [--label L] [--milestone M] [--wip] [--dry-run]
+.claude/skills/contributing/scripts/microtonalist-gh pr    [<issue-spec>] <title> [body] [--label L] [--milestone M] [--dry-run]
+```
+
+- `issue` creates the issue, applies its label (from `--label`, else the branch prefix),
+  optionally sets `--milestone`, assigns you with `--wip`, and adds it to the project.
+- `pr` pushes the branch and opens a **draft** PR assigned to you (`@me`). The optional
+  leading `<issue-spec>` (`33`, or `32/33` for a sub-issue) links an issue: it derives the
+  `[#<issue>]` / `[#<parent>/#<child>]` title prefix and the `Resolves #<issue>` body line,
+  and inherits the issue's milestone. With no `<issue-spec>` the PR links no issue. The PR is
+  always added to the project.
+- `--dry-run` prints the resolved label/milestone/title/body and the exact `gh` commands
+  without any side effects — use it to verify before creating. Run `… --help`, `… issue
+  --help`, or `… pr --help` for the full usage.
+
+```bash
+.claude/skills/contributing/scripts/microtonalist-gh issue "Support Windows audio backend" --milestone "MPE" --wip
+.claude/skills/contributing/scripts/microtonalist-gh pr 220 "Replace scoverage-inspector subagent with an MCP server"
+```
+
+Deciding **which** milestone to set is still your call: the script does not pick one. Check
+the existing milestones, suggest a matching one to the user (see Issues / Pull Requests
+below), then pass it via `--milestone`.
+
+### Underlying behavior / fallback
+
+When the script does not apply (an operation it does not cover, or it is unavailable), use
+the **GitHub MCP plugin** (`mcp__plugin_github_github__*`) for GitHub operations, and the
+`gh` CLI (`/usr/local/bin/gh`) for what the MCP cannot do — notably GitHub Projects (v2).
+The sections below document the conventions the script encodes.
 
 ## Labels
 
@@ -34,7 +71,16 @@ Branch names use the format `<label>/<kebab-case-description>`, where `<label>` 
 the labels above. Examples: `feature/mpe-tuner`, `bugfix/pitch-bend-overflow`,
 `refactoring/program-change-midi-msg-wrapper`.
 
-The label in the branch name determines the label to apply to the corresponding issue and PR.
+The label in the branch name determines the label to apply to the corresponding issue and PR
+(this is what the script infers when `--label` is omitted).
+
+## Sub-issues
+
+When the work is on a **sub-issue**, always use the `[#<parent>/#<child>]` notation so both
+the parent and the sub-issue stay visible. This applies to **PR titles and commit messages**.
+The `pr` script applies it to PR titles automatically when you pass `<parent>/<child>` (e.g.
+`32/33`, which always wins over auto-detection); writing commit messages with this prefix
+stays your responsibility.
 
 ## Issue documents
 
@@ -46,25 +92,29 @@ documents scattered under `docs/` — keep them with their issue.
 
 ## Issues
 
-When creating a new issue:
+When creating a new issue (`microtonalist-gh issue` does all of this):
 
+- Add the appropriate label (inferred from the branch name if available).
 - **Always** add the issue to the **microtonalist** GitHub project (Projects v2). The GitHub
-  MCP does not support Projects v2, so use the `gh` CLI:
+  MCP does not support Projects v2, so the underlying step uses the `gh` CLI:
   ```bash
   gh project item-add 1 --owner calinburloiu --url https://github.com/calinburloiu/microtonalist/issues/<issue_number>
   ```
-- Add the appropriate label (inferred from the branch name if available).
 - Check existing milestones (`mcp__plugin_github_github__list_releases` or similar). If a
   milestone name matches the scope of the new work, suggest adding it to the user before
-  assigning.
+  assigning (then pass it via `--milestone`).
+- If the issue is being worked on in the current session (WIP), assign it to the current user
+  (`@me`, via `--wip`).
 
 ## Pull Requests
 
-When creating a new pull request:
+When creating a new pull request (`microtonalist-gh pr` does all of this):
 
-- **Title format:** `[#<issue_number>] <Short description>` (e.g. `[#151] Add ScProgramChangeMidiMessage`).
+- **Title format:** `[#<issue_number>] <Short description>` (e.g. `[#151] Add ScProgramChangeMidiMessage`);
+  for a sub-issue use `[#<parent>/#<child>]` (see Sub-issues).
 - **Body:** Include `Resolves #<issue_number>` to auto-close the linked issue on merge.
 - **Draft state:** Always open new PRs as **draft**.
+- **Assignee:** Assign the PR to the current user (`@me`).
 - **Project:** Assign the **microtonalist** GitHub project.
-- **Label:** Use the same label as the linked issue.
+- **Label:** Use the same label as the linked issue (the branch prefix).
 - **Milestone:** Use the same milestone as the linked issue, if one is set.

--- a/.claude/skills/contributing/scripts/microtonalist-gh
+++ b/.claude/skills/contributing/scripts/microtonalist-gh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Calin-Andrei Burloiu
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+# microtonalist-gh — create a GitHub issue or pull request following all of the
+# microtonalist contributing conventions in a single, non-interactive call.
+#
+# It encodes the conventions documented by the `contributing` skill so an agent
+# (or a human) does not have to run the multi-step procedure by hand:
+#   - label inferred from the current branch prefix (or given with --label),
+#   - the microtonalist GitHub project (Projects v2) assignment,
+#   - the milestone (given, or inherited from a linked issue),
+#   - draft PRs assigned to the current user (@me),
+#   - the `[#<issue>]` / `[#<parent>/#<child>]` PR title prefix, and
+#   - the `Resolves #<issue>` body line.
+#
+# Use `microtonalist-gh --help`, `microtonalist-gh issue --help`, or
+# `microtonalist-gh pr --help` for usage.
+#
+
+set -euo pipefail
+
+# --- constants --------------------------------------------------------------
+
+# The labels used for issues, PRs, and as branch-name prefixes. Keep in sync
+# with the `contributing` skill's "Labels" section.
+KNOWN_LABELS=(feature bugfix refactoring doc poc)
+
+# The microtonalist GitHub project (Projects v2). The owner and number are the
+# documented defaults; overridable via the environment for reuse elsewhere.
+PROJECT_NUMBER="${MICROTONALIST_GH_PROJECT_NUMBER:-1}"
+PROJECT_OWNER="${MICROTONALIST_GH_PROJECT_OWNER:-calinburloiu}"
+
+# The repository's default branch — PRs may not be opened from it.
+DEFAULT_BRANCH="${MICROTONALIST_GH_DEFAULT_BRANCH:-main}"
+
+PROG="microtonalist-gh"
+
+# Resolved lazily by init_repo(): the GitHub remote name and OWNER/REPO.
+REMOTE=""
+REPO_FULL=""
+OWNER=""
+REPO=""
+
+# --- generic helpers --------------------------------------------------------
+
+die() {
+  printf '%s: %s\n' "$PROG" "$1" >&2
+  exit 1
+}
+
+# Print `gh` followed by its arguments, safely quoted, as it would be run.
+quote_gh_cmd() {
+  local out="gh" arg
+  for arg in "$@"; do
+    out+=" $(printf '%q' "$arg")"
+  done
+  printf '%s\n' "$out"
+}
+
+is_known_label() {
+  local candidate="$1" label
+  for label in "${KNOWN_LABELS[@]}"; do
+    [[ "$label" == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+# Echo the known labels as a human-readable ", "-joined list (for help/errors).
+known_labels_list() {
+  local out="" label
+  for label in "${KNOWN_LABELS[@]}"; do
+    out="${out:+$out, }$label"
+  done
+  printf '%s' "$out"
+}
+
+# Announce, on stderr, that a real (non-dry-run) GitHub mutation is about to
+# happen. Makes a misfire visible — e.g. when `--dry-run` is placed after `--`
+# and is silently demoted to a positional argument.
+announce_real() {
+  printf '%s: %s (not a dry run)…\n' "$PROG" "$1" >&2
+}
+
+current_branch() {
+  git rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+# Echo the label inferred from the current branch prefix (`<label>/<desc>`),
+# but only when that prefix is a known label. Otherwise echo nothing.
+infer_label_from_branch() {
+  local branch prefix
+  branch="$(current_branch)"
+  prefix="${branch%%/*}"
+  if is_known_label "$prefix"; then
+    printf '%s\n' "$prefix"
+  fi
+}
+
+# --- repository inference ---------------------------------------------------
+
+# Echo the name of the first git remote whose URL points at github.com.
+github_remote_name() {
+  local remote url
+  for remote in $(git remote 2>/dev/null); do
+    url="$(git remote get-url "$remote" 2>/dev/null || true)"
+    case "$url" in
+      *github.com*) printf '%s\n' "$remote"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Parse "owner/repo" out of a github.com remote URL (SSH or HTTPS form).
+parse_owner_repo() {
+  local url="$1" rest
+  rest="${url#*github.com}"   # ":owner/repo.git" or "/owner/repo.git"
+  rest="${rest#[:/]}"          # "owner/repo.git"
+  rest="${rest%.git}"          # "owner/repo"
+  rest="${rest%/}"             # tolerate a trailing slash
+  printf '%s\n' "$rest"
+}
+
+# Resolve REMOTE, REPO_FULL, OWNER, REPO from the GitHub remote, with the
+# documented repository as the fallback when no remote can be read.
+init_repo() {
+  REMOTE="$(github_remote_name 2>/dev/null || true)"
+  REMOTE="${REMOTE:-origin}"
+  REPO_FULL="$(parse_owner_repo "$(git remote get-url "$REMOTE" 2>/dev/null || true)")"
+  REPO_FULL="${REPO_FULL:-calinburloiu/microtonalist}"
+  OWNER="${REPO_FULL%%/*}"
+  REPO="${REPO_FULL##*/}"
+}
+
+# Echo the parent issue number of a given issue, or nothing when there is none.
+# Read-only; safe to call in --dry-run.
+detect_parent() {
+  local child="$1"
+  gh api graphql \
+    -f owner="$OWNER" -f name="$REPO" -F n="$child" \
+    -f query='query($owner:String!,$name:String!,$n:Int!){
+      repository(owner:$owner,name:$name){ issue(number:$n){ parent{ number } } } }' \
+    --jq '.data.repository.issue.parent.number' 2>/dev/null || true
+}
+
+# Echo the milestone title of a given issue, or nothing when none is set.
+# Read-only; safe to call in --dry-run.
+issue_milestone() {
+  local issue="$1"
+  gh issue view "$issue" --json milestone --jq '.milestone.title // empty' 2>/dev/null || true
+}
+
+# --- usage ------------------------------------------------------------------
+
+usage_main() {
+  cat <<EOF
+$PROG — create a GitHub issue or pull request the microtonalist way.
+
+Usage:
+  $PROG issue <title> [body] [--label L] [--milestone M] [--wip] [--dry-run]
+  $PROG pr [<issue-spec>] <title> [body] [--label L] [--milestone M] [--dry-run]
+  $PROG --help
+
+Subcommands:
+  issue   Create an issue, apply its label, and add it to the project.
+  pr      Push the branch and open a draft PR, assigned to you (@me).
+
+Run "$PROG <subcommand> --help" for details.
+EOF
+}
+
+usage_issue() {
+  cat <<EOF
+$PROG issue — create a GitHub issue.
+
+Usage:
+  $PROG issue <title> [body] [--label L] [--milestone M] [--wip] [--dry-run]
+
+Arguments:
+  <title>          Issue title (required).
+  [body]           Issue body (optional).
+
+Options:
+  --label L        Label to apply. Defaults to the current branch prefix when
+                   it is a known label ($(known_labels_list)).
+  --milestone M    Milestone to assign (optional).
+  --wip            Assign the issue to you (@me) — use when you will work on it
+                   in this session.
+  --dry-run        Print the resolved values and the exact gh commands without
+                   creating anything.
+
+The issue is always added to the "$PROJECT_OWNER" GitHub project ($PROJECT_NUMBER).
+
+Example:
+  $PROG issue "Support Windows audio backend" "Details..." --milestone "MPE" --wip
+EOF
+}
+
+usage_pr() {
+  cat <<EOF
+$PROG pr — open a draft pull request.
+
+Usage:
+  $PROG pr [<issue-spec>] <title> [body] [--label L] [--milestone M] [--dry-run]
+
+Arguments:
+  <issue-spec>     Optional leading positional linking an issue. Recognized
+                   only when it matches ^[0-9]+(/[0-9]+)?\$:
+                     33      link issue #33 (parent auto-detected, if any)
+                     32/33   sub-issue #33 of parent #32 (explicit, reliable)
+                   When absent, the PR links no issue and gets no title prefix.
+  <title>          PR title (required), without the [#...] prefix. A purely
+                   numeric first positional is always read as <issue-spec>, so a
+                   title that is only digits is not expressible — rephrase it.
+  [body]           PR body (optional).
+
+Options:
+  --label L        Label to apply. Defaults to the current branch prefix when
+                   it is a known label ($(known_labels_list)).
+  --milestone M    Milestone to assign. When omitted and an issue is linked,
+                   the issue's milestone is inherited.
+  --dry-run        Print the resolved values and the exact gh commands without
+                   pushing or creating anything.
+
+Every PR is opened as a draft, assigned to you (@me), and added to the
+"$PROJECT_OWNER" GitHub project ($PROJECT_NUMBER). It may not be opened from the
+default branch ($DEFAULT_BRANCH). A linked issue adds a "[#<issue>]" /
+"[#<parent>/#<child>]" title prefix and a "Resolves #<issue>" body line.
+
+Examples:
+  $PROG pr 220 "Replace scoverage-inspector subagent with an MCP server"
+  $PROG pr 32/33 "Add MPE pitch-bend range parsing" "Implements the spec."
+  $PROG pr "Tidy up build docs" --label doc
+EOF
+}
+
+# --- issue subcommand -------------------------------------------------------
+
+cmd_issue() {
+  local label="" milestone="" wip="" dry_run=""
+  local positionals=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage_issue; exit 0 ;;
+      --label) [[ $# -ge 2 ]] || die "--label requires a value"; label="$2"; shift 2 ;;
+      --label=*) label="${1#*=}"; shift ;;
+      --milestone) [[ $# -ge 2 ]] || die "--milestone requires a value"; milestone="$2"; shift 2 ;;
+      --milestone=*) milestone="${1#*=}"; shift ;;
+      --wip) wip=1; shift ;;
+      --dry-run) dry_run=1; shift ;;
+      --) shift; while [[ $# -gt 0 ]]; do positionals+=("$1"); shift; done ;;
+      -*) die "unknown option for 'issue': $1" ;;
+      *) positionals+=("$1"); shift ;;
+    esac
+  done
+
+  [[ ${#positionals[@]} -ge 1 ]] || { usage_issue >&2; die "missing <title>"; }
+  [[ ${#positionals[@]} -le 2 ]] || die "too many positional arguments for 'issue'"
+  local title="${positionals[0]}"
+  local body="${positionals[1]:-}"
+
+  init_repo
+
+  if [[ -z "$label" ]]; then
+    label="$(infer_label_from_branch)"
+  fi
+  [[ -n "$label" ]] || die "could not resolve a label: pass --label, or work on a branch named <label>/<desc> with a known label ($(known_labels_list))"
+  is_known_label "$label" || die "unknown label '$label'; known labels: $(known_labels_list)"
+
+  local create_args=(issue create --title "$title" --body "$body" --label "$label")
+  [[ -n "$milestone" ]] && create_args+=(--milestone "$milestone")
+  [[ -n "$wip" ]] && create_args+=(--assignee @me)
+
+  if [[ -n "$dry_run" ]]; then
+    cat <<EOF
+[dry-run] would create an issue:
+  repository : $REPO_FULL
+  label      : $label
+  milestone  : ${milestone:-<none>}
+  assignee   : $([[ -n "$wip" ]] && echo '@me (WIP)' || echo '<none>')
+  title      : $title
+  body       : ${body:-<empty>}
+
+Would run:
+  $(quote_gh_cmd "${create_args[@]}")
+  $(quote_gh_cmd project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url ISSUE_URL)
+EOF
+    return 0
+  fi
+
+  announce_real "creating a GitHub issue"
+  local url
+  url="$(gh "${create_args[@]}")"
+  gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$url" >/dev/null
+  printf '%s\n' "$url"
+}
+
+# --- pr subcommand ----------------------------------------------------------
+
+cmd_pr() {
+  local label="" milestone="" dry_run=""
+  local positionals=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage_pr; exit 0 ;;
+      --label) [[ $# -ge 2 ]] || die "--label requires a value"; label="$2"; shift 2 ;;
+      --label=*) label="${1#*=}"; shift ;;
+      --milestone) [[ $# -ge 2 ]] || die "--milestone requires a value"; milestone="$2"; shift 2 ;;
+      --milestone=*) milestone="${1#*=}"; shift ;;
+      --dry-run) dry_run=1; shift ;;
+      --) shift; while [[ $# -gt 0 ]]; do positionals+=("$1"); shift; done ;;
+      -*) die "unknown option for 'pr': $1" ;;
+      *) positionals+=("$1"); shift ;;
+    esac
+  done
+
+  local branch
+  branch="$(current_branch)"
+  [[ "$branch" == "$DEFAULT_BRANCH" ]] && die "refusing to open a PR from the default branch ($DEFAULT_BRANCH); switch to a feature branch first"
+  [[ -n "$branch" && "$branch" != "HEAD" ]] || die "not on a named branch; switch to a feature branch first"
+
+  # Detect an optional leading issue-spec positional.
+  local spec="" parent="" child=""
+  if [[ ${#positionals[@]} -ge 1 && "${positionals[0]}" =~ ^[0-9]+(/[0-9]+)?$ ]]; then
+    spec="${positionals[0]}"
+    positionals=("${positionals[@]:1}")
+    if [[ "$spec" == */* ]]; then
+      parent="${spec%/*}"
+      child="${spec#*/}"
+    else
+      child="$spec"
+    fi
+  fi
+
+  [[ ${#positionals[@]} -ge 1 ]] || { usage_pr >&2; die "missing <title>"; }
+  [[ ${#positionals[@]} -le 2 ]] || die "too many positional arguments for 'pr'"
+  local raw_title="${positionals[0]}"
+  local raw_body="${positionals[1]:-}"
+
+  init_repo
+
+  # Resolve the title prefix from the issue-spec.
+  local issue_prefix=""
+  if [[ -n "$spec" ]]; then
+    if [[ -n "$parent" ]]; then
+      issue_prefix="#$parent/#$child"
+    else
+      local detected
+      detected="$(detect_parent "$child")"
+      if [[ -n "$detected" && "$detected" != "null" ]]; then
+        issue_prefix="#$detected/#$child"
+      else
+        issue_prefix="#$child"
+      fi
+    fi
+  fi
+
+  # Resolve the label.
+  if [[ -z "$label" ]]; then
+    label="$(infer_label_from_branch)"
+  fi
+  [[ -n "$label" ]] || die "could not resolve a label: pass --label, or work on a branch named <label>/<desc> with a known label ($(known_labels_list))"
+  is_known_label "$label" || die "unknown label '$label'; known labels: $(known_labels_list)"
+
+  # Resolve the milestone: explicit --milestone wins, else inherit from the issue.
+  if [[ -z "$milestone" && -n "$child" ]]; then
+    milestone="$(issue_milestone "$child")"
+  fi
+
+  # Build the title and body.
+  local title
+  if [[ -n "$issue_prefix" ]]; then
+    title="[$issue_prefix] $raw_title"
+  else
+    title="$raw_title"
+  fi
+
+  local body="$raw_body"
+  if [[ -n "$child" ]]; then
+    if [[ -n "$body" ]]; then
+      body="$body"$'\n\n'"Resolves #$child"
+    else
+      body="Resolves #$child"
+    fi
+  fi
+
+  local pr_args=(pr create --draft --title "$title" --body "$body" --label "$label" --assignee @me)
+  [[ -n "$milestone" ]] && pr_args+=(--milestone "$milestone")
+
+  if [[ -n "$dry_run" ]]; then
+    local prefix_display="<none>"
+    [[ -n "$issue_prefix" ]] && prefix_display="[$issue_prefix]"
+    cat <<EOF
+[dry-run] would open a draft pull request:
+  repository : $REPO_FULL
+  branch     : $branch
+  issue      : ${spec:-<none>}
+  prefix     : $prefix_display
+  label      : $label
+  milestone  : ${milestone:-<none>}
+  assignee   : @me
+  title      : $title
+  body       : ${body:-<empty>}
+
+Would run:
+  git push -u $REMOTE HEAD
+  $(quote_gh_cmd "${pr_args[@]}")
+  $(quote_gh_cmd project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url PR_URL)
+EOF
+    return 0
+  fi
+
+  announce_real "pushing the branch and opening a draft PR"
+  git push -u "$REMOTE" HEAD
+  local url
+  url="$(gh "${pr_args[@]}")"
+  gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$url" >/dev/null
+  printf '%s\n' "$url"
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+main() {
+  [[ $# -ge 1 ]] || { usage_main >&2; exit 1; }
+  case "$1" in
+    -h|--help) usage_main; exit 0 ;;
+    issue) shift; cmd_issue "$@" ;;
+    pr) shift; cmd_pr "$@" ;;
+    *) usage_main >&2; die "unknown subcommand: $1" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Bundles a committed `microtonalist-gh` helper (issue|pr subcommands) inside the contributing skill so an agent creates an issue or PR in one non-interactive call instead of the multi-step GitHub MCP + `gh` procedure.

The script encodes branch-derived label inference, Projects-v2 assignment, milestone (explicit or inherited from a linked issue), draft PRs assigned to `@me`, the `[#issue]` / `[#parent/#child]` title prefix, and the `Resolves #issue` body line, with `--dry-run` and `--help`. SKILL.md now documents the script as the primary path (GitHub MCP / `gh` framed as the underlying behavior/fallback) and adds three conventions: the sub-issue title prefix, `@me` PR assignee, and WIP-issue `@me` assignee. SKILL.md also instructs agents to invoke the script without reading its source (keeps context lean).

Both this issue and PR were created with the new script (dogfooded).

Resolves #221