### PR TITLE
Fix dead link in CLAUDE.md and add coverageThresholds sbt command

### DIFF
--- a/.claude/skills/scoverage-inspector/SKILL.md
+++ b/.claude/skills/scoverage-inspector/SKILL.md
@@ -21,7 +21,8 @@ mechanical work (freshness check, rebuild if stale, XML parsing) in-process.
 
 Code coverage is measured via [scoverage](https://github.com/scoverage/sbt-scoverage). Each SBT
 project has per-module statement and branch thresholds configured in `build.sbt` via the
-`coverageSettings` helper.
+`coverageSettings` helper. To inspect the current thresholds without reading `build.sbt`, run
+`sbtn coverageThresholds` — it prints a table of stmt% and branch% floors for every covered module.
 
 The target for this project is **80% statement and branch coverage**. This applies for every module,
 as well as for the project-wide aggregated coverage. Modules that have not yet reached 80% are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,10 @@ Scala 3 and is built by using sbt 1.
 
 - Use Metals MCP for compiling and code intelligence (see [Code Intelligence](#code-intelligence) section); fall back to
   sbt only when it is unavailable (see [`docs/development/build.md`](docs/development/build.md)).
-- Before writing code, create a task to explore the architecture: read the always-loaded overview imported in the
-  [Architecture](#architecture) section (from [`docs/agents/architecture.md`](docs/agents/architecture.md)) plus the
-  architecture documents strictly relevant to the prompt — typically the `docs/architecture/$MODULE/README.md` of each
-  module you will touch and its immediate collaborators. That overview explains how the architecture documents are
-  organized.
+- Before writing code, create a task to explore the architecture: read the always-loaded overviews imported in the
+  [Architecture](#architecture) section plus the architecture documents strictly relevant to the prompt — typically the
+  `docs/architecture/$MODULE/README.md` of each module you will touch and its immediate collaborators. That section
+  explains how the architecture documents are organized.
 - Use strict Test Driven Development (_TDD_) by following the _red/green/refactor_ cycle:
     - **Red**. Write failing tests first. If the compiler requires it, create the thinnest possible stub (`???` bodies,
       no logic) to get them to compile, then confirm the tests fail for the right reason. The tests failure reason

--- a/project/Coverage.scala
+++ b/project/Coverage.scala
@@ -118,8 +118,12 @@ object Coverage {
     val rows = structure.allProjectRefs.flatMap { ref =>
       if (!includedIds.contains(ref.project)) None
       else {
-        val isDisabled = extracted.getOpt(ref / coverageEnabled).contains(false)
-        if (isDisabled) None
+        // A module participates iff it enforces a coverage minimum (the `coverageSettings` helper in
+        // `build.sbt` sets `coverageFailOnMinimum := true`). Test-utility modules such as
+        // `common-test-utils` never call it and are excluded. `coverageEnabled` can't be used here: it
+        // defaults to false for every module outside an active `coverage` session.
+        val enforcesMinimum = extracted.getOpt(ref / coverageFailOnMinimum).contains(true)
+        if (!enforcesMinimum) None
         else Some(Row(
           ref.project,
           extracted.get(ref / coverageMinimumStmtTotal),
@@ -128,8 +132,8 @@ object Coverage {
       }
     }.sortBy(_.id)
 
-    val colWidth = rows.map(_.id.length).maxOption.getOrElse(0).max("Module".length)
-    log.info(f"${"Module".padTo(colWidth, ' ')}  %6s  %7s".format("stmt%", "branch%"))
+    val colWidth = ("Module".length +: rows.map(_.id.length)).max
+    log.info(f"${"Module".padTo(colWidth, ' ')}  ${"stmt%"}%6s  ${"branch%"}%7s")
     log.info("-" * (colWidth + 17))
     rows.foreach { row =>
       log.info(f"${row.id.padTo(colWidth, ' ')}  ${row.stmt}%6.1f  ${row.branch}%7.1f")

--- a/project/Coverage.scala
+++ b/project/Coverage.scala
@@ -16,10 +16,12 @@
 
 import sbt.*
 import sbt.Keys.*
+import scoverage.ScoverageKeys.*
 
 /**
- * `coverageAll`, `coverageModules <module> [<module> ...]`, `coverageCheck`, and `coverageClean` sbt commands — run
- * the coverage workflow and clean up the reports directory.
+ * `coverageAll`, `coverageModules <module> [<module> ...]`, `coverageCheck`, `coverageClean`, and
+ * `coverageThresholds` sbt commands — run the coverage workflow, clean up the reports directory, and inspect
+ * per-module thresholds.
  *
  * `coverageAll` runs `clean; coverage; test; coverageReport; coverageAggregate` across all modules.
  *
@@ -38,11 +40,15 @@ import sbt.Keys.*
  * with `coverageFailOnMinimum`) and the aggregate threshold by `coverageAggregate` against the root project's
  * settings. The HTML/Cobertura toggles are restored at the end so a local invocation does not leave the session
  * with reduced output enabled.
+ *
+ * `coverageThresholds` prints a table of the minimum statement and branch coverage percentages configured for
+ * each module aggregated by root (excluding modules with coverage disabled, e.g. `common-test-utils`). Useful
+ * for agents and developers who need to check thresholds without reading `build.sbt`.
  */
 object Coverage {
 
   val commands: Seq[Command] =
-    Seq(coverageAll, coverageModules, coverageCheck, coverageClean)
+    Seq(coverageAll, coverageModules, coverageCheck, coverageClean, coverageThresholds)
 
   private def coverageAll: Command = Command.command("coverageAll") { state =>
     "clean" ::
@@ -92,6 +98,43 @@ object Coverage {
     } else {
       log.info(s"$reportsDir does not exist; nothing to delete")
     }
+    state
+  }
+
+  private def coverageThresholds: Command = Command.command("coverageThresholds") { state =>
+    val extracted = Project.extract(state)
+    val log = state.globalLogging.full
+    val structure = extracted.structure
+
+    // Collect the project IDs that root aggregates, plus root itself.
+    val rootResolved = structure.units.values.flatMap(_.defined.values).find(_.id == "root")
+    val includedIds: Set[String] = rootResolved match {
+      case Some(root) => root.aggregate.map(_.project).toSet + "root"
+      case None       => structure.allProjectRefs.map(_.project).toSet
+    }
+
+    case class Row(id: String, stmt: Double, branch: Double)
+
+    val rows = structure.allProjectRefs.flatMap { ref =>
+      if (!includedIds.contains(ref.project)) None
+      else {
+        val isDisabled = extracted.getOpt(ref / coverageEnabled).contains(false)
+        if (isDisabled) None
+        else Some(Row(
+          ref.project,
+          extracted.get(ref / coverageMinimumStmtTotal),
+          extracted.get(ref / coverageMinimumBranchTotal),
+        ))
+      }
+    }.sortBy(_.id)
+
+    val colWidth = rows.map(_.id.length).maxOption.getOrElse(0).max("Module".length)
+    log.info(f"${"Module".padTo(colWidth, ' ')}  %6s  %7s".format("stmt%", "branch%"))
+    log.info("-" * (colWidth + 17))
+    rows.foreach { row =>
+      log.info(f"${row.id.padTo(colWidth, ' ')}  ${row.stmt}%6.1f  ${row.branch}%7.1f")
+    }
+
     state
   }
 }


### PR DESCRIPTION
- Remove the broken reference to non-existent docs/agents/architecture.md in
  the Coding Workflow section; the Architecture section itself (@imports the
  three overview files) is the correct target
- Add coverageThresholds sbt command to Coverage.scala: prints a table of
  stmt%/branch% floors for all root-aggregated modules, excluding those with
  coverageEnabled=false (e.g. common-test-utils)
- Update scoverage-inspector SKILL.md to point agents to coverageThresholds
  instead of reading build.sbt directly

https://claude.ai/code/session_01Pk3rVAfCToxDXsVjW7Vn84