### PR TITLE
[#154/#237] Document polyphonic expression handling in MPE Tuner paper

### DIFF
--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -118,10 +118,15 @@ flowchart LR
 
 2. **Channel Allocation**: Assigns each incoming note that arrives on a Member Channel (in MPE input mode) or on any
    channel (in non-MPE input mode) to a Member Channel in the output Zone(s), following the dual-group allocation
-   strategy described in Section 4. Notes received on a Master Channel in MPE input mode are exempt from allocation and
-   are forwarded as-is (see Section 3.4).
+   strategy described in Section 4. This allocation enforces the **pitch-class invariant** (Section 4.1): all notes
+   simultaneously active on a Member Channel share the same pitch class, so each occupied channel is associated with
+   exactly one pitch class — and therefore one tuning offset. Notes received on a Master Channel in MPE input mode are
+   exempt from allocation and are forwarded as-is (see Section 3.4).
 
-3. **Tuning Application**: For each occupied Member Channel, computes the output Pitch Bend as the sum of the tuning offset for the channel's associated pitch class and the expressive pitch bend from the input.
+3. **Tuning Application**: For each occupied Member Channel, computes the output Pitch Bend as the sum of the tuning
+   offset for the channel's associated pitch class and the expressive pitch bend from the input. The expressive
+   component applies in MPE input mode; in non-MPE input mode the expressive pitch bend is redirected to the Master
+   Channel (Section 3.3), so the Member Channel Pitch Bend encodes the tuning offset alone.
 
 ### 3.2 Input Modes
 
@@ -137,16 +142,32 @@ In both cases, the output is always MPE-conformant.
 
 When the input is non-MPE, the MPE Tuner must perform the following conversions to produce valid MPE output:
 
-1. **Polyphonic Key Pressure to Channel Pressure**: In MPE, Polyphonic Key Pressure must not be sent on Member Channels [1, §2.5]. Any Polyphonic Key Pressure messages in the non-MPE input shall be converted to Channel Pressure messages on the appropriate Member Channels.
+1. **Polyphonic Key Pressure to Channel Pressure**: In MPE, Polyphonic Key Pressure must not be sent on Member Channels
+   [1, §2.5]. Any Polyphonic Key Pressure message in the non-MPE input is converted to a Channel Pressure message on
+   the Member Channel hosting the addressed note. A Polyphonic Key Pressure addressed to a note number that is not
+   currently active has no Member Channel to target and is discarded; the Tuner does not retain it to influence a later
+   Note On.
 
-2. **Pitch Bend Redirection to Master Channel**: In non-MPE input, Pitch Bend typically applies to all notes on a channel. This global pitch manipulation shall be redirected to the Master Channel of the single output Zone selected for non-MPE input (see Section 3.2), where it serves as Zone-level Pitch Bend affecting all notes equally.
+2. **Channel-Global Control Redirection to Master Channel**: In non-MPE input, Pitch Bend, CC #74, and Channel Pressure
+   each apply to all notes on the input channel rather than to an individual note. These channel-global controls shall
+   be redirected to the Master Channel of the single output Zone selected for non-MPE input (see Section 3.2), where
+   they serve as Zone-level controls affecting all notes equally. Consequently, none of these three dimensions carries
+   a per-note value onto a Member Channel.
 
-3. **Control Dimension Initialization**: To maximize compatibility with MPE receivers, all three control dimensions (Pitch Bend, CC #74, and Channel Pressure) shall be sent before each Note On message, even when the input sender omitted some of them. When a control dimension was not present in the input, the MPE Tuner shall use the default values as documented in the MPE Specification:
-   - **Pitch Bend**: center value (0x2000, i.e., no bend), combined with the tuning offset.
-   - **CC #74**: 64 (0x40), the neutral initial-64 value [1, §3.3.5].
-   - **Channel Pressure**: 0 [1, §3.3.4].
-
-This initialization practice aligns with the MPE Specification's recommendation to prevent audible artifacts at note onset [1, §3.3.1].
+3. **Control Dimension Initialization**: To maximize compatibility with MPE receivers and to prevent audible artifacts
+   at note onset [1, §3.3.1], all three per-note control dimensions (Pitch Bend, CC #74, and Channel Pressure) shall be
+   set on the assigned Member Channel before each Note On message. Because item 2 routes the input's channel-global
+   Pitch Bend, CC #74, and Channel Pressure to the Master Channel, none of these dimensions is taken from the input onto
+   the Member Channel; each is therefore initialized as follows:
+    - **Pitch Bend**: the tuning offset for the note's pitch class. There is no expressive component on the Member
+      Channel — the input's expressive Pitch Bend lives on the Master Channel (item 2) — so the Member Channel Pitch
+      Bend encodes the tuning offset alone.
+    - **CC #74**: 64 (0x40), the neutral initial value [1, §3.3.5].
+    - **Channel Pressure**: 0 [1, §3.3.4]. A non-zero value can arise later in the note's lifetime as the Tuner converts
+      incoming Polyphonic Key Pressure for the active note (item 1), but at onset the value is always the default:
+      Polyphonic Key Pressure that precedes a note's Note On is discarded rather than retained (item 1), and such
+      ordering is in any case uncommon and of dubious musical meaning, since aftertouch models pressure on a key that is
+      already held.
 
 ### 3.4 Master Channel Note Forwarding
 
@@ -177,8 +198,8 @@ threefold:
    notes and requires that receivers play them. Silently relocating them would violate the sender's explicit channel
    assignment.
 2. **Conservation of Member Channel resources.** Master Channel notes are, by design, notes that do not require per-note
-   control. Placing them on a Member Channel would consume a Pitch Class Group or Expression Group slot unnecessarily,
-   reducing the Zone's effective polyphony for notes that do require per-note control.
+   control. Placing them on a Member Channel would consume a slot unnecessarily, reducing the Zone's effective polyphony
+   for notes that do require per-note control.
 3. **Preservation of Polyphonic Key Pressure compatibility.** The MPE Specification [1, §2.5] forbids Polyphonic Key
    Pressure on Member Channels but allows it on Master Channel notes. Forwarding Master Channel notes as-is preserves
    the ability to use Polyphonic Key Pressure on those notes.

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -154,38 +154,20 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
    they serve as Zone-level controls affecting all notes equally. Consequently, none of these three dimensions carries
    a per-note value onto a Member Channel.
 
-3. **Control Dimension Initialization**: Before a note is assigned to a **previously unoccupied** Member Channel, the
-   MPE Tuner shall bring that channel to the correct state in all three per-note control dimensions (Pitch Bend,
-   CC #74, and Channel Pressure), so the new note does not inherit residual values left by the channel's previous
-   occupant — the "swooping" artifact the MPE Specification warns against [1, §3.3.1]. Because item 2 routes the
-   input's channel-global Pitch Bend, CC #74, and Channel Pressure to the Master Channel, none of these dimensions is
-   taken from the input onto the Member Channel; the target state on a freshly occupied channel is therefore:
+3. **Control Dimension Initialization**: To maximize compatibility with MPE receivers and to prevent audible artifacts
+   at note onset [1, §3.3.1], all three per-note control dimensions (Pitch Bend, CC #74, and Channel Pressure) shall be
+   set on the assigned Member Channel before each Note On message. Because item 2 routes the input's channel-global
+   Pitch Bend, CC #74, and Channel Pressure to the Master Channel, none of these dimensions is taken from the input onto
+   the Member Channel; each is therefore initialized as follows:
     - **Pitch Bend**: the tuning offset for the note's pitch class. There is no expressive component on the Member
       Channel — the input's expressive Pitch Bend lives on the Master Channel (item 2) — so the Member Channel Pitch
       Bend encodes the tuning offset alone.
     - **CC #74**: 64 (0x40), the neutral initial value [1, §3.3.5].
     - **Channel Pressure**: 0 [1, §3.3.4]. A non-zero value can arise later in the note's lifetime as the Tuner converts
-      incoming Polyphonic Key Pressure for the active note (item 1), but at onset the value is the default: Polyphonic
-      Key Pressure that precedes a note's Note On is discarded rather than retained (item 1), and such ordering is in
-      any case uncommon and of dubious musical meaning, since aftertouch models pressure on a key that is already held.
-
-   The MPE Specification does not require every dimension to be retransmitted before each Note On: it permits a sender
-   to omit dimensions [1, §3.3.1] and has receivers track and store each Member Channel's control values while no note
-   plays, using them as the next note's initial state [1, §3.3]. Because the MPE Tuner is stateful and knows the value
-   it last sent on every Member Channel, it **may** transmit a setup message only when the target value above differs
-   from the channel's current value, leaving an already-correct dimension untransmitted. In non-MPE input mode this
-   elides nearly all CC #74 messages (the Member-Channel value is permanently 64) and most Channel Pressure resets
-   (needed only after a note whose Polyphonic Key Pressure was converted), whereas Pitch Bend — which changes whenever a
-   channel is reused for a different pitch class or the Tuning changes — is usually sent. A simpler implementation may
-   instead always transmit all three; on a freshly occupied channel the two are equivalent. Divergence between the
-   Tuner's model and the receiver's state is corrected when a Zone is (re)configured — receivers then reset all
-   Member-Channel controls to their defaults [1, §2.1.4] — not by retransmitting on every Note On.
-
-   This initialization applies only to a **newly occupied** channel. When a note instead joins an already-occupied
-   channel (channel sharing, Step 3 of Section 4.5, necessarily by a note of the same pitch class), the Tuner does
-   **not** reset the channel to these defaults — doing so would disturb the notes already sounding on it — but only
-   updates the genuinely shared dimension, recomputing the channel's Pitch Bend as the average over its active notes
-   (Section 4.6).
+      incoming Polyphonic Key Pressure for the active note (item 1), but at onset the value is always the default:
+      Polyphonic Key Pressure that precedes a note's Note On is discarded rather than retained (item 1), and such
+      ordering is in any case uncommon and of dubious musical meaning, since aftertouch models pressure on a key that is
+      already held.
 
 ### 3.4 Master Channel Note Forwarding
 
@@ -537,19 +519,14 @@ The MPE Tuner relies on the default Member Channel Pitch Bend Sensitivity of ±4
 
 ### 6.3 Message Ordering
 
-When a note is assigned to a **newly occupied** Member Channel, the MPE Tuner outputs messages in the following order on
-that channel:
+For each new note, the MPE Tuner outputs messages in the following order on the assigned Member Channel:
 
 1. **Pitch Bend**: Encoding the sum of the tuning offset and the initial expressive pitch bend.
-2. **CC #74**: The timbre control value, forwarded from the input (in MPE input mode) or set to the default value of 64.
-3. **Channel Pressure**: Forwarded from the input (in MPE input mode) or set to the default value of 0.
+2. **CC #74**: The timbre control value, forwarded from the input or set to the default value of 64.
+3. **Channel Pressure**: Forwarded from the input or set to the default value of 0.
 4. **Note On**: The note message itself.
 
-This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has
-the correct pitch and articulation state before the note begins sounding. As described in Section 3.3, the Tuner is
-stateful and may omit any of the three setup messages whose value already matches the channel's current state; only the
-Note On is unconditional. When a note instead joins an already-occupied channel, the Tuner does not re-emit this setup
-sequence — it preserves the channel's established state and updates only the shared Pitch Bend (Section 4.6).
+This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has the correct pitch and articulation state before the note begins sounding.
 
 ### 6.4 Zone-Level Messages
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -154,20 +154,38 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
    they serve as Zone-level controls affecting all notes equally. Consequently, none of these three dimensions carries
    a per-note value onto a Member Channel.
 
-3. **Control Dimension Initialization**: To maximize compatibility with MPE receivers and to prevent audible artifacts
-   at note onset [1, §3.3.1], all three per-note control dimensions (Pitch Bend, CC #74, and Channel Pressure) shall be
-   set on the assigned Member Channel before each Note On message. Because item 2 routes the input's channel-global
-   Pitch Bend, CC #74, and Channel Pressure to the Master Channel, none of these dimensions is taken from the input onto
-   the Member Channel; each is therefore initialized as follows:
+3. **Control Dimension Initialization**: Before a note is assigned to a **previously unoccupied** Member Channel, the
+   MPE Tuner shall bring that channel to the correct state in all three per-note control dimensions (Pitch Bend,
+   CC #74, and Channel Pressure), so the new note does not inherit residual values left by the channel's previous
+   occupant — the "swooping" artifact the MPE Specification warns against [1, §3.3.1]. Because item 2 routes the
+   input's channel-global Pitch Bend, CC #74, and Channel Pressure to the Master Channel, none of these dimensions is
+   taken from the input onto the Member Channel; the target state on a freshly occupied channel is therefore:
     - **Pitch Bend**: the tuning offset for the note's pitch class. There is no expressive component on the Member
       Channel — the input's expressive Pitch Bend lives on the Master Channel (item 2) — so the Member Channel Pitch
       Bend encodes the tuning offset alone.
     - **CC #74**: 64 (0x40), the neutral initial value [1, §3.3.5].
     - **Channel Pressure**: 0 [1, §3.3.4]. A non-zero value can arise later in the note's lifetime as the Tuner converts
-      incoming Polyphonic Key Pressure for the active note (item 1), but at onset the value is always the default:
-      Polyphonic Key Pressure that precedes a note's Note On is discarded rather than retained (item 1), and such
-      ordering is in any case uncommon and of dubious musical meaning, since aftertouch models pressure on a key that is
-      already held.
+      incoming Polyphonic Key Pressure for the active note (item 1), but at onset the value is the default: Polyphonic
+      Key Pressure that precedes a note's Note On is discarded rather than retained (item 1), and such ordering is in
+      any case uncommon and of dubious musical meaning, since aftertouch models pressure on a key that is already held.
+
+   The MPE Specification does not require every dimension to be retransmitted before each Note On: it permits a sender
+   to omit dimensions [1, §3.3.1] and has receivers track and store each Member Channel's control values while no note
+   plays, using them as the next note's initial state [1, §3.3]. Because the MPE Tuner is stateful and knows the value
+   it last sent on every Member Channel, it **may** transmit a setup message only when the target value above differs
+   from the channel's current value, leaving an already-correct dimension untransmitted. In non-MPE input mode this
+   elides nearly all CC #74 messages (the Member-Channel value is permanently 64) and most Channel Pressure resets
+   (needed only after a note whose Polyphonic Key Pressure was converted), whereas Pitch Bend — which changes whenever a
+   channel is reused for a different pitch class or the Tuning changes — is usually sent. A simpler implementation may
+   instead always transmit all three; on a freshly occupied channel the two are equivalent. Divergence between the
+   Tuner's model and the receiver's state is corrected when a Zone is (re)configured — receivers then reset all
+   Member-Channel controls to their defaults [1, §2.1.4] — not by retransmitting on every Note On.
+
+   This initialization applies only to a **newly occupied** channel. When a note instead joins an already-occupied
+   channel (channel sharing, Step 3 of Section 4.5, necessarily by a note of the same pitch class), the Tuner does
+   **not** reset the channel to these defaults — doing so would disturb the notes already sounding on it — but only
+   updates the genuinely shared dimension, recomputing the channel's Pitch Bend as the average over its active notes
+   (Section 4.6).
 
 ### 3.4 Master Channel Note Forwarding
 
@@ -519,14 +537,19 @@ The MPE Tuner relies on the default Member Channel Pitch Bend Sensitivity of ±4
 
 ### 6.3 Message Ordering
 
-For each new note, the MPE Tuner outputs messages in the following order on the assigned Member Channel:
+When a note is assigned to a **newly occupied** Member Channel, the MPE Tuner outputs messages in the following order on
+that channel:
 
 1. **Pitch Bend**: Encoding the sum of the tuning offset and the initial expressive pitch bend.
-2. **CC #74**: The timbre control value, forwarded from the input or set to the default value of 64.
-3. **Channel Pressure**: Forwarded from the input or set to the default value of 0.
+2. **CC #74**: The timbre control value, forwarded from the input (in MPE input mode) or set to the default value of 64.
+3. **Channel Pressure**: Forwarded from the input (in MPE input mode) or set to the default value of 0.
 4. **Note On**: The note message itself.
 
-This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has the correct pitch and articulation state before the note begins sounding.
+This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has
+the correct pitch and articulation state before the note begins sounding. As described in Section 3.3, the Tuner is
+stateful and may omit any of the three setup messages whose value already matches the channel's current state; only the
+Note On is unconditional. When a note instead joins an already-occupied channel, the Tuner does not re-emit this setup
+sequence — it preserves the channel's established state and updates only the shared Pitch Bend (Section 4.6).
 
 ### 6.4 Zone-Level Messages
 


### PR DESCRIPTION
Updates the MPE Tuner paper (`docs/architecture/tuner/mpe-tuner-paper.md`) following a review of Section 3.

- Introduce the pitch-class invariant in the §3.1 signal-flow overview so tuning application reads correctly, and qualify the expressive-bend term by input mode.
- Rework §3.3 non-MPE conversion: generalize control redirection to cover Pitch Bend, CC #74, and Channel Pressure; replace the misleading default-value framing with a positive enumeration of Member-Channel target state; add the poly-pressure discard rule.
- Reframe control-dimension initialization from "always send all three before each Note On" to a state-based requirement (omit unchanged setup messages; do not re-initialize a shared channel), aligning §3.3 and §6.3 with the MPE Specification.

Part of #237