### PR TITLE
[#154] Reorganize MPE Tuner paper configuration section

### DIFF
--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -44,9 +44,9 @@ The Pitch Bend emitted on an output Member Channel is always the sum of the two 
 
 > **Pitch Bend = Tuning Pitch Bend + Expression Pitch Bend**
 
-Any pitch alteration present in the input signal is never interpreted as an alternative tuning; it contributes exclusively to the expression domain — as Expression Pitch Bend in MPE Input Mode, or as Master Channel Pitch Bend in Non-MPE Input Mode (Section 3.4) — while the Tuning Pitch Bend is derived solely from the active Tuning.
+Any pitch alteration present in the input signal is never interpreted as an alternative tuning; it contributes exclusively to the expression domain — as Expression Pitch Bend in MPE Input Mode, or as Master Channel Pitch Bend in Non-MPE Input Mode (Section 3.3) — while the Tuning Pitch Bend is derived solely from the active Tuning.
 
-The performer-controlled values of the three control dimensions are collectively called **Expression Values**. A note's Expression Values comprise its Expression Pitch Bend, its Channel Pressure, and its CC #74 value. The Tuning Pitch Bend is not an Expression Value: it belongs to the tuning domain, not to the expression domain. Section 6 specifies how the Expression Values of individual notes are combined on output Member Channels.
+The performer-controlled values of the three control dimensions are collectively called **Expression Values**. A note's Expression Values comprise its Expression Pitch Bend, its Channel Pressure, and its CC #74 value. The Tuning Pitch Bend is not an Expression Value: it belongs to the tuning domain, not to the expression domain. Section 7 specifies how the Expression Values of individual notes are combined on output Member Channels.
 
 ### 1.4 Overview of Operation
 
@@ -54,12 +54,12 @@ The MPE Tuner sits in the MIDI signal path between a controller (or sequencer) a
 
 1. Receives MIDI input, which may be either conventional (non-MPE) or MPE.
 2. Allocates incoming notes to MPE Member Channels according to a strategy that prioritizes intonation precision.
-3. Computes the appropriate Pitch Bend value for each Member Channel as the sum of the Tuning Pitch Bend for the channel's pitch class and the Expression Pitch Bend derived from the input (Section 1.3); in Non-MPE Input Mode the Expression component is absent (Section 3.4).
+3. Computes the appropriate Pitch Bend value for each Member Channel as the sum of the Tuning Pitch Bend for the channel's pitch class and the Expression Pitch Bend derived from the input (Section 1.3); in Non-MPE Input Mode the Expression component is absent (Section 3.3).
 4. Outputs a fully MPE-conformant MIDI stream.
 
-The output of the MPE Tuner is always MPE, regardless of whether the input is MPE or non-MPE. The input mode may be configured through a non-MIDI interface or detected automatically: upon receiving an MPE Configuration Message (MCM), the MPE Tuner shall switch to MPE Input Mode and reconfigure its Zones accordingly (Section C).
+The output of the MPE Tuner is always MPE, regardless of whether the input is MPE or non-MPE. The input mode may be configured through a non-MIDI interface or detected automatically: upon receiving an MPE Configuration Message (MCM), the MPE Tuner shall switch to MPE Input Mode and reconfigure its Zones accordingly (Section 4).
 
-The obligations of output conformance to the MPE Specification are specified where they arise: configuration of Zones and Pitch Bend Sensitivity in Section C, Note On message ordering in Section 6.1.1, Master Channel forwarding in Section 3.5, Note Off behavior in Section 6.1, and the Channel Pressure reset at Note Off in Section 6.4.
+The obligations of output conformance to the MPE Specification are specified where they arise: configuration of Zones and Pitch Bend Sensitivity in Section 4, Note On message ordering in Section 7.1.1, Master Channel forwarding in Section 3.4, Note Off behavior in Section 7.1, and the Channel Pressure reset at Note Off in Section 7.4.
 
 ---
 
@@ -145,46 +145,46 @@ flowchart LR
     D --> E["MIDI Output"]
 ```
 
-1. **Input Mode Detection**: Determines whether the incoming stream is MPE or non-MPE. The mode may be set via a non-MIDI configuration interface. Receipt of an MCM shall cause the Tuner to switch to MPE Input Mode automatically and to reconfigure its Zones according to the message (Section C).
+1. **Input Mode Detection**: Determines whether the incoming stream is MPE or non-MPE. The mode may be set via a non-MIDI configuration interface. Receipt of an MCM shall cause the Tuner to switch to MPE Input Mode automatically and to reconfigure its Zones according to the message (Section 4).
 
 2. **Channel Allocation**: Assigns each incoming note that arrives on a Member Channel (in MPE Input Mode) or on any
    channel (in Non-MPE Input Mode) to a Member Channel in the output Zone(s), following the dual-group allocation
-   strategy described in Section 4. This allocation enforces the **pitch-class invariant** (Section 4.1): all notes
+   strategy described in Section 5. This allocation enforces the **pitch-class invariant** (Section 5.1): all notes
    simultaneously active on a Member Channel share the same pitch class, so each occupied channel is associated with
    exactly one pitch class — and therefore one tuning offset. Notes received on a Master Channel in MPE Input Mode are
-   exempt from allocation and are forwarded as-is (see Section 3.5).
+   exempt from allocation and are forwarded as-is (see Section 3.4).
 
 3. **Tuning & Expression Application**: For each occupied Member Channel, computes the output Pitch Bend as the sum of
    the Tuning Pitch Bend for the channel's associated pitch class and the channel's Expression Pitch Bend — the average
-   of the Expression Pitch Bends of its active notes (Section 6). The Expression Pitch Bend component applies in MPE
+   of the Expression Pitch Bends of its active notes (Section 7). The Expression Pitch Bend component applies in MPE
    Input Mode; in Non-MPE Input Mode the input's Pitch Bend is redirected to the Master Channel
-   (Section 3.4), so the Member Channel Pitch Bend encodes the Tuning Pitch Bend alone. The Channel Pressure and CC #74
-   Expression Values of each channel are maintained under the same aggregation model (Section 6).
+   (Section 3.3), so the Member Channel Pitch Bend encodes the Tuning Pitch Bend alone. The Channel Pressure and CC #74
+   Expression Values of each channel are maintained under the same aggregation model (Section 7).
 
 ### 3.2 Input Modes
 
 The MPE Tuner accepts two classes of input:
 
-- **Non-MPE input**: Conventional MIDI where all notes may arrive on a single channel or across channels without MPE Zone structure. This input requires conversion to MPE (Section 3.4) and is routed to a single output Zone (Section C.2). In this mode the Zone configuration originates solely from the non-MIDI configuration interface (Section C.2).
+- **Non-MPE input**: Conventional MIDI where all notes may arrive on a single channel or across channels without MPE Zone structure. This input requires conversion to MPE (Section 3.3) and is routed to a single output Zone (Section 4.2). In this mode the Zone configuration originates solely from the non-MIDI configuration interface (Section 4.2).
 - **MPE input**: MIDI conforming to the MPE Specification, with notes primarily distributed across Member Channels
-  within Zones, and optionally on Master Channels as permitted by the specification (see Section 3.5). The input stream
-  may contain MPE Configuration Messages, which reconfigure the Tuner's Zones (Section C.2).
+  within Zones, and optionally on Master Channels as permitted by the specification (see Section 3.4). The input stream
+  may contain MPE Configuration Messages, which reconfigure the Tuner's Zones (Section 4.2).
 
 In both cases, the output is always MPE-conformant.
 
-### 3.4 Non-MPE to MPE Conversion
+### 3.3 Non-MPE to MPE Conversion
 
 When the input is non-MPE, the MPE Tuner must perform the following conversions to produce valid MPE output:
 
 1. **Polyphonic Key Pressure to Channel Pressure**: In MPE, Polyphonic Key Pressure must not be sent on Member Channels
    [1, §2.5]. Any Polyphonic Key Pressure message in the non-MPE input is converted to a Channel Pressure message on
    the Member Channel hosting the addressed note; when multiple notes share that channel, the converted values are
-   combined by averaging (Section 6.3). A Polyphonic Key Pressure addressed to a note number that is not currently
+   combined by averaging (Section 7.3). A Polyphonic Key Pressure addressed to a note number that is not currently
    active has no Member Channel to target and is discarded; the Tuner does not retain it to influence a later Note On.
 
 2. **Channel-Global Control Redirection to Master Channel**: In non-MPE input, Pitch Bend, CC #74, and Channel Pressure
    each apply to all notes on the input channel rather than to an individual note. These channel-global controls shall
-   be redirected to the Master Channel of the single output Zone selected for non-MPE input (see Section C.2), where
+   be redirected to the Master Channel of the single output Zone selected for non-MPE input (see Section 4.2), where
    they serve as Zone-level controls affecting all notes equally. Consequently, none of these three dimensions carries
    a per-note value onto a Member Channel. When the input spans multiple channels, the redirected controls of all input
    channels merge onto the single Master Channel, the most recent message taking effect: the Tuner treats non-MPE input
@@ -193,7 +193,7 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
 3. **Control Dimension Initialization**: To maximize compatibility with MPE receivers and to prevent audible artifacts
    at note onset [1, §3.3.1], the control dimensions of the assigned Member Channel shall be brought to their correct
    values before each Note On message; messages may be omitted for dimensions whose values are already correct on that
-   channel (Section 6.1). Because item 2 routes the input's channel-global Pitch Bend, CC #74, and Channel Pressure to
+   channel (Section 7.1). Because item 2 routes the input's channel-global Pitch Bend, CC #74, and Channel Pressure to
    the Master Channel, none of these dimensions is taken from the input onto the Member Channel; each is therefore
    determined as follows:
     - **Pitch Bend**: the Tuning Pitch Bend for the note's pitch class. There is no per-channel Expression Pitch Bend
@@ -206,18 +206,18 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
       pressure on a key that is already held.
     - **CC #74**: not emitted on Member Channels. In Non-MPE Input Mode there is no source of per-note CC #74 — the
       dimension is controllable only globally, via the Master Channel (item 2) — so the Tuner never sends CC #74 on a
-      Member Channel (Section 6.3).
+      Member Channel (Section 7.3).
 
 4. **Redirection of Remaining Channel Messages**: All other Channel Voice and Channel Mode messages received on a
    non-MPE input channel — for example Damper Pedal (CC #64), Modulation (CC #1), Volume (CC #7), Program Change and
    Bank Select, and Reset All Controllers (CC #121) — are redirected to the Master Channel of the selected output Zone,
-   where they act as Zone-level messages (Section 3.5). Non-MPE input has no Master Channel of its own from which
-   Section 3.5's forwarding could operate; this redirection gives those messages their conformant Zone-level home on
+   where they act as Zone-level messages (Section 3.4). Non-MPE input has no Master Channel of its own from which
+   Section 3.4's forwarding could operate; this redirection gives those messages their conformant Zone-level home on
    the output. A Pitch Bend Sensitivity message (RPN 00 00) received on the non-MPE input is likewise forwarded to the
    Master Channel, where it configures the sensitivity of the Master Channel Pitch Bend to which the input's Pitch Bend
-   is redirected (Section C.3).
+   is redirected (Section 4.3).
 
-### 3.5 Master Channel Forwarding
+### 3.4 Master Channel Forwarding
 
 The MPE Specification permits Note On and Note Off messages on a Master Channel, and requires receivers to respond to
 them [1, §3.2]. Placing a note on the Master Channel is a deliberate choice by the MPE sender: the sender opts out of the
@@ -231,12 +231,12 @@ the Master Channel, in place of the Channel Pressure dimension that Member Chann
 
 In MPE Input Mode, the MPE Tuner shall honor this sender intent: Note On and Note Off messages received on a Master
 Channel of an enabled Zone are forwarded on the same Master Channel without modification, bypassing the channel
-allocation procedure described in Section 4. The MPE Tuner shall not emit any Pitch Bend, CC #74, or Channel Pressure
+allocation procedure described in Section 5. The MPE Tuner shall not emit any Pitch Bend, CC #74, or Channel Pressure
 setup messages for a Master Channel Note On.
 
 A direct consequence of this behavior is that **notes forwarded on the Master Channel do not receive a per-pitch-class
 tuning offset**. They sound in 12-EDO, modulated only by the Master Channel Pitch Bend that the performer sends for
-expressive purposes (see Section 4.7.5). This is an unavoidable consequence of the pitch-class invariant (Section 4.1):
+expressive purposes (see Section 5.7.5). This is an unavoidable consequence of the pitch-class invariant (Section 5.1):
 the Master Channel's Pitch Bend is a Zone-level message that affects all Member Channel notes, so it cannot be used to
 encode a tuning offset for a specific pitch class without mistuning every other sounding note.
 
@@ -253,39 +253,39 @@ threefold:
    the ability to use Polyphonic Key Pressure on those notes.
 
 The forwarding rule extends beyond notes. The MPE Tuner forwards Master Channel Pitch Bend as received, without
-modification; Master Pitch Bend is a Zone-level expressive control, and Section 4.7.5 discusses its relationship to
+modification; Master Pitch Bend is a Zone-level expressive control, and Section 5.7.5 discusses its relationship to
 tuning. Zone-level messages — Damper Pedal, Program Change, Reset All Controllers, and the other messages listed in
 Table 1 of the MPE Specification (Section 2.6) — are likewise forwarded on the Master Channel without modification.
 The MPE Tuner does not interpret or alter any of these messages.
 
 In Non-MPE Input Mode there is no input Master Channel to forward from: every incoming note is allocated to a Member
 Channel regardless of the input channel number, and the input's channel-global controls and Zone-level messages reach
-the output Master Channel by *redirection* instead, under the conversion rules of Section 3.4, items 2 and 4.
+the output Master Channel by *redirection* instead, under the conversion rules of Section 3.3, items 2 and 4.
 
 ---
 
-## C. Configuration
+## 4. Configuration
 
-The MPE Tuner's operation is governed by three configuration parameters, established before any note flows and applying across every stage of the pipeline: the input mode (Section C.1), the Zone configuration (Section C.2), and the Pitch Bend Sensitivity (Section C.3). All three follow the same model: the parameter is established through a **non-MIDI configuration interface**, and may additionally be overridden in-band, through MIDI messages received on the input — MCMs for the input mode and the Zones, and Pitch Bend Sensitivity messages (RPN 00 00) for the Pitch Bend Sensitivity — subject to the per-parameter limitations stated in the subsections below. Where the MPE Specification defines defaults, notably the Pitch Bend Sensitivity values of Section 2.3, the Tuner adopts them in the absence of explicit configuration.
+The MPE Tuner's operation is governed by three configuration parameters, established before any note flows and applying across every stage of the pipeline: the input mode (Section 4.1), the Zone configuration (Section 4.2), and the Pitch Bend Sensitivity (Section 4.3). All three follow the same model: the parameter is established through a **non-MIDI configuration interface**, and may additionally be overridden in-band, through MIDI messages received on the input — MCMs for the input mode and the Zones, and Pitch Bend Sensitivity messages (RPN 00 00) for the Pitch Bend Sensitivity — subject to the per-parameter limitations stated in the subsections below. Where the MPE Specification defines defaults, notably the Pitch Bend Sensitivity values of Section 2.3, the Tuner adopts them in the absence of explicit configuration.
 
-### C.1 Input Mode
+### 4.1 Input Mode
 
 Section 3.2 defines the two input modes; this subsection specifies how the operating mode is selected. The input mode may be set through the non-MIDI configuration interface, or switched in-band by the input stream itself (Section 3.1): upon receiving a valid MCM, the Tuner switches to MPE Input Mode if it is not already in it. The in-band switch is one-way: no MCM returns the Tuner to Non-MPE Input Mode, which is re-entered only through the non-MIDI configuration interface.
 
-MCMs that deactivate all Zones are no exception: they too switch the Tuner to MPE Input Mode if necessary, and they turn MPE operation off [1, §2.1]. The Zone configuration is shared by the input and the output (Section C.2), so all Zones being deactivated leaves the output without MPE as well; the deactivation is mirrored on the output like any other Zone change (Section C.2), and the Tuner produces no note output until a Zone is re-activated, by a subsequent MCM or through the non-MIDI configuration interface.
+MCMs that deactivate all Zones are no exception: they too switch the Tuner to MPE Input Mode if necessary, and they turn MPE operation off [1, §2.1]. The Zone configuration is shared by the input and the output (Section 4.2), so all Zones being deactivated leaves the output without MPE as well; the deactivation is mirrored on the output like any other Zone change (Section 4.2), and the Tuner produces no note output until a Zone is re-activated, by a subsequent MCM or through the non-MIDI configuration interface.
 
-### C.2 Zones
+### 4.2 Zones
 
 The MPE Tuner maintains a single Zone configuration shared by its input and its output — not separate input and output configurations: the number of Member Channels allocated to the Lower Zone and, optionally, to the Upper Zone. As in the MPE Specification, one or two Zones may be defined. The role this shared configuration plays depends on the input mode:
 
 - In **MPE Input Mode**, the Zone configuration applies to both input and output: the Tuner expects the input stream to be organized according to the configured Zones, and produces output organized by the same Zones. Notes received on the Member Channels of an input Zone are allocated to Member Channels of the same output Zone.
 - In **Non-MPE Input Mode**, the input has no Zone structure, so the Zone configuration affects the output only. Furthermore, only one Zone is accessible from the output: input notes are routed exclusively to the Lower Zone if it is enabled, otherwise to the Upper Zone. When two Zones are defined, the Upper Zone is ignored. This restriction prevents ambiguity in channel allocation and zone-level message routing when the input carries no Zone information of its own.
 
-Beyond the non-MIDI configuration interface, the Zone configuration may be changed in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. A valid MCM — which also switches the Tuner to MPE Input Mode if it is not already in it (Section C.1) — reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1]. An MCM that deactivates all Zones suspends MPE operation altogether (Section C.1).
+Beyond the non-MIDI configuration interface, the Zone configuration may be changed in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. A valid MCM — which also switches the Tuner to MPE Input Mode if it is not already in it (Section 4.1) — reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1]. An MCM that deactivates all Zones suspends MPE operation altogether (Section 4.1).
 
-The Tuner emits the MCM(s) describing its Zone configuration at start-up, and again whenever the configuration changes — through either mechanism — so that the receiving instrument adopts the same Zone structure. A reconfiguration also resets the Tuner's state for every channel entering or leaving MPE control, mirroring the receiver obligations of the MPE Specification [1, §2.1.4]: active notes on the affected channels are dropped, the channels' group assignments (Section 4.2) are cleared, the retained Expression Values and remembered input-channel control values (Section 6) return to their defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64 — and Pitch Bend Sensitivity returns to the specification's defaults of ±48 semitones on Member Channels and ±2 semitones on the Master Channel (Section C.3). Channels of a Zone untouched by the reconfiguration keep their notes and state. For the dropped notes, an implementation may either emit no Note Off messages — relying on the downstream receiver's obligation to stop ongoing notes upon receiving the MCM [1, §2.1.4] — or emit explicit Note Off messages before the MCM, for robustness with receivers that do not fully conform; the choice is left to the implementer.
+The Tuner emits the MCM(s) describing its Zone configuration at start-up, and again whenever the configuration changes — through either mechanism — so that the receiving instrument adopts the same Zone structure. A reconfiguration also resets the Tuner's state for every channel entering or leaving MPE control, mirroring the receiver obligations of the MPE Specification [1, §2.1.4]: active notes on the affected channels are dropped, the channels' group assignments (Section 5.2) are cleared, the retained Expression Values and remembered input-channel control values (Section 7) return to their defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64 — and Pitch Bend Sensitivity returns to the specification's defaults of ±48 semitones on Member Channels and ±2 semitones on the Master Channel (Section 4.3). Channels of a Zone untouched by the reconfiguration keep their notes and state. For the dropped notes, an implementation may either emit no Note Off messages — relying on the downstream receiver's obligation to stop ongoing notes upon receiving the MCM [1, §2.1.4] — or emit explicit Note Off messages before the MCM, for robustness with receivers that do not fully conform; the choice is left to the implementer.
 
-### C.3 Pitch Bend Sensitivity
+### 4.3 Pitch Bend Sensitivity
 
 The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The MPE Tuner relies on these defaults both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output.
 
@@ -300,24 +300,24 @@ The Tuner also listens for Pitch Bend Sensitivity messages (RPN 00 00) on its in
   forwarding already configures every output Member Channel.
 - **Non-MPE Input Mode**: the input carries no Member Channels. Because a Member Channel's Pitch Bend then carries
   only the Tuning Pitch Bend, a Pitch Bend Sensitivity message received on the input applies to the output Master
-  Channel, consistent with the redirection of the input's Pitch Bend to that channel (Section 3.4). The output
+  Channel, consistent with the redirection of the input's Pitch Bend to that channel (Section 3.3). The output
   Member Channels retain the specification's default of ±48 semitones, which can be changed only through the
   non-MIDI configuration interface.
 
 ---
 
-## 4. Allocation of Notes to Member Channels
+## 5. Allocation of Notes to Member Channels
 
 The channel allocation strategy is the central contribution of the MPE Tuner design. Standard MPE allocation strategies aim to maximize per-note expressiveness while gracefully handling polyphony overflow. The MPE Tuner reorders these priorities: **intonation precision is the primary objective**, even at the cost of dropping active notes or constraining expressive independence.
 
 The allocation rules in this section apply to notes that are candidates for tuning via per-channel Pitch Bend — that is,
 all notes received in Non-MPE Input Mode, and all notes received on a Member Channel in MPE Input Mode. Notes received
-on a Master Channel in MPE Input Mode are forwarded as-is under the rules of Section 3.5 and are not subject to the
+on a Master Channel in MPE Input Mode are forwarded as-is under the rules of Section 3.4 and are not subject to the
 allocation procedure described below.
 
 Throughout this paper, a Note On with velocity 0 is treated as a Note Off [1, §3.3.2].
 
-### 4.1 Fundamental Invariant
+### 5.1 Fundamental Invariant
 
 The following invariant governs all channel allocation decisions:
 
@@ -327,7 +327,7 @@ This invariant follows directly from how a Tuning is defined: as a set of offset
 
 Furthermore, even when two pitch classes happen to have identical tuning offsets at a given moment, they must not share a Member Channel. The Tuning may change at any time during performance, potentially assigning different offsets to those pitch classes. Preemptively separating them onto distinct channels ensures that the Tuner can always adjust each pitch class independently without interrupting sounding notes.
 
-### 4.2 Dual-Group Channel Partitioning
+### 5.2 Dual-Group Channel Partitioning
 
 For each Zone, the available Member Channels are logically partitioned into two groups:
 
@@ -340,7 +340,7 @@ unoccupied channel may be assigned to either group as notes are allocated. The g
 determined at the moment a note is placed on it and persists for the lifetime of that channel's occupancy. The
 channel becomes available for reuse once all its notes have received Note Off messages.
 
-### 4.3 Group Size Allocation
+### 5.3 Group Size Allocation
 
 Each group has a **capacity** — the maximum number of occupied channels that may be assigned to it at any moment — determined by the total number of Member Channels `n` configured for the Zone:
 
@@ -353,7 +353,7 @@ Each group has a **capacity** — the maximum number of occupied channels that m
 
 The rationale for these sizes is as follows. The Pitch Class Group must be large enough to cover the maximum number of distinct pitch classes likely to be sounding simultaneously. Notably, for a single Zone with 15 Member Channels, the Pitch Class Group has a capacity of 12 channels — exactly the number required to represent all twelve pitch classes of a standard keyboard simultaneously. The Expression Group provides a small buffer for expressive duplication of pitch classes. When only one Member Channel is available, the Expression Group is necessarily empty, and the Tuner operates with strict one-note-per-pitch-class behavior.
 
-### 4.4 High Expression Pitch Bend
+### 5.4 High Expression Pitch Bend
 
 A threshold value `t`, measured in cents, defines the boundary between small expressive gestures (vibrato, subtle
 inflections) and large pitch bends. The value of `t` represents the absolute pitch deviation from the tuned pitch caused
@@ -361,7 +361,7 @@ by the Expression Pitch Bend. A note whose Expression Pitch Bend causes a deviat
 considered to have a **High Expression Pitch Bend**. The recommended value is `t = 50` cents (half a semitone): any note
 bent more than 50 cents up or down from its tuned pitch has a High Expression Pitch Bend.
 
-### 4.5 Allocation Algorithm
+### 5.5 Allocation Algorithm
 
 When a new note arrives, the MPE Tuner executes the following allocation procedure:
 
@@ -376,12 +376,12 @@ When a new note arrives, the MPE Tuner executes the following allocation procedu
 3. **Share channel**: If the Expression Group is at full capacity — and the Pitch Class Group either has an active note
    with the new note's pitch class or is itself at full capacity — assign the new note to any channel (from either
    group) that already holds active notes with the same pitch class. This assignment is subject to the High Expression
-   Pitch Bend rules of Section 5.2, which may require freeing the channel instead (Sections 5.2.2 and 5.2.3).
+   Pitch Bend rules of Section 6.2, which may require freeing the channel instead (Sections 6.2.2 and 6.2.3).
 
 4. **Free a channel**: If none of the preceding steps applies — every Member Channel is occupied and no occupied channel
    holds the new note's pitch class — the Tuner frees a channel and assigns the new note to it. Freeing a channel means
    dropping all of its active notes to make it unoccupied. This is a last-resort measure; the conditions under which it
-   is warranted, the notes protected from it, and the selection of the channel to free are specified in Section 5.1.
+   is warranted, the notes protected from it, and the selection of the channel to free are specified in Section 6.1.
 
 ```mermaid
 flowchart TD
@@ -400,7 +400,7 @@ flowchart TD
     Q2 -- No --> Q3
 
     Q3{"Does some occupied channel, either group,<br/>already hold active notes of P?"}
-    Q3 -- Yes --> A3["Step 3 — Assign to that channel, shared with the<br/>same pitch class (subject to Section 5.2)"]
+    Q3 -- Yes --> A3["Step 3 — Assign to that channel, shared with the<br/>same pitch class (subject to Section 6.2)"]
     Q3 -- No --> A4["Step 4 — Free a channel as a last resort,<br/>then assign"]
 ```
 
@@ -409,7 +409,7 @@ The following rule cuts across the steps above rather than constituting a step o
 **Tie-breaking among candidates.** When a step admits more than one valid channel, the following criteria are applied in
 order until a single channel remains. They share a single principle — prefer to act on the channel whose use or release
 is least perceptually disruptive — with criterion (e) serving as a deterministic backstop. The same criteria govern both
-the placement of a new note (Steps 1–3) and the choice of which channel to free (Step 4, Section 5.1).
+the placement of a new note (Steps 1–3) and the choice of which channel to free (Step 4, Section 6.1).
 
 - **(a)** Prefer channels without a High Expression Pitch Bend.
 - **(b)** Among those, prefer the channel with the lowest count of active notes.
@@ -424,17 +424,17 @@ the placement of a new note (Steps 1–3) and the choice of which channel to fre
       the candidates, reverting to the lowest channel number otherwise.
 
 Of these, criteria (b) and (d) are consistent with the MPE Specification's recommendations [1, §3.2], while criteria
-(a) and (c) are extensions specific to the MPE Tuner: (a) reflects the High Expression Pitch Bend model of Section 4.4,
+(a) and (c) are extensions specific to the MPE Tuner: (a) reflects the High Expression Pitch Bend model of Section 5.4,
 and (c) refines the specification's recency notion using the last note onset. The motivation for each follows the shared
 principle of minimal perceptual disruption.
 
 - **(a)** A High Expression Pitch Bend is a dynamic gesture that draws the listener's attention, so dropping such a note
-  — whether because a new note forces the channel to be freed (Section 5.2.3) or because the channel itself is selected
+  — whether because a new note forces the channel to be freed (Section 6.2.3) or because the channel itself is selected
   for freeing — is immediately noticed; these channels are therefore avoided whenever an alternative exists.
 - **(b)** Preferring the channel with the fewest active notes affects as few notes as possible:
     * On placement, every note added to a shared channel forfeits independent expressive control, because the
       channel's three Expression Values — Expression Pitch Bend, Channel Pressure, and CC #74 — are each reduced to an
-      average over the per-note Expression Values of all active notes on the channel (Section 4.6), so the notes can no
+      average over the per-note Expression Values of all active notes on the channel (Section 5.6), so the notes can no
       longer be articulated independently. This loss of independence, not merely the attenuation of any single gesture,
       is the fundamental cost of channel sharing; averaging is the deliberate compromise by which it is managed.
       Confining sharing to the channel that already holds the fewest active notes both limits the number of notes
@@ -464,7 +464,7 @@ the lowest channel number. For the same reason, preserving the input channel can
 invariant nor the group constraints — a channel is admitted as a candidate at Steps 1 and 2 only once both are
 satisfied — nor can it override the perceptual criteria that govern Steps 3 and 4.
 
-### 4.6 Expression Value Computation for Shared Channels
+### 5.6 Expression Value Computation for Shared Channels
 
 When a Member Channel holds multiple active notes (necessarily of the same pitch class), each of the channel's three
 Expression Values is computed as the average of the corresponding per-note Expression Values of all active notes on the
@@ -476,13 +476,13 @@ Output Pitch Bend = Tuning Pitch Bend(pitch class) + average(Expression Pitch Be
 
 The averaging of Expression Values is a necessary compromise when multiple notes share a channel. It provides a natural and gentle degradation of per-note control. For example, if three notes share a channel and only one has an expressive vibrato in the input, the output vibrato amplitude on that channel will be one-third of the input amplitude — a musically acceptable attenuation that preserves the correct base intonation. The same attenuation applies to the Channel Pressure and CC #74 dimensions.
 
-This behavior aligns with the MPE Specification's suggestion of "gentle degradation of pitch control when all Channels are occupied" [1, §3.2]. Section 6 specifies the full life cycle of Expression Values in each input mode — their origin, retention, and update propagation.
+This behavior aligns with the MPE Specification's suggestion of "gentle degradation of pitch control when all Channels are occupied" [1, §3.2]. Section 7 specifies the full life cycle of Expression Values in each input mode — their origin, retention, and update propagation.
 
-### 4.7 Comparison with Standard MPE Allocation
+### 5.7 Comparison with Standard MPE Allocation
 
 The MPE Tuner's allocation strategy departs from the MPE Specification's recommendations in several important respects. Each departure is motivated by the requirement to maintain precise intonation.
 
-#### 4.7.1 Channel Sharing Before Exhaustion
+#### 5.7.1 Channel Sharing Before Exhaustion
 
 The MPE Specification states, within its normative description of MPE operation:
 
@@ -492,15 +492,15 @@ The MPE Tuner does **not** follow this rule unconditionally; the specification i
 
 This departure is essential: blindly assigning each note to a fresh channel without regard to pitch class would eventually require a single channel to carry conflicting tuning offsets, destroying intonation accuracy.
 
-#### 4.7.2 Prioritizing Intonation Over Note Preservation
+#### 5.7.2 Prioritizing Intonation Over Note Preservation
 
-The MPE Specification's allocation guidelines are designed to maximize polyphonic expressiveness and avoid dropping notes. The MPE Tuner inverts this priority: **correct intonation is never sacrificed to preserve an older note**. When channel resources are insufficient to maintain both intonation precision and all currently sounding notes, the Tuner drops notes (Section 5).
+The MPE Specification's allocation guidelines are designed to maximize polyphonic expressiveness and avoid dropping notes. The MPE Tuner inverts this priority: **correct intonation is never sacrificed to preserve an older note**. When channel resources are insufficient to maintain both intonation precision and all currently sounding notes, the Tuner drops notes (Section 6).
 
-#### 4.7.3 Gentle Degradation via Averaging
+#### 5.7.3 Gentle Degradation via Averaging
 
-The MPE Specification notes that one commercial implementation achieves gentle degradation by "switching to a mode where notes step discretely from one pitch to the next, permitting Pitch Bend to respond only to small vibrato gestures" [1, §3.2]. The MPE Tuner achieves an analogous effect through Expression Pitch Bend averaging on shared channels: because notes sharing a channel must have the same pitch class (and hence the same tuning offset), and because High Expression Pitch Bends are constrained (Section 5.2), the effective Pitch Bend on a shared channel responds primarily to small gestures. More sophisticated implementations of the MPE Tuner may additionally implement discrete pitch stepping when a new note arrives on an occupied channel, smoothing the audible transition.
+The MPE Specification notes that one commercial implementation achieves gentle degradation by "switching to a mode where notes step discretely from one pitch to the next, permitting Pitch Bend to respond only to small vibrato gestures" [1, §3.2]. The MPE Tuner achieves an analogous effect through Expression Pitch Bend averaging on shared channels: because notes sharing a channel must have the same pitch class (and hence the same tuning offset), and because High Expression Pitch Bends are constrained (Section 6.2), the effective Pitch Bend on a shared channel responds primarily to small gestures. More sophisticated implementations of the MPE Tuner may additionally implement discrete pitch stepping when a new note arrives on an occupied channel, smoothing the audible transition.
 
-#### 4.7.4 Same Note Number on Multiple Channels
+#### 5.7.4 Same Note Number on Multiple Channels
 
 The MPE Specification acknowledges the legitimacy of having the same Note Number active on multiple Channels:
 
@@ -508,32 +508,32 @@ The MPE Specification acknowledges the legitimacy of having the same Note Number
 
 The Expression Group was introduced specifically to support this use case. When a note's pitch class already occupies a channel in the Pitch Class Group, the Expression Group provides additional channels where the same pitch class can be sounded with a different Expression Pitch Bend, enabling scenarios such as the bent-then-restruck pattern described in the specification.
 
-#### 4.7.5 Master Channel Pitch Bend
+#### 5.7.5 Master Channel Pitch Bend
 
 The MPE Specification requires:
 
 > "If an MPE synthesizer receives Pitch Bend (for example) on both a Master and a Member Channel, it must combine the data meaningfully." [1, §2.3.2]
 
-Master Channel Pitch Bend is forwarded without modification, as part of Master Channel forwarding (Section 3.5). It is not used by the Tuner in computing tuning offsets; it is a Zone-level expressive control, belonging entirely to the performer. The Tuner's tuning offsets are applied exclusively through the Tuning Pitch Bend component of Member Channel Pitch Bend.
+Master Channel Pitch Bend is forwarded without modification, as part of Master Channel forwarding (Section 3.4). It is not used by the Tuner in computing tuning offsets; it is a Zone-level expressive control, belonging entirely to the performer. The Tuner's tuning offsets are applied exclusively through the Tuning Pitch Bend component of Member Channel Pitch Bend.
 
 ---
 
-## 5. Dropping Notes and Freeing Channels
+## 6. Dropping Notes and Freeing Channels
 
 An acceptable cost of maintaining precise intonation is the occasional dropping of notes. This section specifies the
 conditions under which notes are dropped and the criteria for selecting which notes to drop. Dropping is treated as a
 last-resort measure, used only when the fundamental invariants of intonation would otherwise be violated. Dropping arises in two circumstances. Channel exhaustion realizes Step 4 of the allocation algorithm
-(Section 4.5) and is detailed in Section 5.1. High Expression Pitch Bend (Section 5.2) is only partly an allocation-time
-event: it realizes Step 3 when an incoming note must share a channel (Sections 5.2.2 and 5.2.3), but it can also arise
-after allocation, when notes already sharing a channel diverge (Section 5.2.1).
+(Section 5.5) and is detailed in Section 6.1. High Expression Pitch Bend (Section 6.2) is only partly an allocation-time
+event: it realizes Step 3 when an incoming note must share a channel (Sections 6.2.2 and 6.2.3), but it can also arise
+after allocation, when notes already sharing a channel diverge (Section 6.2.1).
 
-### 5.1 Dropping Notes Due to Channel Exhaustion
+### 6.1 Dropping Notes Due to Channel Exhaustion
 
 When all Member Channels are occupied and the Pitch Class Group does not have enough channels to support all pitch
 classes present among the active notes, some notes must be dropped to free a channel for the incoming note. The term
 **freeing a channel** refers to dropping all notes on that channel to make it unoccupied. When a channel is freed, the
 Tuner emits an explicit Note Off message for each of its dropped notes, before the incoming note's Note On. (Note Off
-emission upon Zone reconfiguration is a distinct case, governed by Section C.2.)
+emission upon Zone reconfiguration is a distinct case, governed by Section 4.2.)
 
 The selection of which channel to free follows this procedure:
 
@@ -552,7 +552,7 @@ The selection of which channel to free follows this procedure:
      the sole candidate must be freed regardless of its register.
 
 2. **Apply the tie-breaking criteria**: Among the channels that remain after boundary exclusion, select the channel to
-   free using the tie-breaking criteria of Section 4.5. Because freeing operates on occupied channels, criteria (a)–(d)
+   free using the tie-breaking criteria of Section 5.5. Because freeing operates on occupied channels, criteria (a)–(d)
    are well-defined and discriminating, backed by the deterministic criterion (e); pursuing the same goal of minimizing
    perceptual disruption, they select — in order — the channel without a High Expression Pitch Bend, with the fewest
    active notes, then the oldest.
@@ -568,58 +568,58 @@ number required to represent every pitch class of a standard piano keyboard — 
 distinct pitch classes in use *and* all Expression Group channels are already occupied — a situation that requires an
 unusually high degree of simultaneous polyphony.
 
-### 5.2 Dropping Notes Due to High Expression Pitch Bend
+### 6.2 Dropping Notes Due to High Expression Pitch Bend
 
 Notes are dropped in the following situations involving High Expression Pitch Bend. The cases triggered by an incoming
-note (Sections 5.2.2 and 5.2.3) are associated with Step 3 of the allocation algorithm (Section 4.5) — the assignment of a
-new note to a channel that already holds active notes of its pitch class — whereas the divergence case (Section 5.2.1)
+note (Sections 6.2.2 and 6.2.3) are associated with Step 3 of the allocation algorithm (Section 5.5) — the assignment of a
+new note to a channel that already holds active notes of its pitch class — whereas the divergence case (Section 6.2.1)
 arises during the lifetime of an already-shared channel rather than at allocation time.
 
-#### 5.2.1 Divergence on a Shared Channel
+#### 6.2.1 Divergence on a Shared Channel
 
 When a channel holds multiple active notes and one of them develops a High Expression Pitch Bend, **all other notes on
 that channel are dropped**. The rationale is that the performer's intent is to bend a single note; the other notes
 sharing the channel would receive an unintended pitch deviation due to the averaged Pitch Bend computation (Section
-4.6), and the note that develops High Expression Pitch Bend will have its final Expression Pitch Bend diluted due to
+5.6), and the note that develops High Expression Pitch Bend will have its final Expression Pitch Bend diluted due to
 averaging.
 
-#### 5.2.2 New Note with High Expression Pitch Bend on an Occupied Channel
+#### 6.2.2 New Note with High Expression Pitch Bend on an Occupied Channel
 
 When a new note with a High Expression Pitch Bend is assigned to an already-occupied channel, **all existing notes on
 that channel are dropped** (the channel is freed). This holds even if the existing notes' Expression Pitch Bend values
 are close to that of the new note, because there is no guarantee that the existing notes' bends will not subsequently
 diverge from the new note's bend, causing unintended intonation changes.
 
-#### 5.2.3 New Note Assigned to a Channel with a High-Bend Note
+#### 6.2.3 New Note Assigned to a Channel with a High-Bend Note
 
 When a new note is assigned to a channel that already contains an active note with a High Expression Pitch Bend, **the
 channel is freed**. The new note then occupies the channel exclusively, preventing its intonation from being compromised
 by the pre-existing high bend.
 
-### 5.3 Summary of Note-Dropping Invariants
+### 6.3 Summary of Note-Dropping Invariants
 
 The following invariants are maintained at all times through the note-dropping mechanisms described above:
 
 1. All active notes on a shared channel have the same pitch class.
 2. An active note with a High Expression Pitch Bend (absolute deviation > `t`) is always the sole active note on its
    channel. No other notes may coexist with it: co-resident notes are dropped when a shared note develops a high bend
-   (Section 5.2.1) or when a new note arrives already carrying one (Section 5.2.2), and a channel holding a high-bend
-   note is freed before any new note is assigned to it (Section 5.2.3).
+   (Section 6.2.1) or when a new note arrives already carrying one (Section 6.2.2), and a channel holding a high-bend
+   note is freed before any new note is assigned to it (Section 6.2.3).
 
 ---
 
-## 6. Expression Value Processing
+## 7. Expression Value Processing
 
 The preceding sections specify where notes are placed; this section specifies how their Expression Values (Section 1.3)
 are combined and maintained on the output Member Channels. The behavior differs between the two input modes, reflecting
 the different sources of expressive information available in each.
 
-### 6.1 Aggregation Model
+### 7.1 Aggregation Model
 
 Each output Member Channel maintains one Expression Value per control dimension. While the channel has at least one
 active note, each of its Expression Values is the **average** of the corresponding Expression Values of its active
-notes (Section 4.6). The Pitch Bend emitted on the channel combines this average with the tuning domain according to
-the formula of Section 4.6. The Channel Pressure and CC #74 dimensions are emitted as plain averages, having no tuning
+notes (Section 5.6). The Pitch Bend emitted on the channel combines this average with the tuning domain according to
+the formula of Section 5.6. The Channel Pressure and CC #74 dimensions are emitted as plain averages, having no tuning
 component.
 
 Upon Note Off, per-note control of the released note ceases: the note is removed from its channel's Expression Value
@@ -631,12 +631,12 @@ Values** rather than resetting them; averaging is defined only while at least on
 serves two purposes. First, it gives every dimension a well-defined value at all times, avoiding the division by zero
 that a literal average over zero notes would entail. Second, it enables an emission optimization: an implementation is
 not required to emit all three control dimensions before a Note On — it may emit only those whose values differ from
-the values the channel already holds (Section 6.1.1).
+the values the channel already holds (Section 7.1.1).
 
 Each time an Expression Value of an output Member Channel changes — whether because a note entered or left the average
 or because a note's contribution was updated — the new value is sent on that channel.
 
-#### 6.1.1 Message Ordering
+#### 7.1.1 Message Ordering
 
 For each new note, the MPE Tuner outputs messages in the following order on the assigned Member Channel:
 
@@ -647,22 +647,22 @@ For each new note, the MPE Tuner outputs messages in the following order on the 
 
 This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has the correct pitch and articulation state before the note begins sounding.
 
-An implementation may omit any of the three control dimension messages whose value is unchanged since its last emission on that output channel, relying on the state retention rule of Section 6.1.
+An implementation may omit any of the three control dimension messages whose value is unchanged since its last emission on that output channel, relying on the state retention rule of Section 7.1.
 
-### 6.2 MPE Input Mode
+### 7.2 MPE Input Mode
 
 In MPE Input Mode, every incoming note carries an Expression Value for each of the three control dimensions, taken from
 the state of its input Member Channel. Since Pitch Bend, Channel Pressure, and CC #74 are channel messages, all notes
 active on the same input channel necessarily share the same Expression Values. Polyphonic Key Pressure is not among the
 control dimensions an input Member Channel may carry — the MPE Specification forbids it there [1, §2.5] — so any
 Polyphonic Key Pressure received on an input Member Channel is discarded and never re-emitted. (Polyphonic Key Pressure
-on a Master Channel is a different case: it is forwarded unmodified as part of Master Channel forwarding, Section 3.5.)
+on a Master Channel is a different case: it is forwarded unmodified as part of Master Channel forwarding, Section 3.4.)
 
-The mapping between input and output channels is not one-to-one. Under the allocation rules of Section 4, notes
+The mapping between input and output channels is not one-to-one. Under the allocation rules of Section 5, notes
 arriving on the same input channel may be assigned to different output channels when their pitch classes differ, and
 notes of the same pitch class arriving on different input channels may be assigned to the same output channel. The
 per-note Expression Values therefore fan out and fan in independently of the input channel structure, and the
-aggregation model of Section 6.1 combines them per output channel: each Expression Value of an output channel is the
+aggregation model of Section 7.1 combines them per output channel: each Expression Value of an output channel is the
 average of its incoming notes' values for that dimension, and the final Pitch Bend adds the channel's Tuning Pitch Bend
 to the averaged Expression Pitch Bend.
 
@@ -677,27 +677,27 @@ note is playing, to provide an initial state for a new note" [1, §3.3].
 Tuner updates the contribution of each of those notes to the average of its assigned output channel. Every output
 channel whose averaged Expression Value changes as a result receives the updated value immediately.
 
-### 6.3 Non-MPE Input Mode
+### 7.3 Non-MPE Input Mode
 
 In Non-MPE Input Mode, only the Pitch Bend and Channel Pressure control dimensions are used on output Member Channels,
 and of these, only Channel Pressure operates as an Expression Value:
 
 - **Pitch Bend** on a Member Channel serves tuning exclusively: it consists of the Tuning Pitch Bend alone, with no
   per-channel Expression Pitch Bend component. Pitch Bend received on an input channel is expressive in intent but
-  global in scope, and is therefore forwarded to the Master Channel (Section 3.4), where it applies to all channels of
+  global in scope, and is therefore forwarded to the Master Channel (Section 3.3), where it applies to all channels of
   the Zone.
 - **Channel Pressure** on a Member Channel is the sole per-note Expression Value available in this mode. It always
-  originates from a converted Polyphonic Key Pressure message (Section 3.4). Channel Pressure received on an input
+  originates from a converted Polyphonic Key Pressure message (Section 3.3). Channel Pressure received on an input
   channel is channel-global in meaning and is always forwarded to the Master Channel.
 - **CC #74** never appears on an output Member Channel. If received on an input channel, it is forwarded on the output
-  Master Channel; the dimension is thus controllable only globally (Section 3.4, item 3).
+  Master Channel; the dimension is thus controllable only globally (Section 3.3, item 3).
 
 A Polyphonic Key Pressure message received on an input channel is assumed to apply to an active note. If it addresses a
 note number for which no Note On was issued on that input channel, it is ignored. Consequently, a note's Polyphonic Key
 Pressure value is always 0 at the time its Note On is issued.
 
 When multiple notes are active on an output Member Channel, their Channel Pressure Expression Values are averaged
-exactly as in MPE Input Mode. The retention rule of Section 6.1 nominally applies when the channel empties, but —
+exactly as in MPE Input Mode. The retention rule of Section 7.1 nominally applies when the channel empties, but —
 unlike in MPE Input Mode — the retained value can have no observable effect on a subsequent note: because per-note
 Channel Pressure originates from Polyphonic Key Pressure, which is always 0 at Note On, the channel's Channel Pressure
 must be reset to 0 by the time of the next Note On.
@@ -706,28 +706,28 @@ must be reset to 0 by the time of the next Note On.
 Tuner updates that note's contribution to the Channel Pressure average of its output channel. As in MPE Input Mode,
 every output channel whose average changes receives the updated value immediately.
 
-### 6.4 Channel Pressure Reset at Note Off
+### 7.4 Channel Pressure Reset at Note Off
 
 At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4].
 
-- In **MPE Input Mode** the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 6.2, and if the sender emits none, neither does the Tuner.
-- In **Non-MPE Input Mode** the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 6.3 requires.
+- In **MPE Input Mode** the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 7.2, and if the sender emits none, neither does the Tuner.
+- In **Non-MPE Input Mode** the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.3); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 7.3 requires.
 
 Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
 
 ---
 
-## 7. Real-Time Tuning Changes
+## 8. Real-Time Tuning Changes
 
 A distinguishing feature of the MPE Tuner is its support for real-time tuning changes during performance. This capability is essential for tuning systems that employ more than twelve pitches per octave, where the performer must switch tunings to access different subsets of the available pitch inventory.
 
 When the performer changes the active Tuning:
 
 1. The Tuner updates the stored tuning offsets for each pitch class.
-2. For every occupied Member Channel, the output Pitch Bend is recomputed as the sum of the new Tuning Pitch Bend for that channel's pitch class and the channel's current Expression Pitch Bend — the average of its active notes' Expression Pitch Bends (Section 6).
+2. For every occupied Member Channel, the output Pitch Bend is recomputed as the sum of the new Tuning Pitch Bend for that channel's pitch class and the channel's current Expression Pitch Bend — the average of its active notes' Expression Pitch Bends (Section 7).
 3. The updated Pitch Bend message is sent immediately on each affected Member Channel.
 
-Because the pitch-class invariant (Section 4.1) guarantees that all notes on a given channel share the same pitch class, a single Pitch Bend update per channel is sufficient to retune all notes on that channel simultaneously.
+Because the pitch-class invariant (Section 5.1) guarantees that all notes on a given channel share the same pitch class, a single Pitch Bend update per channel is sufficient to retune all notes on that channel simultaneously.
 
 If the invariant were violated — if notes of different pitch classes shared a channel — a tuning change that assigned different offsets to those pitch classes could not be correctly represented by a single Pitch Bend value, and at least one note would be mistuned until it was moved to a different channel.
 
@@ -735,7 +735,7 @@ If the invariant were violated — if notes of different pitch classes shared a 
 
 ## 9. Worked Examples
 
-The examples in this section assume Non-MPE Input Mode, so tie-breaking criterion (e) of Section 4.5 resolves to the lowest-numbered candidate channel.
+The examples in this section assume Non-MPE Input Mode, so tie-breaking criterion (e) of Section 5.5 resolves to the lowest-numbered candidate channel.
 
 ### 9.1 Basic Allocation in Quarter-Comma Meantone
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -306,6 +306,8 @@ all notes received in Non-MPE Input Mode, and all notes received on a Member Cha
 on a Master Channel in MPE Input Mode are forwarded as-is under the rules of Section 3.5 and are not subject to the
 allocation procedure described below.
 
+Throughout this paper, a Note On with velocity 0 is treated as a Note Off [1, §3.3.2].
+
 ### 4.1 Fundamental Invariant
 
 The following invariant governs all channel allocation decisions:
@@ -326,7 +328,8 @@ For each Zone, the available Member Channels are logically partitioned into two 
 
 Unoccupied Member Channels are not considered to be part of any group. Group assignment occurs dynamically: any
 unoccupied channel may be assigned to either group as notes are allocated. The group assignment of a channel is
-determined at the moment a note is placed on it and persists for the lifetime of that channel's occupancy.
+determined at the moment a note is placed on it and persists for the lifetime of that channel's occupancy. The
+channel becomes available for reuse once all its notes have received Note Off messages.
 
 ### 4.3 Group Size Allocation
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -57,7 +57,7 @@ The MPE Tuner sits in the MIDI signal path between a controller (or sequencer) a
 3. Computes the appropriate Pitch Bend value for each Member Channel as the sum of the Tuning Pitch Bend for the channel's pitch class and the Expression Pitch Bend derived from the input (Section 1.3); in Non-MPE Input Mode the Expression component is absent (Section 3.4).
 4. Outputs a fully MPE-conformant MIDI stream.
 
-The output of the MPE Tuner is always MPE, regardless of whether the input is MPE or non-MPE. The input mode may be configured through a non-MIDI interface or detected automatically: upon receiving an MPE Configuration Message (MCM), the MPE Tuner shall switch to MPE Input Mode and reconfigure its Zones accordingly (Section 3.3).
+The output of the MPE Tuner is always MPE, regardless of whether the input is MPE or non-MPE. The input mode may be configured through a non-MIDI interface or detected automatically: upon receiving an MPE Configuration Message (MCM), the MPE Tuner shall switch to MPE Input Mode and reconfigure its Zones accordingly (Section C).
 
 ---
 
@@ -143,7 +143,7 @@ flowchart LR
     D --> E["MIDI Output"]
 ```
 
-1. **Input Mode Detection**: Determines whether the incoming stream is MPE or non-MPE. The mode may be set via a non-MIDI configuration interface. Receipt of an MCM shall cause the Tuner to switch to MPE Input Mode automatically and to reconfigure its Zones according to the message (Section 3.3).
+1. **Input Mode Detection**: Determines whether the incoming stream is MPE or non-MPE. The mode may be set via a non-MIDI configuration interface. Receipt of an MCM shall cause the Tuner to switch to MPE Input Mode automatically and to reconfigure its Zones according to the message (Section C).
 
 2. **Channel Allocation**: Assigns each incoming note that arrives on a Member Channel (in MPE Input Mode) or on any
    channel (in Non-MPE Input Mode) to a Member Channel in the output Zone(s), following the dual-group allocation
@@ -163,23 +163,12 @@ flowchart LR
 
 The MPE Tuner accepts two classes of input:
 
-- **Non-MPE input**: Conventional MIDI where all notes may arrive on a single channel or across channels without MPE Zone structure. This input requires conversion to MPE (Section 3.4) and is routed to a single output Zone (Section 3.3). In this mode the Zone configuration originates solely from the non-MIDI configuration interface (Section 3.3).
+- **Non-MPE input**: Conventional MIDI where all notes may arrive on a single channel or across channels without MPE Zone structure. This input requires conversion to MPE (Section 3.4) and is routed to a single output Zone (Section C.2). In this mode the Zone configuration originates solely from the non-MIDI configuration interface (Section C.2).
 - **MPE input**: MIDI conforming to the MPE Specification, with notes primarily distributed across Member Channels
   within Zones, and optionally on Master Channels as permitted by the specification (see Section 3.5). The input stream
-  may contain MPE Configuration Messages, which reconfigure the Tuner's Zones (Section 3.3).
+  may contain MPE Configuration Messages, which reconfigure the Tuner's Zones (Section C.2).
 
 In both cases, the output is always MPE-conformant.
-
-### 3.3 Zones
-
-The MPE Tuner has one Zone configuration, shared by its input and its output: the number of Member Channels allocated to the Lower Zone and, optionally, to the Upper Zone. As in the MPE Specification, one or two Zones may be defined. The role this shared configuration plays depends on the input mode:
-
-- In **MPE Input Mode**, the Zone configuration applies to both input and output: the Tuner expects the input stream to be organized according to the configured Zones, and produces output organized by the same Zones. Notes received on the Member Channels of an input Zone are allocated to Member Channels of the same output Zone.
-- In **Non-MPE Input Mode**, the input has no Zone structure, so the Zone configuration affects the output only. Furthermore, only one Zone is accessible from the output: input notes are routed exclusively to the Lower Zone if it is enabled, otherwise to the Upper Zone. When two Zones are defined, the Upper Zone is ignored. This restriction prevents ambiguity in channel allocation and zone-level message routing when the input carries no Zone information of its own.
-
-The Zone configuration may be established and changed in two ways: through the non-MIDI configuration interface, or in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. Upon receiving a valid MCM, the Tuner switches to MPE Input Mode if it is not already in it (Section 3.1) and reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1]. When MCMs deactivate all Zones, MPE operation is off [1, §2.1]; the Tuner then reverts to Non-MPE Input Mode, restoring the output Zone configuration provided through the configuration interface.
-
-Whenever the Zone configuration changes — through either mechanism — the Tuner emits the corresponding MCM(s) on its output, so that the receiving instrument adopts the same Zone structure (Section 8). The reconfiguration also resets the Tuner's state for every channel entering or leaving MPE control, mirroring the receiver obligations of the MPE Specification [1, §2.1.4]: active notes on the affected channels are dropped, the channels' group assignments (Section 4.2) are cleared, and the retained Expression Values and remembered input-channel control values (Section 6) return to their defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64. Channels of a Zone untouched by the reconfiguration keep their notes and state. For the dropped notes, an implementation may either emit no Note Off messages — relying on the downstream receiver's obligation to stop ongoing notes upon receiving the MCM [1, §2.1.4] — or emit explicit Note Off messages before the MCM, for robustness with receivers that do not fully conform; the choice is left to the implementer.
 
 ### 3.4 Non-MPE to MPE Conversion
 
@@ -193,7 +182,7 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
 
 2. **Channel-Global Control Redirection to Master Channel**: In non-MPE input, Pitch Bend, CC #74, and Channel Pressure
    each apply to all notes on the input channel rather than to an individual note. These channel-global controls shall
-   be redirected to the Master Channel of the single output Zone selected for non-MPE input (see Section 3.3), where
+   be redirected to the Master Channel of the single output Zone selected for non-MPE input (see Section C.2), where
    they serve as Zone-level controls affecting all notes equally. Consequently, none of these three dimensions carries
    a per-note value onto a Member Channel. When the input spans multiple channels, the redirected controls of all input
    channels merge onto the single Master Channel, the most recent message taking effect: the Tuner treats non-MPE input
@@ -224,7 +213,7 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
    Section 8.2's forwarding could operate; this redirection gives those messages their conformant Zone-level home on
    the output. A Pitch Bend Sensitivity message (RPN 00 00) received on the non-MPE input is likewise forwarded to the
    Master Channel, where it configures the sensitivity of the Master Channel Pitch Bend to which the input's Pitch Bend
-   is redirected (Section 8).
+   is redirected (Section C.3).
 
 ### 3.5 Master Channel Note Forwarding
 
@@ -263,6 +252,48 @@ threefold:
 
 In Non-MPE Input Mode the concept of a Master Channel does not apply to the input: every incoming note is allocated to a
 Member Channel regardless of the input channel number.
+
+---
+
+## C. Configuration
+
+The MPE Tuner's operation is governed by three configuration parameters, established before any note flows and applying across every stage of the pipeline: the input mode (Section C.1), the Zone configuration (Section C.2), and the Pitch Bend Sensitivity (Section C.3). All three follow the same model: the parameter is established through a **non-MIDI configuration interface**, and may additionally be overridden in-band, through MIDI messages received on the input — MCMs for the input mode and the Zones, and Pitch Bend Sensitivity messages (RPN 00 00) for the Pitch Bend Sensitivity — subject to the per-parameter limitations stated in the subsections below. Where the MPE Specification defines defaults, notably the Pitch Bend Sensitivity values of Section 2.3, the Tuner adopts them in the absence of explicit configuration.
+
+### C.1 Input Mode
+
+Section 3.2 defines the two input modes; this subsection specifies how the operating mode is selected. The input mode may be set through the non-MIDI configuration interface, or switched in-band by the input stream itself (Section 3.1): upon receiving a valid MCM, the Tuner switches to MPE Input Mode if it is not already in it. The in-band switch is one-way: no MCM returns the Tuner to Non-MPE Input Mode, which is re-entered only through the non-MIDI configuration interface.
+
+MCMs that deactivate all Zones are no exception: they too switch the Tuner to MPE Input Mode if necessary, and they turn MPE operation off [1, §2.1]. The Zone configuration is shared by the input and the output (Section C.2), so all Zones being deactivated leaves the output without MPE as well; the deactivation is mirrored on the output like any other Zone change (Section C.2), and the Tuner produces no note output until a Zone is re-activated, by a subsequent MCM or through the non-MIDI configuration interface.
+
+### C.2 Zones
+
+The MPE Tuner maintains a single Zone configuration shared by its input and its output — not separate input and output configurations: the number of Member Channels allocated to the Lower Zone and, optionally, to the Upper Zone. As in the MPE Specification, one or two Zones may be defined. The role this shared configuration plays depends on the input mode:
+
+- In **MPE Input Mode**, the Zone configuration applies to both input and output: the Tuner expects the input stream to be organized according to the configured Zones, and produces output organized by the same Zones. Notes received on the Member Channels of an input Zone are allocated to Member Channels of the same output Zone.
+- In **Non-MPE Input Mode**, the input has no Zone structure, so the Zone configuration affects the output only. Furthermore, only one Zone is accessible from the output: input notes are routed exclusively to the Lower Zone if it is enabled, otherwise to the Upper Zone. When two Zones are defined, the Upper Zone is ignored. This restriction prevents ambiguity in channel allocation and zone-level message routing when the input carries no Zone information of its own.
+
+Beyond the non-MIDI configuration interface, the Zone configuration may be changed in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. A valid MCM — which also switches the Tuner to MPE Input Mode if it is not already in it (Section C.1) — reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1]. An MCM that deactivates all Zones suspends MPE operation altogether (Section C.1).
+
+The Tuner emits the MCM(s) describing its Zone configuration at start-up, and again whenever the configuration changes — through either mechanism — so that the receiving instrument adopts the same Zone structure. A reconfiguration also resets the Tuner's state for every channel entering or leaving MPE control, mirroring the receiver obligations of the MPE Specification [1, §2.1.4]: active notes on the affected channels are dropped, the channels' group assignments (Section 4.2) are cleared, the retained Expression Values and remembered input-channel control values (Section 6) return to their defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64 — and Pitch Bend Sensitivity returns to the specification's defaults of ±48 semitones on Member Channels and ±2 semitones on the Master Channel (Section C.3). Channels of a Zone untouched by the reconfiguration keep their notes and state. For the dropped notes, an implementation may either emit no Note Off messages — relying on the downstream receiver's obligation to stop ongoing notes upon receiving the MCM [1, §2.1.4] — or emit explicit Note Off messages before the MCM, for robustness with receivers that do not fully conform; the choice is left to the implementer.
+
+### C.3 Pitch Bend Sensitivity
+
+The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The MPE Tuner relies on these defaults both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output.
+
+The Tuner also listens for Pitch Bend Sensitivity messages (RPN 00 00) on its input and conforms to them when interpreting incoming Pitch Bend. How a received message propagates to the output depends on the input mode:
+
+- **MPE Input Mode**: a sensitivity received on any input Member Channel applies Zone-wide, since "[a] receiver must
+  apply the last Pitch Bend Sensitivity message received on any Member Channel to all Member Channels in the Zone"
+  [1, §2.4]. On output, the Tuner mirrors the input, forwarding each received message on its corresponding output
+  Member Channel. It does *not* replicate every received message across all Member Channels. A conforming MPE sender
+  already addresses the message to each of the `n` Member Channels [1, §2.4], so re-fanning those `n` messages to
+  all `n` channels would produce an `n²` flood. Because the Tuner both receives and sends MPE, per-channel
+  forwarding already configures every output Member Channel.
+- **Non-MPE Input Mode**: the input carries no Member Channels. Because a Member Channel's Pitch Bend then carries
+  only the Tuning Pitch Bend, a Pitch Bend Sensitivity message received on the input applies to the output Master
+  Channel, consistent with the redirection of the input's Pitch Bend to that channel (Section 3.4). The output
+  Member Channels retain the specification's default of ±48 semitones, which can be changed only through the
+  non-MIDI configuration interface.
 
 ---
 
@@ -490,7 +521,7 @@ When all Member Channels are occupied and the Pitch Class Group does not have en
 classes present among the active notes, some notes must be dropped to free a channel for the incoming note. The term
 **freeing a channel** refers to dropping all notes on that channel to make it unoccupied. When a channel is freed, the
 Tuner emits an explicit Note Off message for each of its dropped notes, before the incoming note's Note On. (Note Off
-emission upon Zone reconfiguration is a distinct case, governed by Section 3.3.)
+emission upon Zone reconfiguration is a distinct case, governed by Section C.2.)
 
 The selection of which channel to free follows this procedure:
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -252,9 +252,8 @@ encode a tuning offset for a specific pitch class without mistuning every other 
 The rationale for preserving sender intent rather than silently reallocating Master Channel notes to Member Channels is
 threefold:
 
-1. **Compliance with the MPE Specification.** Section 3.2 of the MPE Specification explicitly permits Master Channel
-   notes and requires that receivers play them. Silently relocating them would violate the sender's explicit channel
-   assignment.
+1. **Compliance with the MPE Specification.** The specification explicitly permits Master Channel notes and requires
+   that receivers play them [1, §3.2]. Silently relocating them would violate the sender's explicit channel assignment.
 2. **Conservation of Member Channel resources.** Master Channel notes are, by design, notes that do not require per-note
    control. Placing them on a Member Channel would consume a slot unnecessarily, reducing the Zone's effective polyphony
    for notes that do require per-note control.
@@ -712,7 +711,7 @@ Upon Note Off, per-note control of the released note ceases: the note is removed
 
 A Note On with velocity 0 in the input is treated as a Note Off, following the MIDI 1.0 shorthand and the specification's recommendation "that this message be interpreted as Note Off velocity 64" [1, §3.3.2]. Recognizing the shorthand is essential: occupancy tracking, Expression Value averaging, and channel reuse all depend on detecting note releases.
 
-At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4]. In MPE Input Mode the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 6.2, and if the sender emits none, neither does the Tuner. In Non-MPE Input Mode the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to which §3.3.4 applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 6.3 requires. Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
+At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4]. In MPE Input Mode the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 6.2, and if the sender emits none, neither does the Tuner. In Non-MPE Input Mode the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 6.3 requires. Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
 
 ---
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -209,13 +209,13 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
 4. **Redirection of Remaining Channel Messages**: All other Channel Voice and Channel Mode messages received on a
    non-MPE input channel — for example Damper Pedal (CC #64), Modulation (CC #1), Volume (CC #7), Program Change and
    Bank Select, and Reset All Controllers (CC #121) — are redirected to the Master Channel of the selected output Zone,
-   where they act as Zone-level messages (Section 8.2). Non-MPE input has no Master Channel of its own from which
-   Section 8.2's forwarding could operate; this redirection gives those messages their conformant Zone-level home on
+   where they act as Zone-level messages (Section 3.5). Non-MPE input has no Master Channel of its own from which
+   Section 3.5's forwarding could operate; this redirection gives those messages their conformant Zone-level home on
    the output. A Pitch Bend Sensitivity message (RPN 00 00) received on the non-MPE input is likewise forwarded to the
    Master Channel, where it configures the sensitivity of the Master Channel Pitch Bend to which the input's Pitch Bend
    is redirected (Section C.3).
 
-### 3.5 Master Channel Note Forwarding
+### 3.5 Master Channel Forwarding
 
 The MPE Specification permits Note On and Note Off messages on a Master Channel, and requires receivers to respond to
 them [1, §3.2]. Placing a note on the Master Channel is a deliberate choice by the MPE sender: the sender opts out of the
@@ -250,8 +250,15 @@ threefold:
    Pressure on Member Channels but allows it on Master Channel notes. Forwarding Master Channel notes as-is preserves
    the ability to use Polyphonic Key Pressure on those notes.
 
-In Non-MPE Input Mode the concept of a Master Channel does not apply to the input: every incoming note is allocated to a
-Member Channel regardless of the input channel number.
+The forwarding rule extends beyond notes. The MPE Tuner forwards Master Channel Pitch Bend as received, without
+modification; Master Pitch Bend is a Zone-level expressive control, and Section 4.7.5 discusses its relationship to
+tuning. Zone-level messages — Damper Pedal, Program Change, Reset All Controllers, and the other messages listed in
+Table 1 of the MPE Specification (Section 2.6) — are likewise forwarded on the Master Channel without modification.
+The MPE Tuner does not interpret or alter any of these messages.
+
+In Non-MPE Input Mode there is no input Master Channel to forward from: every incoming note is allocated to a Member
+Channel regardless of the input channel number, and the input's channel-global controls and Zone-level messages reach
+the output Master Channel by *redirection* instead, under the conversion rules of Section 3.4, items 2 and 4.
 
 ---
 
@@ -505,7 +512,7 @@ The MPE Specification requires:
 
 > "If an MPE synthesizer receives Pitch Bend (for example) on both a Master and a Member Channel, it must combine the data meaningfully." [1, §2.3.2]
 
-The MPE Tuner forwards Master Channel Pitch Bend as received, without modification. Master Pitch Bend is not used by the Tuner in computing tuning offsets; it is a Zone-level expressive control, belonging entirely to the performer. The Tuner's tuning offsets are applied exclusively through the Tuning Pitch Bend component of Member Channel Pitch Bend.
+Master Channel Pitch Bend is forwarded without modification, as part of Master Channel forwarding (Section 3.5). It is not used by the Tuner in computing tuning offsets; it is a Zone-level expressive control, belonging entirely to the performer. The Tuner's tuning offsets are applied exclusively through the Tuning Pitch Bend component of Member Channel Pitch Bend.
 
 ---
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -59,6 +59,8 @@ The MPE Tuner sits in the MIDI signal path between a controller (or sequencer) a
 
 The output of the MPE Tuner is always MPE, regardless of whether the input is MPE or non-MPE. The input mode may be configured through a non-MIDI interface or detected automatically: upon receiving an MPE Configuration Message (MCM), the MPE Tuner shall switch to MPE Input Mode and reconfigure its Zones accordingly (Section C).
 
+The obligations of output conformance to the MPE Specification are specified where they arise: configuration of Zones and Pitch Bend Sensitivity in Section C, Note On message ordering in Section 6.1.1, Master Channel forwarding in Section 3.5, Note Off behavior in Section 6.1, and the Channel Pressure reset at Note Off in Section 6.4.
+
 ---
 
 ## 2. Background: The MPE Specification
@@ -204,7 +206,7 @@ When the input is non-MPE, the MPE Tuner must perform the following conversions 
       pressure on a key that is already held.
     - **CC #74**: not emitted on Member Channels. In Non-MPE Input Mode there is no source of per-note CC #74 — the
       dimension is controllable only globally, via the Master Channel (item 2) — so the Tuner never sends CC #74 on a
-      Member Channel (Sections 6.3 and 8.1).
+      Member Channel (Section 6.3).
 
 4. **Redirection of Remaining Channel Messages**: All other Channel Voice and Channel Mode messages received on a
    non-MPE input channel — for example Damper Pedal (CC #64), Modulation (CC #1), Volume (CC #7), Program Change and
@@ -728,57 +730,6 @@ When the performer changes the active Tuning:
 Because the pitch-class invariant (Section 4.1) guarantees that all notes on a given channel share the same pitch class, a single Pitch Bend update per channel is sufficient to retune all notes on that channel simultaneously.
 
 If the invariant were violated — if notes of different pitch classes shared a channel — a tuning change that assigned different offsets to those pitch classes could not be correctly represented by a single Pitch Bend value, and at least one note would be mistuned until it was moved to a different channel.
-
----
-
-## 8. MPE Tuner Output Conformance
-
-The output of the MPE Tuner conforms to the MPE Specification. The following features behave exactly as the MPE Specification defines them, with no Tuner-specific behavior:
-
-- **Zone Configuration**: the MPE Tuner outputs MPE Configuration Messages to establish the Zone structure on the receiving instrument, supporting both single-Zone and dual-Zone configurations [1, §2.1], emitting them at start-up and on every Zone reconfiguration (Section 3.3). It likewise listens for MCMs on its input and conforms to them, reconfiguring its own Zones as specified in Section 3.3; in this case it also configures the Zones of the output instrument by forwarding that configuration.
-- **Pitch Bend Sensitivity**: the MPE Tuner relies on the default Pitch Bend Sensitivity values that the MCM
-  establishes — ±48 semitones for Member Channels and ±2 semitones for the Master Channel [1, §2.4]. It also listens
-  for Pitch Bend Sensitivity messages (RPN 00 00) on its input and conforms to them when interpreting incoming Pitch
-  Bend. How a received message propagates to the output depends on the input mode:
-    - **MPE Input Mode**: a sensitivity received on any input Member Channel applies Zone-wide, since "[a] receiver must
-      apply the last Pitch Bend Sensitivity message received on any Member Channel to all Member Channels in the Zone"
-      [1, §2.4]. On output, the Tuner mirrors the input, forwarding each received message on its corresponding output
-      Member Channel. It does *not* replicate every received message across all Member Channels. A conforming MPE sender
-      already addresses the message to each of the `n` Member Channels [1, §2.4], so re-fanning those `n` messages to
-      all `n` channels would produce an `n²` flood. Because the Tuner both receives and sends MPE, per-channel
-      forwarding already configures every output Member Channel.
-    - **Non-MPE Input Mode**: the input carries no Member Channels. Because a Member Channel's Pitch Bend then carries
-      only the Tuning Pitch Bend, a Pitch Bend Sensitivity message received on the input applies to the output Master
-      Channel, consistent with the redirection of the input's Pitch Bend to that channel (Section 3.4). The output
-      Member Channels retain the MCM's default of ±48 semitones, which can be changed only through the non-MIDI
-      configuration interface.
-
-The subsections below specify the behaviors where the MPE Tuner adds detail beyond the specification.
-
-### 8.1 Message Ordering
-
-For each new note, the MPE Tuner outputs messages in the following order on the assigned Member Channel:
-
-1. **Pitch Bend**: encoding the sum of the Tuning Pitch Bend and the initial averaged Expression Pitch Bend.
-2. **CC #74**: the timbre Expression Value.
-3. **Channel Pressure**: the Channel Pressure Expression Value.
-4. **Note On**: the note message itself.
-
-This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has the correct pitch and articulation state before the note begins sounding.
-
-An implementation may omit any of the three control dimension messages whose value is unchanged since its last emission on that output channel, relying on the state retention of Section 6.1. In particular, in Non-MPE Input Mode CC #74 is never emitted on a Member Channel: the dimension cannot be controlled per note in that mode and is available only globally, on the Master Channel (Section 6.3).
-
-### 8.2 Zone-Level Messages
-
-Zone-level messages (Damper Pedal, Program Change, Reset All Controllers, and other messages listed in Table 1 of the MPE Specification) are forwarded on the Master Channel without modification. The MPE Tuner does not interpret or alter these messages.
-
-### 8.3 Note Off Behavior
-
-Upon Note Off, per-note control of the released note ceases: the note is removed from its channel's Expression Value averages (Section 6.1), consistent with the specification's statement that "control of a note ceases once Note Off has occurred" [1, §3.3.3]. While other notes remain active on the channel, the Tuner continues to update the channel's Pitch Bend — for tuning changes (Section 7) as well as for Expression Value changes (Section 6). The channel becomes available for reuse once all its notes have received Note Off messages.
-
-A Note On with velocity 0 in the input is treated as a Note Off, following the MIDI 1.0 shorthand and the specification's recommendation "that this message be interpreted as Note Off velocity 64" [1, §3.3.2]. Recognizing the shorthand is essential: occupancy tracking, Expression Value averaging, and channel reuse all depend on detecting note releases.
-
-At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4]. In MPE Input Mode the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 6.2, and if the sender emits none, neither does the Tuner. In Non-MPE Input Mode the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 6.3 requires. Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
 
 ---
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -620,15 +620,32 @@ notes (Section 4.6). The Pitch Bend emitted on the channel combines this average
 the formula of Section 4.6. The Channel Pressure and CC #74 dimensions are emitted as plain averages, having no tuning
 component.
 
+Upon Note Off, per-note control of the released note ceases: the note is removed from its channel's Expression Value
+averages, consistent with the specification's statement that "control of a note ceases once Note Off has occurred"
+[1, §3.3.3].
+
 When the last active note on an output Member Channel is released, the channel **preserves its latest Expression
 Values** rather than resetting them; averaging is defined only while at least one note is active. This retention rule
 serves two purposes. First, it gives every dimension a well-defined value at all times, avoiding the division by zero
 that a literal average over zero notes would entail. Second, it enables an emission optimization: an implementation is
 not required to emit all three control dimensions before a Note On — it may emit only those whose values differ from
-the values the channel already holds (Section 8.1).
+the values the channel already holds (Section 6.1.1).
 
 Each time an Expression Value of an output Member Channel changes — whether because a note entered or left the average
 or because a note's contribution was updated — the new value is sent on that channel.
+
+#### 6.1.1 Message Ordering
+
+For each new note, the MPE Tuner outputs messages in the following order on the assigned Member Channel:
+
+1. **Pitch Bend**: encoding the sum of the Tuning Pitch Bend and the initial averaged Expression Pitch Bend.
+2. **CC #74**: the timbre Expression Value.
+3. **Channel Pressure**: the Channel Pressure Expression Value.
+4. **Note On**: the note message itself.
+
+This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has the correct pitch and articulation state before the note begins sounding.
+
+An implementation may omit any of the three control dimension messages whose value is unchanged since its last emission on that output channel, relying on the state retention rule of Section 6.1.
 
 ### 6.2 MPE Input Mode
 
@@ -671,7 +688,7 @@ and of these, only Channel Pressure operates as an Expression Value:
   originates from a converted Polyphonic Key Pressure message (Section 3.4). Channel Pressure received on an input
   channel is channel-global in meaning and is always forwarded to the Master Channel.
 - **CC #74** never appears on an output Member Channel. If received on an input channel, it is forwarded on the output
-  Master Channel; the dimension is thus controllable only globally (Section 8.1).
+  Master Channel; the dimension is thus controllable only globally (Section 3.4, item 3).
 
 A Polyphonic Key Pressure message received on an input channel is assumed to apply to an active note. If it addresses a
 note number for which no Note On was issued on that input channel, it is ignored. Consequently, a note's Polyphonic Key
@@ -686,6 +703,15 @@ must be reset to 0 by the time of the next Note On.
 **Update propagation.** When a Polyphonic Key Pressure update is received on an input channel for an active note, the
 Tuner updates that note's contribution to the Channel Pressure average of its output channel. As in MPE Input Mode,
 every output channel whose average changes receives the updated value immediately.
+
+### 6.4 Channel Pressure Reset at Note Off
+
+At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4].
+
+- In **MPE Input Mode** the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 6.2, and if the sender emits none, neither does the Tuner.
+- In **Non-MPE Input Mode** the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 6.3 requires.
+
+Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
 
 ---
 

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md
@@ -1,23 +1,48 @@
-# Report: Dissolving Section 8 "MPE Tuner Output Conformance"
+# Design: MPE Tuner Paper Reorg — Extract Configuration to a Dedicated Section, Dissolve Section 8
 
 **Target document:** `docs/architecture/tuner/mpe-tuner-paper.md`
 
-**Citations pinned at:** commit `44b7030` (`[#154] Apply paper review fixes (M1-M3, S1-S6) to MPE Tuner
-paper (#240)`) — the last commit that touched the paper. Report written with `HEAD` at `fa4e5d6`, working
-tree clean for the paper.
+**Citations pinned at:** commit `44730ba` (`[#154] Apply paper review fixes (P1-P13, N1-N16) to MPE Tuner
+paper (#241)`) — the newest `main` commit that touched the paper, merged into this branch so the working-tree
+paper matches. (The branch's merge-base `fa4e5d6` did not touch the paper — it changed only
+`paper-review-plan.md` — so `44730ba`, one commit further along `main`, is the meaningful pin.)
 
-**Purpose:** input for a future prompt that performs the reorganization. This report records *what moves
-where and why*; it is not itself the edit.
+**Purpose:** this document specifies the target design of the reorganization — *what moves where and why*. It
+is the design input from which an implementation plan (out of scope for this document) and the edit will be
+generated; it is not itself the edit.
 
 **Referencing convention:** sections are identified by **number and name**. If numbering has drifted since
-`44b7030`, the name is authoritative. Quoted paper text is verbatim at `44b7030` and can be located by
-searching for the quote. No line numbers are used anywhere in this report, by design.
+`44730ba`, the name is authoritative. Quoted paper text is verbatim at `44730ba` and can be located by
+searching for the quote. No line numbers are used anywhere in this document, by design.
+
+**Numbering convention in this document.** This reorg makes two structural changes: it **extracts
+Configuration into a new, dedicated Section 4** (Work item 1) and **dissolves Section 8** (Work items 2–6).
+Both shift the numbers of the sections between them. To stay aligned with the paper the executing prompt
+reads, section numbers below are **current (`44730ba`)** — with one exception: the **new Configuration
+section**, referred to by name and numbered **4** (subsections **4.1 Input Mode / 4.2 Zones / 4.3 Pitch Bend
+Sensitivity**). The resulting global renumber is defined once, authoritatively, under
+[Numbering after the reorg](#numbering-after-the-reorg), and applied as a final step. Keep the clash
+straight: the **new Section 4 is Configuration**, while the **old Section 4 (Allocation) becomes Section 5**.
+On any conflict between a number and a section name, the **name wins**.
 
 ---
 
-## Verdict
+## Design overview
 
-Section 8 ("MPE Tuner Output Conformance") is **dissolved entirely**. Sections 9 and 10 renumber to 8 and 9.
+This reorg makes **two structural changes**.
+
+**1 — Extract Configuration into a new, dedicated Section 4.** Input Mode, Zones, and Pitch Bend Sensitivity
+are gathered under a new Section 4 ("Configuration"), placed after Section 3 ("MPE Tuner Architecture") and
+before Allocation. The paper is otherwise sectioned by **pipeline stage** (input → allocation →
+tuning/expression → output), but configuration is not a pipeline stage: these parameters are established
+*before any note flows* and govern the whole pipeline. A config-time concern does not sit on the
+pipeline-stage axis, so it earns its own section rather than a subsection of Architecture — which also gives
+the substantive Pitch Bend Sensitivity material proper room.
+
+**2 — Dissolve Section 8 ("MPE Tuner Output Conformance") entirely.** Its facts relocate to their
+pipeline-stage homes, and old Sections 4–7 shift up by one. Because Section 4 is inserted above where
+Section 8 is removed, **Worked Examples and Summary keep their numbers (9 and 10)** (see
+[Numbering after the reorg](#numbering-after-the-reorg)).
 
 The section is not wrong to exist so much as wrong about what it contains. It tries to be two things at
 once: an *output message contract* and a *conformance checklist against RP-053*. The checklist job is what
@@ -34,30 +59,89 @@ listed with a destination or a justification for deletion.
 
 ## Target structure
 
-| Current | Becomes |
+Content changes by location. Section numbers are **current (`44730ba`)** except the new Configuration
+section; the resulting renumber is in [Numbering after the reorg](#numbering-after-the-reorg).
+
+| Location | Change |
 |---|---|
 | 3.2 Input Modes | unchanged (taxonomy of the two modes) |
-| 3.3 **Zones** | 3.3 **Configuration** — with 3.3.1 Input Mode, 3.3.2 Zones, 3.3.3 Pitch Bend Sensitivity |
-| 3.4 Non-MPE to MPE Conversion | unchanged in scope; cross-refs repointed |
-| 3.5 **Master Channel Note Forwarding** | 3.5 **Master Channel Forwarding** — notes, Pitch Bend, Zone-level controls |
-| 4 preamble | gains the velocity-0 convention |
-| 4.2 Dual-Group Channel Partitioning | gains the channel-reuse rule |
-| 4.7.5 Master Channel Pitch Bend | keeps its argument; forwarding mechanic moves to 3.5 |
-| 6.1 Aggregation Model | gains Note Off removal + `[1, §3.3.3]`; new **6.1.1 Message Ordering** |
-| **8 MPE Tuner Output Conformance** | **removed** |
-| 9 Worked Examples | 8 |
-| 10 Summary | 9 |
+| 3.3 **Zones** | **extracted** into the new Configuration section (Work item 1) |
+| **Configuration** — *new section (4)* | preamble + **4.1 Input Mode**, **4.2 Zones**, **4.3 Pitch Bend Sensitivity** (Work item 1) |
+| 3.4 Non-MPE to MPE Conversion | unchanged in scope; cross-refs repointed (renumbers to 3.3) |
+| 3.5 **Master Channel Note Forwarding** | retitled **Master Channel Forwarding** — notes, Pitch Bend, Zone-level controls (Work item 3; renumbers to 3.4) |
+| 4 (Allocation) preamble | gains the velocity-0 convention (Work item 2) |
+| 4.2 Dual-Group Channel Partitioning | gains the channel-reuse rule (Work item 5) |
+| 4.7.5 Master Channel Pitch Bend | keeps its argument; forwarding mechanic moves to Master Channel Forwarding (Work item 3) |
+| 6.1 Aggregation Model | gains Note Off removal + `[1, §3.3.3]`; new **Message Ordering** subsection (Work item 4) |
+| **6.4 Channel Pressure Reset at Note Off** — *new subsection* | absorbs Section 8.3's Channel Pressure reset paragraph `[1, §3.3.4]` (Work item 6) |
+| **8 MPE Tuner Output Conformance** | **removed** (Work items 2–6) |
 
 ---
 
-## Work item 1 — Repurpose Section 3.3 "Zones" → "Configuration"
+## Numbering after the reorg
+
+Inserting **Configuration** as Section 4 and removing Section 8 renumbers the sections between them. Because
+the insertion is above the removal, **Worked Examples (9) and Summary (10) keep their numbers**; old
+Sections 4–7 shift up by one, and Section 3's tail (old 3.4, 3.5) shifts down to fill the slot Zones vacates.
+
+This is the **single authority** for target numbers; the Work items and tables elsewhere use current
+numbering. Perform it as the **final** step: after the content moves, renumber the section headers to match
+the map, then update every cross-reference to the **target** number of the section it denotes — resolving by
+**meaning** (the section names disambiguate), not by blind text replacement.
+
+**Watch the Section 4 clash:** the *new* Section 4 is **Configuration**; the *old* Section 4 (Allocation)
+becomes **Section 5**. A reference to allocation must land on 5, never on the new Configuration section.
+
+**Never renumber `[1, §N]`.** Those cite the MPE Specification (reference [1]), not this paper. Every `§` in
+the paper belongs to a `[1, §…]` citation — the paper numbers its own sections only as `Section N`. Restrict
+the sweep to `Section N`.
+
+### Current → target map
+
+| Current | Target | Section |
+|---|---|---|
+| 3.1, 3.2 | 3.1, 3.2 | Signal Flow, Input Modes — unchanged |
+| **3.3 Zones** | **→ 4** | extracted into the new Configuration section |
+| 3.4 | **3.3** | Non-MPE to MPE Conversion |
+| 3.5 | **3.4** | Master Channel Forwarding (retitled — Work item 3) |
+| *(new)* | **4** | **Configuration** — 4.1 Input Mode, 4.2 Zones, 4.3 Pitch Bend Sensitivity |
+| 4 … 4.7.5 | **5 … 5.7.5** | Allocation of Notes to Member Channels |
+| 5 … 5.2.3 | **6 … 6.2.3** | Dropping Notes and Freeing Channels |
+| 6 … 6.3 (+ new 6.4) | **7 … 7.3 (+ new 7.4)** | Expression Value Processing (6.1 Aggregation → 7.1, plus new **7.1.1** Message Ordering — Work item 4; and new **7.4** Channel Pressure Reset at Note Off — Work item 6) |
+| 7 | **8** | Real-Time Tuning Changes |
+| **8** | — | MPE Tuner Output Conformance — **dissolved** (Work items 2–6; repoints in the Cross-references table) |
+| 9, 10 | 9, 10 | Worked Examples, Summary — unchanged |
+
+The `3.3` (Zones) cross-references need judgment, not a blind swap: each resolves to the new Configuration
+section — usually **Section 4**, or a specific subsection (4.1 Input Mode / 4.2 Zones / 4.3 Pitch Bend
+Sensitivity) when the sentence means one.
+
+### Cross-reference checksum (as of `44730ba`)
+
+Occurrences of each `Section N` the paper makes to itself, so the sweep can be verified complete:
+
+| Current ref (count) | → target |
+|---|---|
+| 3.3 ×9 | 4 (or 4.1 / 4.2 / 4.3 by context) |
+| 3.4 ×8 | 3.3 |
+| 3.5 ×4 | 3.4 |
+| 4 ×3, 4.1 ×3, 4.2 ×1, 4.4 ×1, 4.5 ×4, 4.6 ×4, 4.7.5 ×1 | 5, 5.1, 5.2, 5.4, 5.5, 5.6, 5.7.5 |
+| 5 ×1, 5.1 ×3, 5.2 ×4, 5.2.1 ×3, 5.2.2 ×4, 5.2.3 ×2 | 6, 6.1, 6.2, 6.2.1, 6.2.2, 6.2.3 |
+| 6 ×7, 6.1 ×5, 6.2 ×1, 6.3 ×4 | 7, 7.1, 7.2, 7.3 |
+| 7 ×1 | 8 |
+| 8 ×2, 8.1 ×2, 8.2 ×2 | dissolved — repoint per the Cross-references table |
+| 3, 3.1, 3.2, 2.1, 1.3 | unchanged |
+
+---
+
+## Work item 1 — Extract Configuration into a new, dedicated Section 4
 
 ### Rationale
 
 Section 3.3 already states the dual-source configuration model:
 
 > "The Zone configuration may be established and changed in two ways: through the non-MIDI configuration
-> interface, or in-band, through an MPE Configuration Message (MCM) received on a Master Channel."
+> interface, or in-band, through an MCM received on a Master Channel."
 
 That pattern is **not Zone-specific** — it is the Tuner's configuration model, and Input Mode and Pitch
 Bend Sensitivity follow the identical shape (non-MIDI interface establishes a base; MIDI messages override
@@ -66,27 +150,27 @@ second time in parallel for one parameter. State the model once; list the parame
 
 ### Structure
 
-Section 3.3 becomes **"Configuration"** with a short preamble stating the general model, then:
+The new **Configuration** section (Section 4) opens with a short preamble stating the general model, then:
 
-- **3.3.1 Input Mode**
-- **3.3.2 Zones**
-- **3.3.3 Pitch Bend Sensitivity**
+- **4.1 Input Mode**
+- **4.2 Zones**
+- **4.3 Pitch Bend Sensitivity**
 
 The preamble carries what is common to all three: the Tuner is configured through a **non-MIDI
 configuration interface**; the MPE Specification defines **defaults** for these parameters; a user may
 **override** the non-MIDI configuration in-band via MCM and RPN 00 00 messages, subject to per-parameter
 limitations stated in the subsections.
 
-Sub-subsectioning is required here, not cosmetic: 3.3 is already two dense paragraphs, and it is absorbing
-PBS's mode-split plus the defaults model.
+Subsectioning is required here, not cosmetic: the current Zones material (3.3) is already two dense
+paragraphs, and the section is absorbing PBS's mode-split plus the defaults model.
 
-### 3.3.1 Input Mode
+### 4.1 Input Mode
 
-Section 3.2 ("Input Modes") keeps defining **what the modes are**; 3.3.1 defines **how the mode is
-selected**. This mirrors the existing split between Section 2.1 (what Zones are) and 3.3 (how the Tuner's
-Zones are configured).
+Section 3.2 ("Input Modes") keeps defining **what the modes are**; 4.1 defines **how the mode is
+selected**. This mirrors the split between what a thing *is* and how it is *configured*, as between
+Section 2.1 (what Zones are) and 4.2 (how the Tuner's Zones are configured).
 
-This subsection is nearly free — Section 3.3 already contains the mode-switching rules. Naming Input Mode
+This subsection is nearly free — the current Zones section (3.3) already contains the mode-switching rules. Naming Input Mode
 as a configuration parameter labels what is already there. Facts to gather:
 
 - Set via the non-MIDI configuration interface (from Section 1.4 "Overview of Operation" and Section 3.1
@@ -95,7 +179,7 @@ as a configuration parameter labels what is already there. Facts to gather:
 - MCMs deactivating all Zones revert to Non-MPE Input Mode, "restoring the output Zone configuration
   provided through the configuration interface" (already in 3.3).
 
-### 3.3.2 Zones
+### 4.2 Zones
 
 Keeps **all** existing Section 3.3 Zone facts, unchanged in substance:
 
@@ -110,7 +194,7 @@ Keeps **all** existing Section 3.3 Zone facts, unchanged in substance:
 **Add:** MCMs are emitted **at start-up** as well as on reconfiguration. This is the one genuinely new fact
 in the Section 8 "Zone Configuration" bullet; everything else in that bullet restates 3.3.
 
-### 3.3.3 Pitch Bend Sensitivity
+### 4.3 Pitch Bend Sensitivity
 
 This is the substantive addition. Section 8's PBS bullet is the **only** place in the paper specifying how
 the Tuner interprets incoming PBS; it must not be lost.
@@ -125,7 +209,7 @@ Sensitivity") states:
 
 > "Upon receiving an MCM, a receiver must set: **Master Channel Pitch Bend Sensitivity**: ±2 semitones
 > (default). **Member Channel Pitch Bend Sensitivity**: ±48 semitones (default). These values may be
-> changed via RPN 0."
+> changed via RPN 00 00."
 
 And Section 2.1 ("Zones, Master Channels, and Member Channels"):
 
@@ -133,7 +217,7 @@ And Section 2.1 ("Zones, Master Channels, and Member Channels"):
 > controls to reasonable default values on each channel entering or leaving MPE control [1, §2.1.4]."
 
 The defaults are **spec-defined properties of MPE**; the MCM is the **reset trigger** that applies them.
-Write 3.3.3 in that direction: the defaults exist independently, and an MCM resets PBS to them.
+Write 4.3 in that direction: the defaults exist independently, and an MCM resets PBS to them.
 
 **Facts to carry over from Section 8's PBS bullet:**
 
@@ -178,7 +262,7 @@ Reasoning to preserve:
 **The empty-Zone MCM revert path.** When an MCM with zero Member Channels deactivates all Zones and the
 Tuner reverts to Non-MPE Input Mode, there is no way to set output **Member Channel PBS** over MIDI — in
 Non-MPE Input Mode the input has no Member Channel to receive RPN 00 00 on, and input PBS is redirected to
-the Master Channel. **Decision: accept this limitation.** Consider one sentence in 3.3.3 acknowledging it,
+the Master Channel. **Decision: accept this limitation.** Consider one sentence in 4.3 acknowledging it,
 so the constraint is documented rather than discovered.
 
 > **Open question for the drafting step.** Section 3.3 says the revert restores "the output Zone
@@ -191,7 +275,7 @@ so the constraint is documented rather than discovered.
 
 ---
 
-## Work item 2 — Velocity-0 convention → Section 4 preamble
+## Work item 2 — Velocity-0 convention → Allocation preamble
 
 Section 8.3 currently carries:
 
@@ -274,7 +358,7 @@ Split it:
 
 - **Moves to 3.5:** the bare mechanic — *forwards Master Channel Pitch Bend as received, without
   modification*.
-- **Stays in 4.7.5:** the RP-053 quote (*"If an MPE synthesizer receives Pitch Bend on both a Master and a
+- **Stays in 4.7.5:** the RP-053 quote (*"If an MPE synthesizer receives Pitch Bend (for example) on both a Master and a
   Member Channel, it must combine the data meaningfully."* `[1, §2.3.2]`) **and** the argument — Master
   Pitch Bend is a Zone-level expressive control belonging entirely to the performer, is not an input to
   tuning, and tuning offsets are applied exclusively via the Tuning Pitch Bend component of Member Channel
@@ -345,10 +429,41 @@ Section 8.3 is dissolved. Its content:
   > the lifetime of that channel's occupancy."
 
   The two rules are the same occupancy lifecycle stated from opposite ends.
-- **→ Section 4 preamble:** the velocity-0 convention (Work item 2).
+- **→ Allocation preamble (Section 4):** the velocity-0 convention (Work item 2).
 - **Delete as restatement:** "While other notes remain active on the channel, the Tuner continues to update
   the channel's Pitch Bend — for tuning changes (Section 7) as well as for Expression Value changes
   (Section 6)." Already covered by Section 6.1's update-propagation rule and Section 7.
+
+---
+
+## Work item 6 — New Section 6.4 "Channel Pressure Reset at Note Off"
+
+`#241` added a paragraph to Section 8.3 that is the one genuinely new fact in the dissolved Section 8: whether
+the Tuner emits a Channel Pressure reset at Note Off, and why the answer depends on the input mode. Section 8
+dissolves, so this paragraph needs a pipeline-stage home. Channel Pressure is an Expression Value, and its
+Note Off reset is Expression Value emission behavior, so its home is **Section 6 ("Expression Value
+Processing")**. Because the paragraph's substance is the *contrast between the two input modes* — a single
+argument that reads as a unit and already cross-references both Section 6.2 and Section 6.3 — keep it whole as
+a new subsection **6.4 "Channel Pressure Reset at Note Off"** (renumbers to **7.4**), a sibling of 6.2 and
+6.3, rather than splitting it across them.
+
+Move the paragraph verbatim in substance, preserving:
+
+- The spec obligation: *"Channel Pressure must be set to zero immediately before a Note On or a Note Off
+  wherever it is appropriate to the design of a controller"* `[1, §3.3.4]`.
+- **MPE Input Mode:** output Channel Pressure passes through from the input sender, so the Tuner emits no
+  reset of its own — a conforming sender's pre-release reset propagates through the update mechanism of
+  Section 6.2, and if the sender emits none, neither does the Tuner.
+- **Non-MPE Input Mode:** the per-note Channel Pressure on an output Member Channel is the Tuner's own,
+  synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to
+  which the `[1, §3.3.4]` obligation applies, so it performs the reset itself, returning Channel Pressure to 0
+  as Section 6.3 requires.
+- The closing point that deferring in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the
+  specification's *"wherever it is appropriate"* qualifier and are documented design choices.
+
+The internal references to Sections 6.2 and 6.3 renumber to 7.2 and 7.3; the reference to Section 3.4 (the
+Polyphonic Key Pressure conversion) renumbers to 3.3. This is the only Section 8 fact that lands in the
+Expression Value Processing section.
 
 ---
 
@@ -358,29 +473,34 @@ Every reference to Section 8 in the paper, with its resolution. Search for the p
 
 | In section | Current reference | Action |
 |---|---|---|
-| 3.3 Zones | "the receiving instrument adopts the same Zone structure **(Section 8)**" | Drop the cross-reference; absorb the start-up MCM fact into 3.3.2. |
+| 3.3 Zones (→ 4.2) | "the receiving instrument adopts the same Zone structure **(Section 8)**" | Drop the cross-reference; absorb the start-up MCM fact into the Zones subsection (4.2). |
 | 3.4 item 3 (CC #74) | "never sends CC #74 on a Member Channel **(Sections 6.3 and 8.1)**" | → "(Section 6.3)" |
 | 3.4 item 4 | "where they act as Zone-level messages **(Section 8.2)**" | → Section 3.5 |
 | 3.4 item 4 | "Non-MPE input has no Master Channel of its own from which **Section 8.2's** forwarding could operate" | → Section 3.5's |
-| 3.4 item 4 | "the sensitivity of the Master Channel Pitch Bend to which the input's Pitch Bend is redirected **(Section 8)**" | → Section 3.3.3 |
+| 3.4 item 4 | "the sensitivity of the Master Channel Pitch Bend to which the input's Pitch Bend is redirected **(Section 8)**" | → Section 4.3 |
 | 6.1 Aggregation Model | "it may emit only those whose values differ from the values the channel already holds **(Section 8.1)**" | → Section 6.1.1, or inline now that it is adjacent. |
 | 6.3 Non-MPE Input Mode | "the dimension is thus controllable only globally **(Section 8.1)**" | → Section 3.4 item 3 |
 
-**Renumbering:** Section 9 ("Worked Examples") → 8; Section 10 ("Summary") → 9. Check for any prose
-references to those numbers before renumbering. Appendix A is unaffected.
+**Renumbering:** see [Numbering after the reorg](#numbering-after-the-reorg). Worked Examples and Summary
+keep 9 and 10; old Sections 4–7 shift up by one; old 3.4/3.5 become 3.3/3.4; the new Configuration section
+is Section 4. Check for prose references to any renumbered section before finalizing. Appendix A is
+unaffected.
 
-**Sweep after editing:** grep the paper for `Section 8` and `§8` to confirm no dangling references survive.
-Also grep the repo outside the paper — `issues/00202-pbs-non-mpe-input/pbs-non-mpe-and-mcm-test-mode-plan.md`
-already cites the paper by a stale path and stale numbering (`docs/tuner/mpe-tuner-paper.md` §3.3.2), so
-other docs may cite Section 8 numbers too. Updating stale sibling docs is **out of scope** for the reorg
-unless trivially cheap; note them rather than fix them.
+**Sweep after editing:** grep the paper for `Section 8` to confirm no dangling references survive (the paper
+has no `§8` — every `§` is a `[1, §…]` spec citation and must **not** be renumbered). Then verify the
+renumber against the checksum in [Numbering after the reorg](#numbering-after-the-reorg): no `Section 4`–
+`Section 7` reference should still resolve to its old target. Also grep the repo outside the paper —
+`issues/00202-pbs-non-mpe-input/pbs-non-mpe-and-mcm-test-mode-plan.md` already cites the paper by a stale
+path and stale numbering (`docs/tuner/mpe-tuner-paper.md` §3.3.2), so other docs may cite these numbers too.
+Updating stale sibling docs is **out of scope** for the reorg unless trivially cheap; note them rather than
+fix them.
 
 ---
 
 ## Coherence risk to watch
 
 After dissolution, no single section says "here is what conformant output looks like." A reader wanting the
-output contract must assemble it from 3.3.3, 3.4, 3.5, and 6.1.1. **This is the real cost of dissolution**
+output contract must assemble it from 4.3, 3.4, 3.5, 6.1.1, and 6.4. **This is the real cost of dissolution**
 and it is accepted deliberately — the alternative (retitling Section 8 to "Output Message Contract" and
 keeping only 8.1 and 8.2) leaves a thin two-subsection section whose parts both have better homes.
 
@@ -392,23 +512,23 @@ sentence and is the natural host. Optional — evaluate when drafting.
 
 ## Facts inventory
 
-Completeness guarantee. Every fact in Section 8 at `44b7030`, its status, and its destination. **New** =
+Completeness guarantee. Every fact in Section 8 at `44730ba`, its status, and its destination. **New** =
 exists nowhere else in the paper and must not be lost. **Restatement** = verifiably duplicated elsewhere;
 safe to delete.
 
 | # | Fact | From | Status | Destination |
 |---|---|---|---|---|
 | 1 | Output MCMs establish Zone structure on the receiver; single- and dual-Zone `[1, §2.1]` | 8 intro | restatement of 3.3 | delete |
-| 2 | **MCMs emitted at start-up** | 8 intro | **new** | 3.3.2 Zones |
+| 2 | **MCMs emitted at start-up** | 8 intro | **new** | 4.2 Zones |
 | 3 | MCMs emitted on every Zone reconfiguration | 8 intro | restatement of 3.3 | delete |
 | 4 | Tuner listens for input MCMs and reconfigures its own Zones | 8 intro | restatement of 3.3 | delete |
 | 5 | Tuner forwards that configuration to the output instrument | 8 intro | restatement of 3.3 | delete |
-| 6 | **PBS defaults ±48 Member / ±2 Master relied upon** `[1, §2.4]` | 8 intro | **new** (2.3 states the spec rule; this states the Tuner's reliance) | 3.3.3 — **with causality corrected** |
-| 7 | **Listens for RPN 00 00 on input; conforms when interpreting incoming Pitch Bend** | 8 intro | **new** | 3.3.3 |
-| 8 | **MPE Input Mode: sensitivity on any Member Channel applies Zone-wide** (+ `[1, §2.4]` quote) | 8 intro | **new** | 3.3.3 |
-| 9 | **MPE Input Mode: mirrors input per-channel; no fan-out; `n²` flood rationale** | 8 intro | **new** | 3.3.3 |
+| 6 | **PBS defaults ±48 Member / ±2 Master relied upon** `[1, §2.4]` | 8 intro | **new** (2.3 states the spec rule; this states the Tuner's reliance) | 4.3 — **with causality corrected** |
+| 7 | **Listens for RPN 00 00 on input; conforms when interpreting incoming Pitch Bend** | 8 intro | **new** | 4.3 |
+| 8 | **MPE Input Mode: sensitivity on any Member Channel applies Zone-wide** (+ `[1, §2.4]` quote) | 8 intro | **new** | 4.3 |
+| 9 | **MPE Input Mode: mirrors input per-channel; no fan-out; `n²` flood rationale** | 8 intro | **new** | 4.3 |
 | 10 | **Non-MPE Input Mode: RPN 00 00 → output Master Channel** | 8 intro | restatement of 3.4 item 4 | delete from 8; 3.4 item 4 keeps it, repointed |
-| 11 | **Non-MPE Input Mode: output Member Channels retain ±48; changeable only via non-MIDI interface** | 8 intro | **new** | 3.3.3 (+ limitation note) |
+| 11 | **Non-MPE Input Mode: output Member Channels retain ±48; changeable only via non-MIDI interface** | 8 intro | **new** | 4.3 (+ limitation note) |
 | 12 | **Emission order: Pitch Bend → CC #74 → Channel Pressure → Note On** `[1, §3.3.1]` | 8.1 | **new** | 6.1.1 |
 | 13 | Omission optimization for unchanged dimensions | 8.1 | half-restatement of 6.1 | merge into 6.1.1 |
 | 14 | CC #74 never emitted on a Member Channel in Non-MPE Input Mode | 8.1 | restatement of 6.3 and 3.4 item 3 | delete |
@@ -416,16 +536,17 @@ safe to delete.
 | 16 | **Note removed from Expression Value averages on Note Off** (+ `[1, §3.3.3]` quote) | 8.3 | **new** (the quote) | 6.1 |
 | 17 | Channel keeps receiving Pitch Bend updates while other notes remain active | 8.3 | restatement of 6.1 and 7 | delete |
 | 18 | **Channel available for reuse once all its notes have received Note Off** | 8.3 | **new** | 4.2 |
-| 19 | **Note On velocity 0 treated as Note Off** `[1, §3.3.2]` | 8.3 | **new** | Section 4 preamble, as a global convention |
+| 19 | **Note On velocity 0 treated as Note Off** `[1, §3.3.2]` | 8.3 | **new** | Allocation preamble (Work item 2), as a global convention |
 | 20 | "Recognizing the shorthand is essential: occupancy tracking, …" | 8.3 | self-justifying prose | delete |
+| 21 | **Channel Pressure reset at Note Off is input-mode-dependent** — MPE: pass-through, deferring to the sender via Section 6.2; Non-MPE: Tuner resets to 0 per Section 6.3 `[1, §3.3.4]` | 8.3 | **new** (added by #241) | new Section 6.4 (Work item 6) |
 
-**Totals:** 11 new facts relocated, 1 merged, 8 deleted as restatement or padding.
+**Totals:** 12 new facts relocated, 1 merged, 8 deleted as restatement or padding.
 
 ### Additional fixes surfaced by this analysis (not from Section 8)
 
 | Fact | Location | Action |
 |---|---|---|
-| PBS missing from the reconfiguration reset list | 3.3 | **Add** PBS to the defaults enumeration — the `[1, §2.1.4]` obligation is to reset *all* controls. |
+| PBS missing from the reconfiguration reset list | 4.2 (Zones) | **Add** PBS to the defaults enumeration — the `[1, §2.1.4]` obligation is to reset *all* controls. |
 | Master Channel Pitch Bend forwarding mechanic | 4.7.5 | Move mechanic to 3.5; keep quote and argument in place. |
 
 ---
@@ -439,4 +560,4 @@ safe to delete.
   not a description of the current implementation.
 - Preserve the paper's existing capitalization of MPE terms (Zone, Master Channel, Member Channel, Pitch
   Bend, Tuning Pitch Bend, Expression Pitch Bend, Expression Values, Tuning, Tuner).
-- Verify each quoted passage still matches before editing; the paper may have moved past `44b7030`.
+- Verify each quoted passage still matches before editing; the paper may have moved past `44730ba`.

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md
@@ -37,7 +37,9 @@ before Allocation. The paper is otherwise sectioned by **pipeline stage** (input
 tuning/expression → output), but configuration is not a pipeline stage: these parameters are established
 *before any note flows* and govern the whole pipeline. A config-time concern does not sit on the
 pipeline-stage axis, so it earns its own section rather than a subsection of Architecture — which also gives
-the substantive Pitch Bend Sensitivity material proper room.
+the substantive Pitch Bend Sensitivity material proper room. Work item 1 also carries the reorg's one
+deliberate behavior change: the in-band switch to MPE Input Mode is one-way — MCMs that deactivate all
+Zones no longer revert the Tuner to Non-MPE Input Mode (see the decision under Work item 1).
 
 **2 — Dissolve Section 8 ("MPE Tuner Output Conformance") entirely.** Its facts relocate to their
 pipeline-stage homes, and old Sections 4–7 shift up by one. Because Section 4 is inserted above where
@@ -51,7 +53,8 @@ Configuration without describing how the Zone was obtained. The paper is otherwi
 **pipeline stage** (input → allocation → tuning/expression → output); Section 8 is sectioned by **topic**,
 and the topic axis lost.
 
-Nothing is deleted that is not a verifiable restatement of text elsewhere in the paper. Section
+Nothing is deleted that is not a verifiable restatement of text elsewhere in the paper — except the
+revert-to-Non-MPE clause of 3.3, which the Work item 1 decision replaces rather than relocates. Section
 ["Facts inventory"](#facts-inventory) below is the completeness guarantee: every fact in Section 8 is
 listed with a destination or a justification for deletion.
 
@@ -173,20 +176,53 @@ Section 3.2 ("Input Modes") keeps defining **what the modes are**; 4.1 defines *
 selected**. This mirrors the split between what a thing *is* and how it is *configured*, as between
 Section 2.1 (what Zones are) and 4.2 (how the Tuner's Zones are configured).
 
-This subsection is nearly free — the current Zones section (3.3) already contains the mode-switching rules. Naming Input Mode
-as a configuration parameter labels what is already there. Facts to gather:
+The current Zones section (3.3) already contains the mode-switching rules; naming Input Mode as a
+configuration parameter mostly labels what is already there — except the all-Zones deactivation rule,
+which this reorg deliberately changes (see the decision below). Facts to gather:
 
 - Set via the non-MIDI configuration interface (from Section 1.4 "Overview of Operation" and Section 3.1
   "Signal Flow", item 1 *Input Mode Detection*).
-- Receipt of a valid MCM switches to MPE Input Mode (already in 3.3).
-- MCMs deactivating all Zones revert to Non-MPE Input Mode, "restoring the output Zone configuration
-  provided through the configuration interface" (already in 3.3).
+- Receipt of a valid MCM switches to MPE Input Mode (already in 3.3) — uniformly, including MCMs that
+  deactivate all Zones.
+- The in-band switch is one-way: no MCM returns the Tuner to Non-MPE Input Mode (decision below; replaces
+  3.3's revert).
+
+#### Decided: no revert to Non-MPE Input Mode — the in-band mode switch is one-way
+
+The paper at `44730ba` (Section 3.3) reverts to Non-MPE Input Mode when MCMs deactivate all Zones,
+"restoring the output Zone configuration provided through the configuration interface". This is
+withdrawn — the reorg's one deliberate behavior change. The Zone configuration is shared by input and
+output, so an MCM deactivating all Zones turns MPE off for the output too, disabling per-note tuning —
+the Tuner's main purpose. The resulting state is not "Non-MPE input" but no MPE at all, and relabeling it
+as an input mode (while silently restoring the output configuration) misrepresents it. The replacement
+behavior:
+
+- Every valid MCM — deactivating or not, received in either input mode — switches the Tuner to MPE Input
+  Mode if it is not already in it and applies its Zone reconfiguration. The switch is one-way: no MCM
+  returns the Tuner to Non-MPE Input Mode; that mode is re-entered only through the non-MIDI
+  configuration interface.
+- When the result is that all Zones are deactivated, MPE operation is off [1, §2.1]: the deactivation is
+  mirrored to the output like any Zone change, and the Tuner produces no note output until a Zone is
+  re-activated — by a subsequent MCM or through the non-MIDI configuration interface. The input mode
+  remains MPE Input Mode.
+
+The uniform rule keeps the overview sentences in Section 1.4 and Section 3.1 item 1 ("Receipt of an MCM
+shall cause the Tuner to switch to MPE Input Mode…") unconditionally true — they need only their
+cross-reference repointed — and preserves Section 3.2's statement that in Non-MPE Input Mode the Zone
+configuration originates solely from the non-MIDI configuration interface: any accepted MCM exits that
+mode before reconfiguring. A stray deactivating MCM silencing the Tuner is accepted on the existing
+reasoning that a user who sends an MCM does so intentionally. The decision also dissolves the PBS
+dilemmas of the revert path (see the superseded section below): with no revert there is no restore step,
+no MCM-only re-emission question, and no state in which output Member Channel PBS is stranded at the
+default.
 
 ### 4.2 Zones
 
 Keeps **all** existing Section 3.3 Zone facts, unchanged in substance:
 
-- One Zone configuration shared by input and output; role per input mode.
+- One Zone configuration shared by input and output; role per input mode. Phrase the opening so it is
+  unambiguous that this means a single shared *configuration*, not a single Zone (the next sentence
+  already says one or two Zones may be defined).
 - Non-MPE Input Mode: output only, single Zone (Lower if enabled, else Upper); Upper ignored when two are
   defined.
 - MCM validity rules `[1, §2.1.1]`, zero-Member-Channel deactivation, channel stealing by most-recent MCM.
@@ -220,7 +256,8 @@ And Section 2.1 ("Zones, Master Channels, and Member Channels"):
 > controls to reasonable default values on each channel entering or leaving MPE control [1, §2.1.4]."
 
 The defaults are **spec-defined properties of MPE**; the MCM is the **reset trigger** that applies them.
-Write 4.3 in that direction: the defaults exist independently, and an MCM resets PBS to them.
+Write 4.3 in that direction — an MCM resets PBS to the spec-defined defaults — without a meta-sentence
+about the defaults "existing independently" of any message; stating the Tuner's reliance on them suffices.
 
 **Facts to carry over from Section 8's PBS bullet:**
 
@@ -256,32 +293,17 @@ Reasoning to preserve:
 - In **Non-MPE Input Mode**, the Tuner emits MCM **+** PBS only at start-up or when the non-MIDI
   configuration changes, and it must emit both to completely configure the output. Correct configuration is
   therefore true by construction — there is no window in which an MCM strands a configured PBS.
-- If an **MCM is received on the input** while in Non-MPE Input Mode, the Tuner will normally switch to MPE
-  Input Mode, and resetting PBS to defaults is correct. A user who sends an MCM does so intentionally, knows
-  an MCM resets PBS to defaults, and will send their own PBS values if they want others.
+- If an **MCM is received on the input** while in Non-MPE Input Mode, the Tuner switches to MPE Input
+  Mode, and resetting PBS to defaults is correct. A user who sends an MCM does so intentionally, knows an
+  MCM resets PBS to defaults, and will send their own PBS values if they want others.
 
-### Known limitation to record (may warrant a sentence in the paper)
+### Superseded: the empty-Zone MCM revert path
 
-**The empty-Zone MCM revert path.** When an MCM with zero Member Channels deactivates all Zones and the
-Tuner reverts to Non-MPE Input Mode, there is no way to set output **Member Channel PBS** over MIDI — in
-Non-MPE Input Mode the input has no Member Channel to receive RPN 00 00 on, and input PBS is redirected to
-the Master Channel. **Decision: accept this limitation.** Consider one sentence in 4.3 acknowledging it,
-so the constraint is documented rather than discovered.
-
-**Decided: the revert emits MCM(s) only — no PBS re-emission.** (This resolves the drafting-step question
-an earlier draft left open.) When the revert restores "the output Zone configuration provided through the
-configuration interface" (Section 3.3), the Tuner emits only the corresponding MCM(s); it does not re-emit
-RPN 00 00. Per the receiver obligations the MCM triggers `[1, §2.1.4]`, PBS on the affected channels
-returns to the spec defaults (±48 Member / ±2 Master) — on the receiving instrument **and in the Tuner's
-own interpretation alike**: in Non-MPE Input Mode the Member Channel PBS is what the Tuner encodes Tuning
-Pitch Bend against, so the Tuner must compute with ±48 after the revert or its output pitch math would
-disagree with the receiver it just reset. A non-default Member PBS configured through the non-MIDI
-interface is therefore **not re-applied automatically**; it takes effect again only when the non-MIDI
-configuration is next applied. Phrase the 4.3 limitation in this stronger form: after an
-all-Zones-deactivating MCM, output Member Channel PBS stands at the default ±48 and cannot be changed over
-MIDI. (This refines the first bullet under the non-issue decision above: the revert is a third
-MCM-emission occasion, emitting the MCM without the PBS pairing; it is covered by the second bullet's
-reasoning — the user sent the deactivating MCM intentionally, knowing an MCM resets PBS to defaults.)
+Earlier drafts recorded a limitation of the revert path (after an all-Zones-deactivating MCM, output
+Member Channel PBS stood at the default ±48 and could not be changed over MIDI) and a decision that the
+revert emits MCM(s) only, without re-emitting RPN 00 00. Both are superseded by the one-way-switch
+decision in 4.1: the revert no longer exists, so neither the limitation nor the re-emission question
+arises, and 4.3 needs no limitation sentence.
 
 ---
 
@@ -538,7 +560,7 @@ safe to delete.
 | 8 | **MPE Input Mode: sensitivity on any Member Channel applies Zone-wide** (+ `[1, §2.4]` quote) | 8 intro | **new** | 4.3 |
 | 9 | **MPE Input Mode: mirrors input per-channel; no fan-out; `n²` flood rationale** | 8 intro | **new** | 4.3 |
 | 10 | **Non-MPE Input Mode: RPN 00 00 → output Master Channel** | 8 intro | restatement of 3.4 item 4 | delete from 8; 3.4 item 4 keeps it, repointed |
-| 11 | **Non-MPE Input Mode: output Member Channels retain ±48; changeable only via non-MIDI interface** | 8 intro | **new** | 4.3 (+ limitation note) |
+| 11 | **Non-MPE Input Mode: output Member Channels retain ±48; changeable only via non-MIDI interface** | 8 intro | **new** | 4.3 |
 | 12 | **Emission order: Pitch Bend → CC #74 → Channel Pressure → Note On** `[1, §3.3.1]` | 8.1 | **new** | 6.1.1 |
 | 13 | Omission optimization for unchanged dimensions | 8.1 | half-restatement of 6.1 | merge into 6.1.1 |
 | 14 | CC #74 never emitted on a Member Channel in Non-MPE Input Mode | 8.1 | restatement of 6.3 and 3.4 item 3 | delete |

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md
@@ -94,7 +94,10 @@ becomes **Section 5**. A reference to allocation must land on 5, never on the ne
 
 **Never renumber `[1, §N]`.** Those cite the MPE Specification (reference [1]), not this paper. Every `§` in
 the paper belongs to a `[1, §…]` citation — the paper numbers its own sections only as `Section N`. Restrict
-the sweep to `Section N`.
+the sweep to `Section N`. At `44730ba` one `Section N` phrase cited the spec — *"Section 3.2 of the MPE
+Specification"* in Section 3.5's rationale item 1 — but the working tree rewrites it to the `[1, §3.2]`
+citation form (see the constraints), so every remaining `Section N` is a self-reference and the sweep may
+treat them uniformly.
 
 ### Current → target map
 
@@ -106,7 +109,7 @@ the sweep to `Section N`.
 | 3.5 | **3.4** | Master Channel Forwarding (retitled — Work item 3) |
 | *(new)* | **4** | **Configuration** — 4.1 Input Mode, 4.2 Zones, 4.3 Pitch Bend Sensitivity |
 | 4 … 4.7.5 | **5 … 5.7.5** | Allocation of Notes to Member Channels |
-| 5 … 5.2.3 | **6 … 6.2.3** | Dropping Notes and Freeing Channels |
+| 5 … 5.3 | **6 … 6.3** | Dropping Notes and Freeing Channels (5.3 Summary of Note-Dropping Invariants → 6.3; no cross-references cite 5.3 — only the header renumbers) |
 | 6 … 6.3 (+ new 6.4) | **7 … 7.3 (+ new 7.4)** | Expression Value Processing (6.1 Aggregation → 7.1, plus new **7.1.1** Message Ordering — Work item 4; and new **7.4** Channel Pressure Reset at Note Off — Work item 6) |
 | 7 | **8** | Real-Time Tuning Changes |
 | **8** | — | MPE Tuner Output Conformance — **dissolved** (Work items 2–6; repoints in the Cross-references table) |
@@ -126,11 +129,11 @@ Occurrences of each `Section N` the paper makes to itself, so the sweep can be v
 | 3.4 ×8 | 3.3 |
 | 3.5 ×4 | 3.4 |
 | 4 ×3, 4.1 ×3, 4.2 ×1, 4.4 ×1, 4.5 ×4, 4.6 ×4, 4.7.5 ×1 | 5, 5.1, 5.2, 5.4, 5.5, 5.6, 5.7.5 |
-| 5 ×1, 5.1 ×3, 5.2 ×4, 5.2.1 ×3, 5.2.2 ×4, 5.2.3 ×2 | 6, 6.1, 6.2, 6.2.1, 6.2.2, 6.2.3 |
+| 5 ×1, 5.1 ×3, 5.2 ×4, 5.2.1 ×3, 5.2.2 ×4, 5.2.3 ×5 | 6, 6.1, 6.2, 6.2.1, 6.2.2, 6.2.3 |
 | 6 ×7, 6.1 ×5, 6.2 ×1, 6.3 ×4 | 7, 7.1, 7.2, 7.3 |
 | 7 ×1 | 8 |
-| 8 ×2, 8.1 ×2, 8.2 ×2 | dissolved — repoint per the Cross-references table |
-| 3, 3.1, 3.2, 2.1, 1.3 | unchanged |
+| 8 ×2, 8.1 ×3, 8.2 ×2 | dissolved — repoint per the Cross-references table |
+| 3, 3.1, 2.1, 1.3 | unchanged (`44730ba` also had one `Section 3.2` phrase citing the spec, rewritten to `[1, §3.2]` in the working tree) |
 
 ---
 
@@ -265,13 +268,20 @@ Non-MPE Input Mode the input has no Member Channel to receive RPN 00 00 on, and 
 the Master Channel. **Decision: accept this limitation.** Consider one sentence in 4.3 acknowledging it,
 so the constraint is documented rather than discovered.
 
-> **Open question for the drafting step.** Section 3.3 says the revert restores "the output Zone
-> configuration provided through the configuration interface", and Section 3.3 also requires an output MCM
-> "[w]henever the Zone configuration changes — through either mechanism". If that restore emits MCM **+**
-> PBS (the same pairing as start-up), the non-MIDI interface's Member PBS *is* re-applied and the
-> limitation reduces to the general Non-MPE one — the *performer* cannot change Member PBS over MIDI,
-> which is already stated. Decide whether the revert re-emits the PBS pair, and phrase the limitation to
-> match. This affects only the wording of the limitation, not any other work item.
+**Decided: the revert emits MCM(s) only — no PBS re-emission.** (This resolves the drafting-step question
+an earlier draft left open.) When the revert restores "the output Zone configuration provided through the
+configuration interface" (Section 3.3), the Tuner emits only the corresponding MCM(s); it does not re-emit
+RPN 00 00. Per the receiver obligations the MCM triggers `[1, §2.1.4]`, PBS on the affected channels
+returns to the spec defaults (±48 Member / ±2 Master) — on the receiving instrument **and in the Tuner's
+own interpretation alike**: in Non-MPE Input Mode the Member Channel PBS is what the Tuner encodes Tuning
+Pitch Bend against, so the Tuner must compute with ±48 after the revert or its output pitch math would
+disagree with the receiver it just reset. A non-default Member PBS configured through the non-MIDI
+interface is therefore **not re-applied automatically**; it takes effect again only when the non-MIDI
+configuration is next applied. Phrase the 4.3 limitation in this stronger form: after an
+all-Zones-deactivating MCM, output Member Channel PBS stands at the default ±48 and cannot be changed over
+MIDI. (This refines the first bullet under the non-issue decision above: the revert is a third
+MCM-emission occasion, emitting the MCM without the PBS pairing; it is covered by the second bullet's
+reasoning — the user sent the deactivating MCM intentionally, knowing an MCM resets PBS to defaults.)
 
 ---
 
@@ -561,3 +571,9 @@ safe to delete.
 - Preserve the paper's existing capitalization of MPE terms (Zone, Master Channel, Member Channel, Pitch
   Bend, Tuning Pitch Bend, Expression Pitch Bend, Expression Values, Tuning, Tuner).
 - Verify each quoted passage still matches before editing; the paper may have moved past `44730ba`.
+- The working tree carries two one-line fixes over `44730ba`: in Section 8.3, the paper's only bare
+  `§3.3.4` becomes the citation form `[1, §3.3.4]`; in Section 3.5's rationale item 1, "Section 3.2 of the
+  MPE Specification … play them" becomes "The specification … play them [1, §3.2]". Together they make the
+  invariants relied on above true — every `§` belongs to a `[1, §…]` citation, and every `Section N` is a
+  self-reference. Commit both before or together with the reorg, and quote these passages from the working
+  tree, not from `44730ba`.

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -522,12 +522,12 @@ design's coherence mitigation to Section 1.4.
 **Files:**
 - Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
 
-- [ ] **Step 1: Repoint 3.4 item 3's reference**
+- [x] **Step 1: Repoint 3.4 item 3's reference**
 
 Remove: `Member Channel (Sections 6.3 and 8.1).`
 Add: `Member Channel (Section 6.3).`
 
-- [ ] **Step 2: Delete Section 8 in its entirety**
+- [x] **Step 2: Delete Section 8 in its entirety**
 
 Remove (ends by consuming Section 8's trailing `---`; the rule preceding `## 8.` remains as the
 separator before `## 9.`):
@@ -593,7 +593,7 @@ Add:
 ## 9. Worked Examples
 ```
 
-- [ ] **Step 3: Add the conformance pointer to Section 1.4**
+- [x] **Step 3: Add the conformance pointer to Section 1.4**
 
 Position: end of 1.4, as a new paragraph after the paragraph edited in Task 2 Step 3 (which now ends
 `…reconfigure its Zones accordingly (Section C).`). This is the design's accepted mitigation for the
@@ -621,7 +621,7 @@ The obligations of output conformance to the MPE Specification are specified whe
 ## 2. Background: The MPE Specification
 ```
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 ```bash
 grep -c "Section 8" docs/architecture/tuner/mpe-tuner-paper.md   # expect 0
@@ -630,7 +630,7 @@ grep -c "velocity 0" docs/architecture/tuner/mpe-tuner-paper.md  # expect 1
 grep -c "Section 3.3" docs/architecture/tuner/mpe-tuner-paper.md # expect 0
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add docs/architecture/tuner/mpe-tuner-paper.md

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -1,0 +1,860 @@
+# MPE Tuner Paper Config Reorg — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended)
+> or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** Execute the reorg specified in `paper-config-reorg-design.md` — extract Configuration into a new
+dedicated Section 4 and dissolve Section 8 — on `docs/architecture/tuner/mpe-tuner-paper.md`, with every
+insertion and removal spelled out verbatim below.
+
+**Architecture:** Content edits (Tasks 2–6) happen first, in **current** section numbering, with one
+sentinel: references to the new Configuration section are written `Section C` / `C.1` / `C.2` / `C.3`.
+The renumber (Task 7) is a single final sweep — a one-pass map over `Section N` references and headers,
+then a `C → 4` pass — verified against a before/after reference-count snapshot. This realizes the design's
+"renumber last, resolve by meaning" rule: at sweep time every number still means its current section, so a
+one-pass map *is* resolution by meaning.
+
+**Tech Stack:** Markdown, `perl` one-liners for the sweep, `grep` for verification. No build, no tests.
+
+## Global Constraints
+
+- **Markdown only.** Do not modify Scala or any other committed source. Do not read `MpeTuner` to resolve
+  behavior questions — the paper is the specification.
+- **Target file:** `docs/architecture/tuner/mpe-tuner-paper.md` (called "the paper" below). The design
+  spec is `issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md`.
+- **Maintain the paper's technical academic tone** and its capitalization of MPE terms (Zone, Master
+  Channel, Member Channel, Pitch Bend, Tuning Pitch Bend, Expression Pitch Bend, Expression Values,
+  Tuning, Tuner). Generic "input mode" stays lowercase; the modes themselves are "MPE Input Mode" /
+  "Non-MPE Input Mode".
+- **Numbering convention:** all text inserted by Tasks 2–6 uses **current** section numbers. References
+  to the new Configuration section use the **C sentinel** (`Section C`, `Section C.1`, `Section C.2`,
+  `Section C.3`). Only Task 7 renumbers.
+- **Never touch `[1, §N]`** — those cite the MPE Specification, not the paper.
+- Every `Remove:`/`Add:` block below is exact text. If an old string fails to match, **stop and
+  re-verify against the file** — do not improvise a similar edit.
+- Work on branch `doc/mpe-paper-config-reorg`. Commit after each task with the `[#154]` prefix.
+
+---
+
+### Task 1: Commit the pending working-tree changes
+
+Two files are already modified in the working tree and must be committed before the reorg edits start,
+as two separate commits.
+
+**Files:**
+- Commit: `docs/architecture/tuner/mpe-tuner-paper.md` (two one-line citation-notation fixes)
+- Commit: `issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md` (review fixes + decisions)
+- Commit: `issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md` (this plan)
+
+**Interfaces:**
+- Produces: a clean working tree whose paper text is the baseline every `Remove:` block in Tasks 2–7
+  matches.
+
+- [ ] **Step 1: Verify the expected diff**
+
+Run: `git status --short && git diff --stat`
+Expected: exactly the three files above modified/untracked, nothing else.
+
+- [ ] **Step 2: Commit the paper citation fixes**
+
+```bash
+git add docs/architecture/tuner/mpe-tuner-paper.md
+git commit -m "[#154] Use [1, §N] citation form for in-prose MPE spec references"
+```
+
+- [ ] **Step 3: Commit the design spec update and this plan**
+
+```bash
+git add issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md \
+        issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+git commit -m "[#154] Resolve review findings in config reorg design spec; add implementation plan"
+```
+
+---
+
+### Task 2: Extract Configuration into new Section C (Work item 1)
+
+Removes Section 3.3 (Zones) from the Architecture chapter, inserts the new Configuration section between
+Section 3 and Section 4, and repoints the seven surviving `Section 3.3` references (the other two die
+with Section 8 in Task 6). Also repoints the `(Section 8)` reference in 3.4 item 4 to the new PBS
+subsection.
+
+**Files:**
+- Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
+
+**Interfaces:**
+- Produces: sections `## C. Configuration`, `### C.1 Input Mode`, `### C.2 Zones`,
+  `### C.3 Pitch Bend Sensitivity`; consumed by Task 7's `C → 4` pass. Task 6's coherence sentence
+  references `Section C`.
+
+- [ ] **Step 1: Remove Section 3.3 Zones**
+
+Position: Section 3, between 3.2 and 3.4.
+
+Remove (replace with the `### 3.4` heading alone, i.e. delete everything before it):
+
+```markdown
+### 3.3 Zones
+
+The MPE Tuner has one Zone configuration, shared by its input and its output: the number of Member Channels allocated to the Lower Zone and, optionally, to the Upper Zone. As in the MPE Specification, one or two Zones may be defined. The role this shared configuration plays depends on the input mode:
+
+- In **MPE Input Mode**, the Zone configuration applies to both input and output: the Tuner expects the input stream to be organized according to the configured Zones, and produces output organized by the same Zones. Notes received on the Member Channels of an input Zone are allocated to Member Channels of the same output Zone.
+- In **Non-MPE Input Mode**, the input has no Zone structure, so the Zone configuration affects the output only. Furthermore, only one Zone is accessible from the output: input notes are routed exclusively to the Lower Zone if it is enabled, otherwise to the Upper Zone. When two Zones are defined, the Upper Zone is ignored. This restriction prevents ambiguity in channel allocation and zone-level message routing when the input carries no Zone information of its own.
+
+The Zone configuration may be established and changed in two ways: through the non-MIDI configuration interface, or in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. Upon receiving a valid MCM, the Tuner switches to MPE Input Mode if it is not already in it (Section 3.1) and reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1]. When MCMs deactivate all Zones, MPE operation is off [1, §2.1]; the Tuner then reverts to Non-MPE Input Mode, restoring the output Zone configuration provided through the configuration interface.
+
+Whenever the Zone configuration changes — through either mechanism — the Tuner emits the corresponding MCM(s) on its output, so that the receiving instrument adopts the same Zone structure (Section 8). The reconfiguration also resets the Tuner's state for every channel entering or leaving MPE control, mirroring the receiver obligations of the MPE Specification [1, §2.1.4]: active notes on the affected channels are dropped, the channels' group assignments (Section 4.2) are cleared, and the retained Expression Values and remembered input-channel control values (Section 6) return to their defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64. Channels of a Zone untouched by the reconfiguration keep their notes and state. For the dropped notes, an implementation may either emit no Note Off messages — relying on the downstream receiver's obligation to stop ongoing notes upon receiving the MCM [1, §2.1.4] — or emit explicit Note Off messages before the MCM, for robustness with receivers that do not fully conform; the choice is left to the implementer.
+
+### 3.4 Non-MPE to MPE Conversion
+```
+
+Add:
+
+```markdown
+### 3.4 Non-MPE to MPE Conversion
+```
+
+- [ ] **Step 2: Insert the Configuration section**
+
+Position: between the end of Section 3 (after 3.5) and Section 4, i.e. anchored on the `---` +
+`## 4. Allocation of Notes to Member Channels` boundary.
+
+Remove:
+
+```markdown
+---
+
+## 4. Allocation of Notes to Member Channels
+```
+
+Add:
+
+```markdown
+---
+
+## C. Configuration
+
+The MPE Tuner's operation is governed by three configuration parameters, established before any note flows and applying across every stage of the pipeline: the input mode (Section C.1), the Zone configuration (Section C.2), and the Pitch Bend Sensitivity (Section C.3). All three follow the same model: the parameter is established through a **non-MIDI configuration interface**, and may additionally be overridden in-band, through MIDI messages received on the input — MCMs for the input mode and the Zones, and Pitch Bend Sensitivity messages (RPN 00 00) for the Pitch Bend Sensitivity — subject to the per-parameter limitations stated in the subsections below. Where the MPE Specification defines defaults, notably the Pitch Bend Sensitivity values of Section 2.3, the Tuner adopts them in the absence of explicit configuration.
+
+### C.1 Input Mode
+
+Section 3.2 defines the two input modes; this subsection specifies how the operating mode is selected. The input mode may be set through the non-MIDI configuration interface, or switched in-band by the input stream itself (Section 3.1): upon receiving a valid MCM, the Tuner switches to MPE Input Mode if it is not already in it. Conversely, when MCMs deactivate all Zones, MPE operation is off [1, §2.1]; the Tuner then reverts to Non-MPE Input Mode, restoring the output Zone configuration provided through the configuration interface (Section C.2).
+
+### C.2 Zones
+
+The MPE Tuner has one Zone configuration, shared by its input and its output: the number of Member Channels allocated to the Lower Zone and, optionally, to the Upper Zone. As in the MPE Specification, one or two Zones may be defined. The role this shared configuration plays depends on the input mode:
+
+- In **MPE Input Mode**, the Zone configuration applies to both input and output: the Tuner expects the input stream to be organized according to the configured Zones, and produces output organized by the same Zones. Notes received on the Member Channels of an input Zone are allocated to Member Channels of the same output Zone.
+- In **Non-MPE Input Mode**, the input has no Zone structure, so the Zone configuration affects the output only. Furthermore, only one Zone is accessible from the output: input notes are routed exclusively to the Lower Zone if it is enabled, otherwise to the Upper Zone. When two Zones are defined, the Upper Zone is ignored. This restriction prevents ambiguity in channel allocation and zone-level message routing when the input carries no Zone information of its own.
+
+Beyond the non-MIDI configuration interface, the Zone configuration may be changed in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. A valid MCM — which also switches the Tuner to MPE Input Mode if necessary (Section C.1) — reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1].
+
+The Tuner emits the MCM(s) describing its Zone configuration at start-up, and again whenever the configuration changes — through either mechanism — so that the receiving instrument adopts the same Zone structure. A reconfiguration also resets the Tuner's state for every channel entering or leaving MPE control, mirroring the receiver obligations of the MPE Specification [1, §2.1.4]: active notes on the affected channels are dropped, the channels' group assignments (Section 4.2) are cleared, the retained Expression Values and remembered input-channel control values (Section 6) return to their defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64 — and Pitch Bend Sensitivity returns to the specification's defaults of ±48 semitones on Member Channels and ±2 semitones on the Master Channel (Section C.3). Channels of a Zone untouched by the reconfiguration keep their notes and state. For the dropped notes, an implementation may either emit no Note Off messages — relying on the downstream receiver's obligation to stop ongoing notes upon receiving the MCM [1, §2.1.4] — or emit explicit Note Off messages before the MCM, for robustness with receivers that do not fully conform; the choice is left to the implementer.
+
+### C.3 Pitch Bend Sensitivity
+
+The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The defaults exist independently of any particular message; the MPE Tuner relies on them both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output.
+
+The Tuner also listens for Pitch Bend Sensitivity messages (RPN 00 00) on its input and conforms to them when interpreting incoming Pitch Bend. How a received message propagates to the output depends on the input mode:
+
+- **MPE Input Mode**: a sensitivity received on any input Member Channel applies Zone-wide, since "[a] receiver must
+  apply the last Pitch Bend Sensitivity message received on any Member Channel to all Member Channels in the Zone"
+  [1, §2.4]. On output, the Tuner mirrors the input, forwarding each received message on its corresponding output
+  Member Channel. It does *not* replicate every received message across all Member Channels. A conforming MPE sender
+  already addresses the message to each of the `n` Member Channels [1, §2.4], so re-fanning those `n` messages to
+  all `n` channels would produce an `n²` flood. Because the Tuner both receives and sends MPE, per-channel
+  forwarding already configures every output Member Channel.
+- **Non-MPE Input Mode**: the input carries no Member Channels. Because a Member Channel's Pitch Bend then carries
+  only the Tuning Pitch Bend, a Pitch Bend Sensitivity message received on the input applies to the output Master
+  Channel, consistent with the redirection of the input's Pitch Bend to that channel (Section 3.4). The output
+  Member Channels retain the specification's default of ±48 semitones, which can be changed only through the
+  non-MIDI configuration interface.
+
+One limitation follows from the reset semantics. When MCMs deactivate all Zones and the Tuner reverts to Non-MPE Input Mode (Section C.1), the restore of the configured Zone structure emits MCM(s) only; the Pitch Bend Sensitivity of every channel entering or leaving MPE control — on the receiving instrument, per its reset obligations [1, §2.1.4], and in the Tuner's own interpretation alike — returns to the defaults. A non-default Member Channel sensitivity previously provided through the non-MIDI configuration interface is not re-applied automatically: it takes effect again only when the non-MIDI configuration is next applied. Until then, the output Member Channels' sensitivity stands at the default ±48 semitones and, as stated above, cannot be changed over MIDI in Non-MPE Input Mode.
+
+---
+
+## 4. Allocation of Notes to Member Channels
+```
+
+Notes against the design spec: the C.2 text keeps every 3.3 fact; the mode-switching clauses move to
+C.1; the dual-source sentence generalizes into the C preamble; the `(Section 8)` cross-reference is
+dropped and replaced by the absorbed start-up-MCM fact (inventory fact 2); PBS joins the reconfiguration
+reset list; C.3 carries inventory facts 6–9 and 11 with the causality corrected, the `n²` bullet verbatim
+(only "the MCM's default of ±48 semitones" becomes "the specification's default of ±48 semitones"), and
+the limitation in its stronger, MCM-only-revert form.
+
+- [ ] **Step 3: Repoint the seven surviving `Section 3.3` references**
+
+Seven `Edit` operations (fragments are unique after Step 1):
+
+1. Section 1.4 — Remove: `reconfigure its Zones accordingly (Section 3.3).`
+   Add: `reconfigure its Zones accordingly (Section C).`
+2. Section 3.1 item 1 — Remove: `reconfigure its Zones according to the message (Section 3.3).`
+   Add: `reconfigure its Zones according to the message (Section C).`
+3. Section 3.2, Non-MPE bullet (both references on the same line) —
+   Remove: `is routed to a single output Zone (Section 3.3). In this mode the Zone configuration originates solely from the non-MIDI configuration interface (Section 3.3).`
+   Add: `is routed to a single output Zone (Section C.2). In this mode the Zone configuration originates solely from the non-MIDI configuration interface (Section C.2).`
+4. Section 3.2, MPE bullet — Remove: `which reconfigure the Tuner's Zones (Section 3.3).`
+   Add: `which reconfigure the Tuner's Zones (Section C.2).`
+5. Section 3.4 item 2 — Remove: `selected for non-MPE input (see Section 3.3), where`
+   Add: `selected for non-MPE input (see Section C.2), where`
+6. Section 5.1 — Remove: `emission upon Zone reconfiguration is a distinct case, governed by Section 3.3.)`
+   Add: `emission upon Zone reconfiguration is a distinct case, governed by Section C.2.)`
+7. Section 3.4 item 4 (PBS sentence; per the design's repoint table this goes to the PBS subsection) —
+   Remove: `is redirected (Section 8).`
+   Add: `is redirected (Section C.3).`
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -c "Section 3.3" docs/architecture/tuner/mpe-tuner-paper.md   # expect 1 (Section 8 intro; dies in Task 6)
+grep -c "^### C\." docs/architecture/tuner/mpe-tuner-paper.md      # expect 3
+grep -c "^## C\. Configuration" docs/architecture/tuner/mpe-tuner-paper.md  # expect 1
+grep -c "(Section 8)" docs/architecture/tuner/mpe-tuner-paper.md   # expect 0
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/architecture/tuner/mpe-tuner-paper.md
+git commit -m "[#154] Extract Configuration into a dedicated section (reorg WI1)"
+```
+
+---
+
+### Task 3: Velocity-0 convention and channel-reuse rule into Allocation (Work items 2, 5-part)
+
+**Files:**
+- Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
+
+- [ ] **Step 1: Add the velocity-0 convention to the Section 4 preamble**
+
+Position: Section 4, end of the scoping paragraph, before `### 4.1 Fundamental Invariant`. Phrased as a
+global convention (it also governs Section 6's averaging), one sentence, no block quote, no
+self-justification.
+
+Remove:
+
+```markdown
+allocation procedure described below.
+
+### 4.1 Fundamental Invariant
+```
+
+Add:
+
+```markdown
+allocation procedure described below.
+
+Throughout this paper, a Note On with velocity 0 is treated as a Note Off [1, §3.3.2].
+
+### 4.1 Fundamental Invariant
+```
+
+- [ ] **Step 2: Add the channel-reuse rule to 4.2 Dual-Group Channel Partitioning**
+
+Position: 4.2, end of the group-assignment paragraph — the reuse rule is the same occupancy lifecycle as
+the persistence rule, stated from the other end.
+
+Remove:
+
+```markdown
+determined at the moment a note is placed on it and persists for the lifetime of that channel's occupancy.
+```
+
+Add:
+
+```markdown
+determined at the moment a note is placed on it and persists for the lifetime of that channel's occupancy. The
+channel becomes available for reuse once all its notes have received Note Off messages.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -c "velocity 0" docs/architecture/tuner/mpe-tuner-paper.md          # expect 2 (new + 8.3; 8.3 dies in Task 6)
+grep -c "available for reuse" docs/architecture/tuner/mpe-tuner-paper.md # expect 2 (same)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/architecture/tuner/mpe-tuner-paper.md
+git commit -m "[#154] Move velocity-0 convention and channel-reuse rule into Allocation (reorg WI2, WI5)"
+```
+
+---
+
+### Task 4: Broaden 3.5 into "Master Channel Forwarding" (Work item 3)
+
+Retitles 3.5, makes it own the passthrough mechanic for notes, Pitch Bend, and Zone-level controls;
+splits 4.7.5 (mechanic moves out, quote and argument stay); repoints 3.4 item 4's two `Section 8.2`
+references.
+
+**Files:**
+- Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
+
+- [ ] **Step 1: Retitle 3.5**
+
+Remove: `### 3.5 Master Channel Note Forwarding`
+Add: `### 3.5 Master Channel Forwarding`
+
+- [ ] **Step 2: Absorb the Pitch Bend mechanic and Zone-level messages; widen the closing line**
+
+Position: end of 3.5, after rationale item 3, replacing the current closing paragraph.
+
+Remove:
+
+```markdown
+   the ability to use Polyphonic Key Pressure on those notes.
+
+In Non-MPE Input Mode the concept of a Master Channel does not apply to the input: every incoming note is allocated to a
+Member Channel regardless of the input channel number.
+```
+
+Add:
+
+```markdown
+   the ability to use Polyphonic Key Pressure on those notes.
+
+The forwarding rule extends beyond notes. The MPE Tuner forwards Master Channel Pitch Bend as received, without
+modification; Master Pitch Bend is a Zone-level expressive control, and Section 4.7.5 discusses its relationship to
+tuning. Zone-level messages — Damper Pedal, Program Change, Reset All Controllers, and the other messages listed in
+Table 1 of the MPE Specification (Section 2.6) — are likewise forwarded on the Master Channel without modification.
+The MPE Tuner does not interpret or alter any of these messages.
+
+In Non-MPE Input Mode there is no input Master Channel to forward from: every incoming note is allocated to a Member
+Channel regardless of the input channel number, and the input's channel-global controls and Zone-level messages reach
+the output Master Channel by *redirection* instead, under the conversion rules of Section 3.4, items 2 and 4.
+```
+
+- [ ] **Step 3: Split 4.7.5 — mechanic out, argument and quote stay**
+
+Remove:
+
+```markdown
+The MPE Tuner forwards Master Channel Pitch Bend as received, without modification. Master Pitch Bend is not used by the Tuner in computing tuning offsets; it is a Zone-level expressive control, belonging entirely to the performer. The Tuner's tuning offsets are applied exclusively through the Tuning Pitch Bend component of Member Channel Pitch Bend.
+```
+
+Add:
+
+```markdown
+Master Channel Pitch Bend is forwarded without modification, as part of Master Channel forwarding (Section 3.5). It is not used by the Tuner in computing tuning offsets; it is a Zone-level expressive control, belonging entirely to the performer. The Tuner's tuning offsets are applied exclusively through the Tuning Pitch Bend component of Member Channel Pitch Bend.
+```
+
+Do **not** touch 4.7.4.
+
+- [ ] **Step 4: Repoint 3.4 item 4's two `Section 8.2` references**
+
+Remove:
+
+```markdown
+   where they act as Zone-level messages (Section 8.2). Non-MPE input has no Master Channel of its own from which
+   Section 8.2's forwarding could operate;
+```
+
+Add:
+
+```markdown
+   where they act as Zone-level messages (Section 3.5). Non-MPE input has no Master Channel of its own from which
+   Section 3.5's forwarding could operate;
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -c "Master Channel Note Forwarding" docs/architecture/tuner/mpe-tuner-paper.md  # expect 0
+grep -c "Section 8.2" docs/architecture/tuner/mpe-tuner-paper.md                     # expect 0 (8.2's own heading doesn't match)
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/architecture/tuner/mpe-tuner-paper.md
+git commit -m "[#154] Broaden 3.5 into Master Channel Forwarding (reorg WI3)"
+```
+
+---
+
+### Task 5: Expression Value Processing additions (Work items 4, 5-part, 6)
+
+Adds the Note Off removal rule to 6.1, creates 6.1.1 Message Ordering, repoints 6.1's and 6.3's `Section
+8.1` references, and creates 6.4 Channel Pressure Reset at Note Off.
+
+**Files:**
+- Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
+
+- [ ] **Step 1: Add the Note Off removal rule to 6.1**
+
+Position: 6.1, between the averaging paragraph and the retention paragraph (the removal rule is why the
+retention rule has a moment to apply). The `(Section 6.1)` self-reference from the 8.3 original is
+dropped; the `[1, §3.3.3]` quote is kept.
+
+Remove:
+
+```markdown
+component.
+
+When the last active note
+```
+
+Add:
+
+```markdown
+component.
+
+Upon Note Off, per-note control of the released note ceases: the note is removed from its channel's Expression Value
+averages, consistent with the specification's statement that "control of a note ceases once Note Off has occurred"
+[1, §3.3.3].
+
+When the last active note
+```
+
+- [ ] **Step 2: Repoint 6.1's omission-optimization reference**
+
+Remove: `the values the channel already holds (Section 8.1).`
+Add: `the values the channel already holds (Section 6.1.1).`
+
+- [ ] **Step 3: Insert 6.1.1 Message Ordering**
+
+Position: end of 6.1, before `### 6.2`. The trailing "In particular, in Non-MPE Input Mode CC #74 is
+never emitted…" sentence of 8.1 is **not** carried over (restatement of 6.3 and 3.4 item 3).
+
+Remove:
+
+```markdown
+the new value is sent on that channel.
+
+### 6.2 MPE Input Mode
+```
+
+Add:
+
+```markdown
+the new value is sent on that channel.
+
+#### 6.1.1 Message Ordering
+
+For each new note, the MPE Tuner outputs messages in the following order on the assigned Member Channel:
+
+1. **Pitch Bend**: encoding the sum of the Tuning Pitch Bend and the initial averaged Expression Pitch Bend.
+2. **CC #74**: the timbre Expression Value.
+3. **Channel Pressure**: the Channel Pressure Expression Value.
+4. **Note On**: the note message itself.
+
+This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has the correct pitch and articulation state before the note begins sounding.
+
+An implementation may omit any of the three control dimension messages whose value is unchanged since its last emission on that output channel, relying on the state retention rule of Section 6.1.
+
+### 6.2 MPE Input Mode
+```
+
+- [ ] **Step 4: Repoint 6.3's `Section 8.1` reference**
+
+Remove: `the dimension is thus controllable only globally (Section 8.1).`
+Add: `the dimension is thus controllable only globally (Section 3.4, item 3).`
+
+- [ ] **Step 5: Insert 6.4 Channel Pressure Reset at Note Off**
+
+Position: end of Section 6, after 6.3's last paragraph, before the `---` + `## 7.` boundary. Verbatim
+move of the 8.3 paragraph (working-tree wording).
+
+Remove:
+
+```markdown
+every output channel whose average changes receives the updated value immediately.
+
+---
+
+## 7. Real-Time Tuning Changes
+```
+
+Add:
+
+```markdown
+every output channel whose average changes receives the updated value immediately.
+
+### 6.4 Channel Pressure Reset at Note Off
+
+At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4].
+
+- In **MPE Input Mode** the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 6.2, and if the sender emits none, neither does the Tuner.
+- In **Non-MPE Input Mode** the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 6.3 requires.
+
+Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
+
+---
+
+## 7. Real-Time Tuning Changes
+```
+
+- [ ] **Step 6: Verify**
+
+```bash
+grep -c "Section 8.1" docs/architecture/tuner/mpe-tuner-paper.md   # expect 1 (3.4 item 3; fixed in Task 6)
+grep -c "^#### 6.1.1" docs/architecture/tuner/mpe-tuner-paper.md   # expect 1
+grep -c "^### 6.4" docs/architecture/tuner/mpe-tuner-paper.md      # expect 1
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/architecture/tuner/mpe-tuner-paper.md
+git commit -m "[#154] Move message ordering and Note Off facts into Expression Value Processing (reorg WI4-WI6)"
+```
+
+---
+
+### Task 6: Dissolve Section 8; add the conformance pointer to 1.4
+
+Every Section 8 fact now lives at its destination (Tasks 2–5); what remains is restatement (inventory
+facts 1, 3–5, 10, 13-merged, 14, 17, 20). Delete the section, fix the last `8.1` reference, and add the
+design's coherence mitigation to Section 1.4.
+
+**Files:**
+- Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
+
+- [ ] **Step 1: Repoint 3.4 item 3's reference**
+
+Remove: `Member Channel (Sections 6.3 and 8.1).`
+Add: `Member Channel (Section 6.3).`
+
+- [ ] **Step 2: Delete Section 8 in its entirety**
+
+Remove (ends by consuming Section 8's trailing `---`; the rule preceding `## 8.` remains as the
+separator before `## 9.`):
+
+```markdown
+## 8. MPE Tuner Output Conformance
+
+The output of the MPE Tuner conforms to the MPE Specification. The following features behave exactly as the MPE Specification defines them, with no Tuner-specific behavior:
+
+- **Zone Configuration**: the MPE Tuner outputs MPE Configuration Messages to establish the Zone structure on the receiving instrument, supporting both single-Zone and dual-Zone configurations [1, §2.1], emitting them at start-up and on every Zone reconfiguration (Section 3.3). It likewise listens for MCMs on its input and conforms to them, reconfiguring its own Zones as specified in Section 3.3; in this case it also configures the Zones of the output instrument by forwarding that configuration.
+- **Pitch Bend Sensitivity**: the MPE Tuner relies on the default Pitch Bend Sensitivity values that the MCM
+  establishes — ±48 semitones for Member Channels and ±2 semitones for the Master Channel [1, §2.4]. It also listens
+  for Pitch Bend Sensitivity messages (RPN 00 00) on its input and conforms to them when interpreting incoming Pitch
+  Bend. How a received message propagates to the output depends on the input mode:
+    - **MPE Input Mode**: a sensitivity received on any input Member Channel applies Zone-wide, since "[a] receiver must
+      apply the last Pitch Bend Sensitivity message received on any Member Channel to all Member Channels in the Zone"
+      [1, §2.4]. On output, the Tuner mirrors the input, forwarding each received message on its corresponding output
+      Member Channel. It does *not* replicate every received message across all Member Channels. A conforming MPE sender
+      already addresses the message to each of the `n` Member Channels [1, §2.4], so re-fanning those `n` messages to
+      all `n` channels would produce an `n²` flood. Because the Tuner both receives and sends MPE, per-channel
+      forwarding already configures every output Member Channel.
+    - **Non-MPE Input Mode**: the input carries no Member Channels. Because a Member Channel's Pitch Bend then carries
+      only the Tuning Pitch Bend, a Pitch Bend Sensitivity message received on the input applies to the output Master
+      Channel, consistent with the redirection of the input's Pitch Bend to that channel (Section 3.4). The output
+      Member Channels retain the MCM's default of ±48 semitones, which can be changed only through the non-MIDI
+      configuration interface.
+
+The subsections below specify the behaviors where the MPE Tuner adds detail beyond the specification.
+
+### 8.1 Message Ordering
+
+For each new note, the MPE Tuner outputs messages in the following order on the assigned Member Channel:
+
+1. **Pitch Bend**: encoding the sum of the Tuning Pitch Bend and the initial averaged Expression Pitch Bend.
+2. **CC #74**: the timbre Expression Value.
+3. **Channel Pressure**: the Channel Pressure Expression Value.
+4. **Note On**: the note message itself.
+
+This ordering follows the MPE Specification's recommendation [1, §3.3.1] and ensures that the receiving instrument has the correct pitch and articulation state before the note begins sounding.
+
+An implementation may omit any of the three control dimension messages whose value is unchanged since its last emission on that output channel, relying on the state retention of Section 6.1. In particular, in Non-MPE Input Mode CC #74 is never emitted on a Member Channel: the dimension cannot be controlled per note in that mode and is available only globally, on the Master Channel (Section 6.3).
+
+### 8.2 Zone-Level Messages
+
+Zone-level messages (Damper Pedal, Program Change, Reset All Controllers, and other messages listed in Table 1 of the MPE Specification) are forwarded on the Master Channel without modification. The MPE Tuner does not interpret or alter these messages.
+
+### 8.3 Note Off Behavior
+
+Upon Note Off, per-note control of the released note ceases: the note is removed from its channel's Expression Value averages (Section 6.1), consistent with the specification's statement that "control of a note ceases once Note Off has occurred" [1, §3.3.3]. While other notes remain active on the channel, the Tuner continues to update the channel's Pitch Bend — for tuning changes (Section 7) as well as for Expression Value changes (Section 6). The channel becomes available for reuse once all its notes have received Note Off messages.
+
+A Note On with velocity 0 in the input is treated as a Note Off, following the MIDI 1.0 shorthand and the specification's recommendation "that this message be interpreted as Note Off velocity 64" [1, §3.3.2]. Recognizing the shorthand is essential: occupancy tracking, Expression Value averaging, and channel reuse all depend on detecting note releases.
+
+At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4]. In MPE Input Mode the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 6.2, and if the sender emits none, neither does the Tuner. In Non-MPE Input Mode the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.4); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 6.3 requires. Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
+
+---
+
+## 9. Worked Examples
+```
+
+Add:
+
+```markdown
+## 9. Worked Examples
+```
+
+- [ ] **Step 3: Add the conformance pointer to Section 1.4**
+
+Position: end of 1.4, as a new paragraph after the paragraph edited in Task 2 Step 3 (which now ends
+`…reconfigure its Zones accordingly (Section C).`). This is the design's accepted mitigation for the
+dissolution's coherence cost.
+
+Remove:
+
+```markdown
+reconfigure its Zones accordingly (Section C).
+
+---
+
+## 2. Background: The MPE Specification
+```
+
+Add:
+
+```markdown
+reconfigure its Zones accordingly (Section C).
+
+The obligations of output conformance to the MPE Specification are specified where they arise: configuration of Zones and Pitch Bend Sensitivity in Section C, Note On message ordering in Section 6.1.1, Master Channel forwarding in Section 3.5, Note Off behavior in Section 6.1, and the Channel Pressure reset at Note Off in Section 6.4.
+
+---
+
+## 2. Background: The MPE Specification
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -c "Section 8" docs/architecture/tuner/mpe-tuner-paper.md   # expect 0
+grep -c "^## 8\." docs/architecture/tuner/mpe-tuner-paper.md     # expect 0
+grep -c "velocity 0" docs/architecture/tuner/mpe-tuner-paper.md  # expect 1
+grep -c "Section 3.3" docs/architecture/tuner/mpe-tuner-paper.md # expect 0
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/architecture/tuner/mpe-tuner-paper.md
+git commit -m "[#154] Dissolve Output Conformance section; add conformance pointer to 1.4 (reorg WI2-WI6)"
+```
+
+---
+
+### Task 7: Renumber sections and cross-references
+
+The single final sweep, per the design's [Numbering after the reorg]. All content is final; only numbers
+change. Take a reference-count snapshot first — it is the verification baseline.
+
+**Files:**
+- Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
+
+**Interfaces:**
+- Consumes: the C-sentinel sections and references produced by Tasks 2–6.
+
+- [ ] **Step 1: Snapshot reference counts (before)**
+
+```bash
+SCRATCH=/private/tmp/claude-501/-Users-calinburloiu-Development-microtonalist/fbfe8223-7c10-46fd-89b0-082b5a5e89c1/scratchpad
+PAPER=docs/architecture/tuner/mpe-tuner-paper.md
+count_refs() {
+  perl -0777 -ne 'while (/Sections?\s+([C\d]+(?:\.\d+)*)(?:(?:,\s*|\s+and\s+)([C\d]+(?:\.\d+)*))?(?:\s+and\s+([C\d]+(?:\.\d+)*))?/g) { for my $s ($1,$2,$3) { print "$s\n" if defined $s } }' "$1" | sort | uniq -c | awk "{print \$2, \$1}" | sort
+}
+count_refs "$PAPER" > "$SCRATCH/refs-before.txt"
+cat "$SCRATCH/refs-before.txt"
+```
+
+- [ ] **Step 2: Hand-fix the three plural constructs**
+
+The sweep regex renumbers only the first number after `Section(s)`; the paper's three
+`(Sections 5.2.2 and 5.2.3)` constructs get explicit edits to their **target** numbers first. This is
+safe: `6.2.2`/`6.2.3` are not keys of the sweep map, so Step 3 will not re-map them.
+
+Edit (replace_all): Remove `(Sections 5.2.2 and 5.2.3)` → Add `(Sections 6.2.2 and 6.2.3)`
+(3 occurrences: Section 4.5 algorithm step 3, Section 5 preamble, Section 5.2 preamble).
+
+- [ ] **Step 3: Run the sweep (references + headers, one pass each)**
+
+One-pass hash map — no chained replacements possible. Slurp mode (`-0777`) so line-wrapped references
+(e.g. `Section\n4.6`) are caught, preserving the whitespace.
+
+```bash
+perl -0777 -pi -e '
+  BEGIN { our %m = (
+    "3.4"=>"3.3", "3.5"=>"3.4",
+    "4"=>"5", "4.1"=>"5.1", "4.2"=>"5.2", "4.3"=>"5.3", "4.4"=>"5.4", "4.5"=>"5.5", "4.6"=>"5.6",
+    "4.7"=>"5.7", "4.7.1"=>"5.7.1", "4.7.2"=>"5.7.2", "4.7.3"=>"5.7.3", "4.7.4"=>"5.7.4", "4.7.5"=>"5.7.5",
+    "5"=>"6", "5.1"=>"6.1", "5.2"=>"6.2", "5.2.1"=>"6.2.1", "5.2.2"=>"6.2.2", "5.2.3"=>"6.2.3", "5.3"=>"6.3",
+    "6"=>"7", "6.1"=>"7.1", "6.1.1"=>"7.1.1", "6.2"=>"7.2", "6.3"=>"7.3", "6.4"=>"7.4",
+    "7"=>"8"
+  ); }
+  s/(Sections?)(\s+)(\d+(?:\.\d+)*)/$1 . $2 . ($m{$3} \/\/ $3)/ge;
+  s/^(\#{2,4} )(\d+(?:\.\d+)*)/$1 . ($m{$2} \/\/ $2)/gme;
+' docs/architecture/tuner/mpe-tuner-paper.md
+```
+
+Map notes: `3.3` is deliberately **absent** (no `Section 3.3` text remains after Task 6; old 3.4/3.5
+slide down to fill Zones' slot). `[1, §N]` citations never match (`Section` prefix required; headers
+carry no `§`).
+
+- [ ] **Step 4: Run the C → 4 pass**
+
+```bash
+perl -0777 -pi -e '
+  s/^## C\. Configuration/## 4. Configuration/m;
+  s/^### C\./### 4./gm;
+  s/Section C\.([123])/Section 4.$1/g;
+  s/Section C\b/Section 4/g;
+' docs/architecture/tuner/mpe-tuner-paper.md
+```
+
+- [ ] **Step 5: Verify — greps, count diff, header list**
+
+(a) No dangling sentinels or dissolved-section references, and no references to numbers that no longer
+exist (`Section 3.5` and `Section 4.7*` have no post-reorg referent):
+
+```bash
+grep -nE "Section C|## C\.|### C\.|Section 8\b|Section 8\.|Section 3\.5|Section 4\.7" docs/architecture/tuner/mpe-tuner-paper.md
+```
+
+Expected: no output.
+
+(b) Reference-count diff — map the before-snapshot through the same table and compare. (Shell state does
+not persist between tool calls: redefine the helpers first.)
+
+```bash
+SCRATCH=/private/tmp/claude-501/-Users-calinburloiu-Development-microtonalist/fbfe8223-7c10-46fd-89b0-082b5a5e89c1/scratchpad
+PAPER=docs/architecture/tuner/mpe-tuner-paper.md
+count_refs() {
+  perl -0777 -ne 'while (/Sections?\s+([C\d]+(?:\.\d+)*)(?:(?:,\s*|\s+and\s+)([C\d]+(?:\.\d+)*))?(?:\s+and\s+([C\d]+(?:\.\d+)*))?/g) { for my $s ($1,$2,$3) { print "$s\n" if defined $s } }' "$1" | sort | uniq -c | awk "{print \$2, \$1}" | sort
+}
+count_refs "$PAPER" > "$SCRATCH/refs-after.txt"
+perl -ne '
+  BEGIN { %m = (
+    "3.4"=>"3.3", "3.5"=>"3.4",
+    "4"=>"5", "4.1"=>"5.1", "4.2"=>"5.2", "4.3"=>"5.3", "4.4"=>"5.4", "4.5"=>"5.5", "4.6"=>"5.6",
+    "4.7"=>"5.7", "4.7.1"=>"5.7.1", "4.7.2"=>"5.7.2", "4.7.3"=>"5.7.3", "4.7.4"=>"5.7.4", "4.7.5"=>"5.7.5",
+    "5"=>"6", "5.1"=>"6.1", "5.2"=>"6.2", "5.2.1"=>"6.2.1", "5.2.2"=>"6.2.2", "5.2.3"=>"6.2.3", "5.3"=>"6.3",
+    "6"=>"7", "6.1"=>"7.1", "6.1.1"=>"7.1.1", "6.2"=>"7.2", "6.3"=>"7.3", "6.4"=>"7.4",
+    "7"=>"8",
+    "C"=>"4", "C.1"=>"4.1", "C.2"=>"4.2", "C.3"=>"4.3"
+  ); }
+  my ($n, $c) = split; $e{$m{$n} // $n} += $c;
+  END { print "$_ $e{$_}\n" for sort keys %e }
+' "$SCRATCH/refs-before.txt" | sort > "$SCRATCH/refs-expected.txt"
+diff "$SCRATCH/refs-expected.txt" "$SCRATCH/refs-after.txt" && echo COUNTS-OK
+```
+
+Expected: `COUNTS-OK` (empty diff).
+
+(c) Header list must equal exactly:
+
+```bash
+grep -E "^#{1,4} " docs/architecture/tuner/mpe-tuner-paper.md
+```
+
+```
+# MPE Tuner: A MIDI Polyphonic Expression Approach to Microtonal Intonation
+## 1. Introduction
+### 1.1 Motivation
+### 1.2 Scope and Definitions
+### 1.3 Control Dimensions
+### 1.4 Overview of Operation
+## 2. Background: The MPE Specification
+### 2.1 Zones, Master Channels, and Member Channels
+### 2.2 Per-Note Control via Channel Assignment
+### 2.3 Pitch Bend Sensitivity
+### 2.4 Channel Allocation Recommendations
+### 2.5 Note On Setup and Message Ordering
+### 2.6 Zone-Level Messages
+### 2.7 Pressure
+## 3. MPE Tuner Architecture
+### 3.1 Signal Flow
+### 3.2 Input Modes
+### 3.3 Non-MPE to MPE Conversion
+### 3.4 Master Channel Forwarding
+## 4. Configuration
+### 4.1 Input Mode
+### 4.2 Zones
+### 4.3 Pitch Bend Sensitivity
+## 5. Allocation of Notes to Member Channels
+### 5.1 Fundamental Invariant
+### 5.2 Dual-Group Channel Partitioning
+### 5.3 Group Size Allocation
+### 5.4 High Expression Pitch Bend
+### 5.5 Allocation Algorithm
+### 5.6 Expression Value Computation for Shared Channels
+### 5.7 Comparison with Standard MPE Allocation
+#### 5.7.1 Channel Sharing Before Exhaustion
+#### 5.7.2 Prioritizing Intonation Over Note Preservation
+#### 5.7.3 Gentle Degradation via Averaging
+#### 5.7.4 Same Note Number on Multiple Channels
+#### 5.7.5 Master Channel Pitch Bend
+## 6. Dropping Notes and Freeing Channels
+### 6.1 Dropping Notes Due to Channel Exhaustion
+### 6.2 Dropping Notes Due to High Expression Pitch Bend
+#### 6.2.1 Divergence on a Shared Channel
+#### 6.2.2 New Note with High Expression Pitch Bend on an Occupied Channel
+#### 6.2.3 New Note Assigned to a Channel with a High-Bend Note
+### 6.3 Summary of Note-Dropping Invariants
+## 7. Expression Value Processing
+### 7.1 Aggregation Model
+#### 7.1.1 Message Ordering
+### 7.2 MPE Input Mode
+### 7.3 Non-MPE Input Mode
+### 7.4 Channel Pressure Reset at Note Off
+## 8. Real-Time Tuning Changes
+## 9. Worked Examples
+### 9.1 Basic Allocation in Quarter-Comma Meantone
+### 9.2 Tuning Change During Performance
+### 9.3 Note Dropping Under Channel Exhaustion
+## 10. Summary
+## References
+## Appendix A: Channel Group Allocation Table
+```
+
+- [ ] **Step 6: Note stale sibling docs (do not fix — out of scope per the design)**
+
+```bash
+rtk proxy grep -rn "mpe-tuner-paper" --include="*.md" issues/ docs/ | grep -v 00154
+```
+
+Known stale citations (record in the PR description, leave unfixed):
+`issues/00202-pbs-non-mpe-input/pbs-non-mpe-and-mcm-test-mode-plan.md` (stale path + `§3.3.2` numbering)
+and `issues/00143-add-mpe-tuner/plan.md` (stale path).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/architecture/tuner/mpe-tuner-paper.md
+git commit -m "[#154] Renumber sections and cross-references after config reorg"
+```
+
+---
+
+### Task 8: Final read-through and quote integrity check
+
+**Files:**
+- Read: `docs/architecture/tuner/mpe-tuner-paper.md` (whole file)
+
+- [ ] **Step 1: Verify the design's key quotes survived intact**
+
+Expected occurrence counts (the "combine" quote legitimately lives in both 2.2 and 5.7.5):
+
+```bash
+for q in \
+  "control of a note ceases once Note Off has occurred" \
+  "it must combine the data meaningfully" \
+  "to all Member Channels in the Zone" \
+  "wherever it is appropriate to the design of a controller" \
+  "treated as a Note Off"; do
+  printf '%-60s %s\n' "$q" "$(grep -c "$q" docs/architecture/tuner/mpe-tuner-paper.md)"
+done
+```
+
+Expected: count `1` for every quote, except `it must combine the data meaningfully` → `2`.
+
+- [ ] **Step 2: Read the full paper top to bottom**
+
+Check: every `Section N` reference resolves to a section whose content matches the sentence's intent
+(spot-check especially: all `Section 4`/`4.x` references now mean Configuration, all `Section 5`/`5.x`
+mean Allocation); the new Section 4 reads as one coherent section; no doubled blank lines or stray `---`
+around the deleted Section 8; Appendix A untouched.
+
+- [ ] **Step 3: Commit fixes if any were needed; otherwise done**
+
+If the read-through surfaced fixes: commit as
+`[#154] Fix renumbering fallout found in final read-through`. Otherwise no commit — the branch is ready
+for PR (use the `contributing` skill when opening it).

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -78,7 +78,8 @@ git commit -m "[#154] Resolve review findings in config reorg design spec; add i
 Removes Section 3.3 (Zones) from the Architecture chapter, inserts the new Configuration section between
 Section 3 and Section 4, and repoints the seven surviving `Section 3.3` references (the other two die
 with Section 8 in Task 6). Also repoints the `(Section 8)` reference in 3.4 item 4 to the new PBS
-subsection.
+subsection. The C.1 text carries the design's one-way-switch decision — MCMs that deactivate all Zones
+no longer revert the Tuner to Non-MPE Input Mode — the reorg's one deliberate behavior change.
 
 **Files:**
 - Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
@@ -139,22 +140,24 @@ The MPE Tuner's operation is governed by three configuration parameters, establi
 
 ### C.1 Input Mode
 
-Section 3.2 defines the two input modes; this subsection specifies how the operating mode is selected. The input mode may be set through the non-MIDI configuration interface, or switched in-band by the input stream itself (Section 3.1): upon receiving a valid MCM, the Tuner switches to MPE Input Mode if it is not already in it. Conversely, when MCMs deactivate all Zones, MPE operation is off [1, §2.1]; the Tuner then reverts to Non-MPE Input Mode, restoring the output Zone configuration provided through the configuration interface (Section C.2).
+Section 3.2 defines the two input modes; this subsection specifies how the operating mode is selected. The input mode may be set through the non-MIDI configuration interface, or switched in-band by the input stream itself (Section 3.1): upon receiving a valid MCM, the Tuner switches to MPE Input Mode if it is not already in it. The in-band switch is one-way: no MCM returns the Tuner to Non-MPE Input Mode, which is re-entered only through the non-MIDI configuration interface.
+
+MCMs that deactivate all Zones are no exception: they too switch the Tuner to MPE Input Mode if necessary, and they turn MPE operation off [1, §2.1]. The Zone configuration is shared by the input and the output (Section C.2), so all Zones being deactivated leaves the output without MPE as well; the deactivation is mirrored on the output like any other Zone change (Section C.2), and the Tuner produces no note output until a Zone is re-activated, by a subsequent MCM or through the non-MIDI configuration interface.
 
 ### C.2 Zones
 
-The MPE Tuner has one Zone configuration, shared by its input and its output: the number of Member Channels allocated to the Lower Zone and, optionally, to the Upper Zone. As in the MPE Specification, one or two Zones may be defined. The role this shared configuration plays depends on the input mode:
+The MPE Tuner maintains a single Zone configuration shared by its input and its output — not separate input and output configurations: the number of Member Channels allocated to the Lower Zone and, optionally, to the Upper Zone. As in the MPE Specification, one or two Zones may be defined. The role this shared configuration plays depends on the input mode:
 
 - In **MPE Input Mode**, the Zone configuration applies to both input and output: the Tuner expects the input stream to be organized according to the configured Zones, and produces output organized by the same Zones. Notes received on the Member Channels of an input Zone are allocated to Member Channels of the same output Zone.
 - In **Non-MPE Input Mode**, the input has no Zone structure, so the Zone configuration affects the output only. Furthermore, only one Zone is accessible from the output: input notes are routed exclusively to the Lower Zone if it is enabled, otherwise to the Upper Zone. When two Zones are defined, the Upper Zone is ignored. This restriction prevents ambiguity in channel allocation and zone-level message routing when the input carries no Zone information of its own.
 
-Beyond the non-MIDI configuration interface, the Zone configuration may be changed in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. A valid MCM — which also switches the Tuner to MPE Input Mode if necessary (Section C.1) — reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1].
+Beyond the non-MIDI configuration interface, the Zone configuration may be changed in-band, through an MCM received on a Master Channel. Conforming to the MPE Specification, an MCM received on any channel other than a Master Channel is invalid and is ignored [1, §2.1.1]. A valid MCM — which also switches the Tuner to MPE Input Mode if it is not already in it (Section C.1) — reconfigures the addressed Zone to the received number of Member Channels, applying the specification's rules: an MCM with zero Member Channels deactivates the Zone, and channels claimed from the other Zone are reassigned to the Zone configured most recently [1, §2.1.1]. An MCM that deactivates all Zones suspends MPE operation altogether (Section C.1).
 
 The Tuner emits the MCM(s) describing its Zone configuration at start-up, and again whenever the configuration changes — through either mechanism — so that the receiving instrument adopts the same Zone structure. A reconfiguration also resets the Tuner's state for every channel entering or leaving MPE control, mirroring the receiver obligations of the MPE Specification [1, §2.1.4]: active notes on the affected channels are dropped, the channels' group assignments (Section 4.2) are cleared, the retained Expression Values and remembered input-channel control values (Section 6) return to their defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64 — and Pitch Bend Sensitivity returns to the specification's defaults of ±48 semitones on Member Channels and ±2 semitones on the Master Channel (Section C.3). Channels of a Zone untouched by the reconfiguration keep their notes and state. For the dropped notes, an implementation may either emit no Note Off messages — relying on the downstream receiver's obligation to stop ongoing notes upon receiving the MCM [1, §2.1.4] — or emit explicit Note Off messages before the MCM, for robustness with receivers that do not fully conform; the choice is left to the implementer.
 
 ### C.3 Pitch Bend Sensitivity
 
-The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The defaults exist independently of any particular message; the MPE Tuner relies on them both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output.
+The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The MPE Tuner relies on these defaults both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output.
 
 The Tuner also listens for Pitch Bend Sensitivity messages (RPN 00 00) on its input and conforms to them when interpreting incoming Pitch Bend. How a received message propagates to the output depends on the input mode:
 
@@ -171,23 +174,26 @@ The Tuner also listens for Pitch Bend Sensitivity messages (RPN 00 00) on its in
   Member Channels retain the specification's default of ±48 semitones, which can be changed only through the
   non-MIDI configuration interface.
 
-One limitation follows from the reset semantics. When MCMs deactivate all Zones and the Tuner reverts to Non-MPE Input Mode (Section C.1), the restore of the configured Zone structure emits MCM(s) only; the Pitch Bend Sensitivity of every channel entering or leaving MPE control — on the receiving instrument, per its reset obligations [1, §2.1.4], and in the Tuner's own interpretation alike — returns to the defaults. A non-default Member Channel sensitivity previously provided through the non-MIDI configuration interface is not re-applied automatically: it takes effect again only when the non-MIDI configuration is next applied. Until then, the output Member Channels' sensitivity stands at the default ±48 semitones and, as stated above, cannot be changed over MIDI in Non-MPE Input Mode.
-
 ---
 
 ## 4. Allocation of Notes to Member Channels
 ```
 
-Notes against the design spec: the C.2 text keeps every 3.3 fact; the mode-switching clauses move to
-C.1; the dual-source sentence generalizes into the C preamble; the `(Section 8)` cross-reference is
-dropped and replaced by the absorbed start-up-MCM fact (inventory fact 2); PBS joins the reconfiguration
-reset list; C.3 carries inventory facts 6–9 and 11 with the causality corrected, the `n²` bullet verbatim
-(only "the MCM's default of ±48 semitones" becomes "the specification's default of ±48 semitones"), and
-the limitation in its stronger, MCM-only-revert form.
+Notes against the design spec: the C.2 text keeps every 3.3 fact except the revert clause, which the
+design's one-way-switch decision replaces in C.1 (the reorg's one deliberate behavior change), and
+clarifies the opening sentence (a single shared Zone *configuration*, not a single Zone); the remaining
+mode-switching clauses move to C.1; the dual-source sentence generalizes into the C preamble; the
+`(Section 8)` cross-reference is dropped and replaced by the absorbed start-up-MCM fact (inventory
+fact 2); PBS joins the reconfiguration reset list; C.3 carries inventory facts 6–9 and 11 with the
+causality corrected and the `n²` bullet verbatim (only "the MCM's default of ±48 semitones" becomes "the
+specification's default of ±48 semitones") — the revert-path limitation paragraph is gone with the
+revert itself.
 
 - [ ] **Step 3: Repoint the seven surviving `Section 3.3` references**
 
-Seven `Edit` operations (fragments are unique after Step 1):
+Seven `Edit` operations (fragments are unique after Step 1). The overview sentences in 1.4 and 3.1
+item 1 stay unconditionally true under the design's one-way-switch decision, so edits 1 and 2 are plain
+repoints:
 
 1. Section 1.4 — Remove: `reconfigure its Zones accordingly (Section 3.3).`
    Add: `reconfigure its Zones accordingly (Section C).`

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -302,12 +302,12 @@ references.
 **Files:**
 - Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
 
-- [ ] **Step 1: Retitle 3.5**
+- [x] **Step 1: Retitle 3.5**
 
 Remove: `### 3.5 Master Channel Note Forwarding`
 Add: `### 3.5 Master Channel Forwarding`
 
-- [ ] **Step 2: Absorb the Pitch Bend mechanic and Zone-level messages; widen the closing line**
+- [x] **Step 2: Absorb the Pitch Bend mechanic and Zone-level messages; widen the closing line**
 
 Position: end of 3.5, after rationale item 3, replacing the current closing paragraph.
 
@@ -336,7 +336,7 @@ Channel regardless of the input channel number, and the input's channel-global c
 the output Master Channel by *redirection* instead, under the conversion rules of Section 3.4, items 2 and 4.
 ```
 
-- [ ] **Step 3: Split 4.7.5 — mechanic out, argument and quote stay**
+- [x] **Step 3: Split 4.7.5 — mechanic out, argument and quote stay**
 
 Remove:
 
@@ -352,7 +352,7 @@ Master Channel Pitch Bend is forwarded without modification, as part of Master C
 
 Do **not** touch 4.7.4.
 
-- [ ] **Step 4: Repoint 3.4 item 4's two `Section 8.2` references**
+- [x] **Step 4: Repoint 3.4 item 4's two `Section 8.2` references**
 
 Remove:
 
@@ -368,14 +368,14 @@ Add:
    Section 3.5's forwarding could operate;
 ```
 
-- [ ] **Step 5: Verify**
+- [x] **Step 5: Verify**
 
 ```bash
 grep -c "Master Channel Note Forwarding" docs/architecture/tuner/mpe-tuner-paper.md  # expect 0
 grep -c "Section 8.2" docs/architecture/tuner/mpe-tuner-paper.md                     # expect 0 (8.2's own heading doesn't match)
 ```
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add docs/architecture/tuner/mpe-tuner-paper.md

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -650,7 +650,7 @@ change. Take a reference-count snapshot first — it is the verification baselin
 **Interfaces:**
 - Consumes: the C-sentinel sections and references produced by Tasks 2–6.
 
-- [ ] **Step 1: Snapshot reference counts (before)**
+- [x] **Step 1: Snapshot reference counts (before)**
 
 ```bash
 SCRATCH=/private/tmp/claude-501/-Users-calinburloiu-Development-microtonalist/fbfe8223-7c10-46fd-89b0-082b5a5e89c1/scratchpad
@@ -662,7 +662,7 @@ count_refs "$PAPER" > "$SCRATCH/refs-before.txt"
 cat "$SCRATCH/refs-before.txt"
 ```
 
-- [ ] **Step 2: Hand-fix the three plural constructs**
+- [x] **Step 2: Hand-fix the three plural constructs**
 
 The sweep regex renumbers only the first number after `Section(s)`; the paper's three
 `(Sections 5.2.2 and 5.2.3)` constructs get explicit edits to their **target** numbers first. This is
@@ -671,7 +671,7 @@ safe: `6.2.2`/`6.2.3` are not keys of the sweep map, so Step 3 will not re-map t
 Edit (replace_all): Remove `(Sections 5.2.2 and 5.2.3)` → Add `(Sections 6.2.2 and 6.2.3)`
 (3 occurrences: Section 4.5 algorithm step 3, Section 5 preamble, Section 5.2 preamble).
 
-- [ ] **Step 3: Run the sweep (references + headers, one pass each)**
+- [x] **Step 3: Run the sweep (references + headers, one pass each)**
 
 One-pass hash map — no chained replacements possible. Slurp mode (`-0777`) so line-wrapped references
 (e.g. `Section\n4.6`) are caught, preserving the whitespace.
@@ -695,7 +695,7 @@ Map notes: `3.3` is deliberately **absent** (no `Section 3.3` text remains after
 slide down to fill Zones' slot). `[1, §N]` citations never match (`Section` prefix required; headers
 carry no `§`).
 
-- [ ] **Step 4: Run the C → 4 pass**
+- [x] **Step 4: Run the C → 4 pass**
 
 ```bash
 perl -0777 -pi -e '
@@ -706,7 +706,7 @@ perl -0777 -pi -e '
 ' docs/architecture/tuner/mpe-tuner-paper.md
 ```
 
-- [ ] **Step 5: Verify — greps, count diff, header list**
+- [x] **Step 5: Verify — greps, count diff, header list**
 
 (a) No dangling sentinels or dissolved-section references, and no references to numbers that no longer
 exist (`Section 3.5` and `Section 4.7*` have no post-reorg referent):
@@ -811,7 +811,7 @@ grep -E "^#{1,4} " docs/architecture/tuner/mpe-tuner-paper.md
 ## Appendix A: Channel Group Allocation Table
 ```
 
-- [ ] **Step 6: Note stale sibling docs (do not fix — out of scope per the design)**
+- [x] **Step 6: Note stale sibling docs (do not fix — out of scope per the design)**
 
 ```bash
 rtk proxy grep -rn "mpe-tuner-paper" --include="*.md" issues/ docs/ | grep -v 00154
@@ -821,7 +821,7 @@ Known stale citations (record in the PR description, leave unfixed):
 `issues/00202-pbs-non-mpe-input/pbs-non-mpe-and-mcm-test-mode-plan.md` (stale path + `§3.3.2` numbering)
 and `issues/00143-add-mpe-tuner/plan.md` (stale path).
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add docs/architecture/tuner/mpe-tuner-paper.md

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -835,7 +835,7 @@ git commit -m "[#154] Renumber sections and cross-references after config reorg"
 **Files:**
 - Read: `docs/architecture/tuner/mpe-tuner-paper.md` (whole file)
 
-- [ ] **Step 1: Verify the design's key quotes survived intact**
+- [x] **Step 1: Verify the design's key quotes survived intact**
 
 Expected occurrence counts (the "combine" quote legitimately lives in both 2.2 and 5.7.5):
 
@@ -852,14 +852,14 @@ done
 
 Expected: count `1` for every quote, except `it must combine the data meaningfully` → `2`.
 
-- [ ] **Step 2: Read the full paper top to bottom**
+- [x] **Step 2: Read the full paper top to bottom**
 
 Check: every `Section N` reference resolves to a section whose content matches the sentence's intent
 (spot-check especially: all `Section 4`/`4.x` references now mean Configuration, all `Section 5`/`5.x`
 mean Allocation); the new Section 4 reads as one coherent section; no doubled blank lines or stray `---`
 around the deleted Section 8; Appendix A untouched.
 
-- [ ] **Step 3: Commit fixes if any were needed; otherwise done**
+- [x] **Step 3: Commit fixes if any were needed; otherwise done**
 
 If the read-through surfaced fixes: commit as
 `[#154] Fix renumbering fallout found in final read-through`. Otherwise no commit — the branch is ready

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -235,7 +235,7 @@ git commit -m "[#154] Extract Configuration into a dedicated section (reorg WI1)
 **Files:**
 - Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
 
-- [ ] **Step 1: Add the velocity-0 convention to the Section 4 preamble**
+- [x] **Step 1: Add the velocity-0 convention to the Section 4 preamble**
 
 Position: Section 4, end of the scoping paragraph, before `### 4.1 Fundamental Invariant`. Phrased as a
 global convention (it also governs Section 6's averaging), one sentence, no block quote, no
@@ -259,7 +259,7 @@ Throughout this paper, a Note On with velocity 0 is treated as a Note Off [1, §
 ### 4.1 Fundamental Invariant
 ```
 
-- [ ] **Step 2: Add the channel-reuse rule to 4.2 Dual-Group Channel Partitioning**
+- [x] **Step 2: Add the channel-reuse rule to 4.2 Dual-Group Channel Partitioning**
 
 Position: 4.2, end of the group-assignment paragraph — the reuse rule is the same occupancy lifecycle as
 the persistence rule, stated from the other end.
@@ -277,14 +277,14 @@ determined at the moment a note is placed on it and persists for the lifetime of
 channel becomes available for reuse once all its notes have received Note Off messages.
 ```
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 ```bash
 grep -c "velocity 0" docs/architecture/tuner/mpe-tuner-paper.md          # expect 2 (new + 8.3; 8.3 dies in Task 6)
 grep -c "available for reuse" docs/architecture/tuner/mpe-tuner-paper.md # expect 2 (same)
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add docs/architecture/tuner/mpe-tuner-paper.md

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -392,7 +392,7 @@ Adds the Note Off removal rule to 6.1, creates 6.1.1 Message Ordering, repoints 
 **Files:**
 - Modify: `docs/architecture/tuner/mpe-tuner-paper.md`
 
-- [ ] **Step 1: Add the Note Off removal rule to 6.1**
+- [x] **Step 1: Add the Note Off removal rule to 6.1**
 
 Position: 6.1, between the averaging paragraph and the retention paragraph (the removal rule is why the
 retention rule has a moment to apply). The `(Section 6.1)` self-reference from the 8.3 original is
@@ -418,12 +418,12 @@ averages, consistent with the specification's statement that "control of a note 
 When the last active note
 ```
 
-- [ ] **Step 2: Repoint 6.1's omission-optimization reference**
+- [x] **Step 2: Repoint 6.1's omission-optimization reference**
 
 Remove: `the values the channel already holds (Section 8.1).`
 Add: `the values the channel already holds (Section 6.1.1).`
 
-- [ ] **Step 3: Insert 6.1.1 Message Ordering**
+- [x] **Step 3: Insert 6.1.1 Message Ordering**
 
 Position: end of 6.1, before `### 6.2`. The trailing "In particular, in Non-MPE Input Mode CC #74 is
 never emitted…" sentence of 8.1 is **not** carried over (restatement of 6.3 and 3.4 item 3).
@@ -457,12 +457,12 @@ An implementation may omit any of the three control dimension messages whose val
 ### 6.2 MPE Input Mode
 ```
 
-- [ ] **Step 4: Repoint 6.3's `Section 8.1` reference**
+- [x] **Step 4: Repoint 6.3's `Section 8.1` reference**
 
 Remove: `the dimension is thus controllable only globally (Section 8.1).`
 Add: `the dimension is thus controllable only globally (Section 3.4, item 3).`
 
-- [ ] **Step 5: Insert 6.4 Channel Pressure Reset at Note Off**
+- [x] **Step 5: Insert 6.4 Channel Pressure Reset at Note Off**
 
 Position: end of Section 6, after 6.3's last paragraph, before the `---` + `## 7.` boundary. Verbatim
 move of the 8.3 paragraph (working-tree wording).
@@ -496,7 +496,7 @@ Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode bo
 ## 7. Real-Time Tuning Changes
 ```
 
-- [ ] **Step 6: Verify**
+- [x] **Step 6: Verify**
 
 ```bash
 grep -c "Section 8.1" docs/architecture/tuner/mpe-tuner-paper.md   # expect 1 (3.4 item 3; fixed in Task 6)
@@ -504,7 +504,7 @@ grep -c "^#### 6.1.1" docs/architecture/tuner/mpe-tuner-paper.md   # expect 1
 grep -c "^### 6.4" docs/architecture/tuner/mpe-tuner-paper.md      # expect 1
 ```
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add docs/architecture/tuner/mpe-tuner-paper.md

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -89,7 +89,7 @@ no longer revert the Tuner to Non-MPE Input Mode — the reorg's one deliberate 
   `### C.3 Pitch Bend Sensitivity`; consumed by Task 7's `C → 4` pass. Task 6's coherence sentence
   references `Section C`.
 
-- [ ] **Step 1: Remove Section 3.3 Zones**
+- [x] **Step 1: Remove Section 3.3 Zones**
 
 Position: Section 3, between 3.2 and 3.4.
 
@@ -116,7 +116,7 @@ Add:
 ### 3.4 Non-MPE to MPE Conversion
 ```
 
-- [ ] **Step 2: Insert the Configuration section**
+- [x] **Step 2: Insert the Configuration section**
 
 Position: between the end of Section 3 (after 3.5) and Section 4, i.e. anchored on the `---` +
 `## 4. Allocation of Notes to Member Channels` boundary.
@@ -189,7 +189,7 @@ causality corrected and the `n²` bullet verbatim (only "the MCM's default of ±
 specification's default of ±48 semitones") — the revert-path limitation paragraph is gone with the
 revert itself.
 
-- [ ] **Step 3: Repoint the seven surviving `Section 3.3` references**
+- [x] **Step 3: Repoint the seven surviving `Section 3.3` references**
 
 Seven `Edit` operations (fragments are unique after Step 1). The overview sentences in 1.4 and 3.1
 item 1 stay unconditionally true under the design's one-way-switch decision, so edits 1 and 2 are plain
@@ -212,7 +212,7 @@ repoints:
    Remove: `is redirected (Section 8).`
    Add: `is redirected (Section C.3).`
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 ```bash
 grep -c "Section 3.3" docs/architecture/tuner/mpe-tuner-paper.md   # expect 1 (Section 8 intro; dies in Task 6)
@@ -221,7 +221,7 @@ grep -c "^## C\. Configuration" docs/architecture/tuner/mpe-tuner-paper.md  # ex
 grep -c "(Section 8)" docs/architecture/tuner/mpe-tuner-paper.md   # expect 0
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add docs/architecture/tuner/mpe-tuner-paper.md

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md
@@ -51,19 +51,19 @@ as two separate commits.
 - Produces: a clean working tree whose paper text is the baseline every `Remove:` block in Tasks 2–7
   matches.
 
-- [ ] **Step 1: Verify the expected diff**
+- [x] **Step 1: Verify the expected diff**
 
 Run: `git status --short && git diff --stat`
 Expected: exactly the three files above modified/untracked, nothing else.
 
-- [ ] **Step 2: Commit the paper citation fixes**
+- [x] **Step 2: Commit the paper citation fixes**
 
 ```bash
 git add docs/architecture/tuner/mpe-tuner-paper.md
 git commit -m "[#154] Use [1, §N] citation form for in-prose MPE spec references"
 ```
 
-- [ ] **Step 3: Commit the design spec update and this plan**
+- [x] **Step 3: Commit the design spec update and this plan**
 
 ```bash
 git add issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md \

--- a/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-report.md
+++ b/issues/00154-mpe-tuner-poly-expr/paper-config-reorg-report.md
@@ -1,0 +1,442 @@
+# Report: Dissolving Section 8 "MPE Tuner Output Conformance"
+
+**Target document:** `docs/architecture/tuner/mpe-tuner-paper.md`
+
+**Citations pinned at:** commit `44b7030` (`[#154] Apply paper review fixes (M1-M3, S1-S6) to MPE Tuner
+paper (#240)`) — the last commit that touched the paper. Report written with `HEAD` at `fa4e5d6`, working
+tree clean for the paper.
+
+**Purpose:** input for a future prompt that performs the reorganization. This report records *what moves
+where and why*; it is not itself the edit.
+
+**Referencing convention:** sections are identified by **number and name**. If numbering has drifted since
+`44b7030`, the name is authoritative. Quoted paper text is verbatim at `44b7030` and can be located by
+searching for the quote. No line numbers are used anywhere in this report, by design.
+
+---
+
+## Verdict
+
+Section 8 ("MPE Tuner Output Conformance") is **dissolved entirely**. Sections 9 and 10 renumber to 8 and 9.
+
+The section is not wrong to exist so much as wrong about what it contains. It tries to be two things at
+once: an *output message contract* and a *conformance checklist against RP-053*. The checklist job is what
+drags input-side material into a section titled "Output Conformance" — you cannot claim conformance on Zone
+Configuration without describing how the Zone was obtained. The paper is otherwise sectioned by
+**pipeline stage** (input → allocation → tuning/expression → output); Section 8 is sectioned by **topic**,
+and the topic axis lost.
+
+Nothing is deleted that is not a verifiable restatement of text elsewhere in the paper. Section
+["Facts inventory"](#facts-inventory) below is the completeness guarantee: every fact in Section 8 is
+listed with a destination or a justification for deletion.
+
+---
+
+## Target structure
+
+| Current | Becomes |
+|---|---|
+| 3.2 Input Modes | unchanged (taxonomy of the two modes) |
+| 3.3 **Zones** | 3.3 **Configuration** — with 3.3.1 Input Mode, 3.3.2 Zones, 3.3.3 Pitch Bend Sensitivity |
+| 3.4 Non-MPE to MPE Conversion | unchanged in scope; cross-refs repointed |
+| 3.5 **Master Channel Note Forwarding** | 3.5 **Master Channel Forwarding** — notes, Pitch Bend, Zone-level controls |
+| 4 preamble | gains the velocity-0 convention |
+| 4.2 Dual-Group Channel Partitioning | gains the channel-reuse rule |
+| 4.7.5 Master Channel Pitch Bend | keeps its argument; forwarding mechanic moves to 3.5 |
+| 6.1 Aggregation Model | gains Note Off removal + `[1, §3.3.3]`; new **6.1.1 Message Ordering** |
+| **8 MPE Tuner Output Conformance** | **removed** |
+| 9 Worked Examples | 8 |
+| 10 Summary | 9 |
+
+---
+
+## Work item 1 — Repurpose Section 3.3 "Zones" → "Configuration"
+
+### Rationale
+
+Section 3.3 already states the dual-source configuration model:
+
+> "The Zone configuration may be established and changed in two ways: through the non-MIDI configuration
+> interface, or in-band, through an MPE Configuration Message (MCM) received on a Master Channel."
+
+That pattern is **not Zone-specific** — it is the Tuner's configuration model, and Input Mode and Pitch
+Bend Sensitivity follow the identical shape (non-MIDI interface establishes a base; MIDI messages override
+it in-band, with per-parameter limitations). A separate section for PBS would re-explain the same model a
+second time in parallel for one parameter. State the model once; list the parameters it governs.
+
+### Structure
+
+Section 3.3 becomes **"Configuration"** with a short preamble stating the general model, then:
+
+- **3.3.1 Input Mode**
+- **3.3.2 Zones**
+- **3.3.3 Pitch Bend Sensitivity**
+
+The preamble carries what is common to all three: the Tuner is configured through a **non-MIDI
+configuration interface**; the MPE Specification defines **defaults** for these parameters; a user may
+**override** the non-MIDI configuration in-band via MCM and RPN 00 00 messages, subject to per-parameter
+limitations stated in the subsections.
+
+Sub-subsectioning is required here, not cosmetic: 3.3 is already two dense paragraphs, and it is absorbing
+PBS's mode-split plus the defaults model.
+
+### 3.3.1 Input Mode
+
+Section 3.2 ("Input Modes") keeps defining **what the modes are**; 3.3.1 defines **how the mode is
+selected**. This mirrors the existing split between Section 2.1 (what Zones are) and 3.3 (how the Tuner's
+Zones are configured).
+
+This subsection is nearly free — Section 3.3 already contains the mode-switching rules. Naming Input Mode
+as a configuration parameter labels what is already there. Facts to gather:
+
+- Set via the non-MIDI configuration interface (from Section 1.4 "Overview of Operation" and Section 3.1
+  "Signal Flow", item 1 *Input Mode Detection*).
+- Receipt of a valid MCM switches to MPE Input Mode (already in 3.3).
+- MCMs deactivating all Zones revert to Non-MPE Input Mode, "restoring the output Zone configuration
+  provided through the configuration interface" (already in 3.3).
+
+### 3.3.2 Zones
+
+Keeps **all** existing Section 3.3 Zone facts, unchanged in substance:
+
+- One Zone configuration shared by input and output; role per input mode.
+- Non-MPE Input Mode: output only, single Zone (Lower if enabled, else Upper); Upper ignored when two are
+  defined.
+- MCM validity rules `[1, §2.1.1]`, zero-Member-Channel deactivation, channel stealing by most-recent MCM.
+- Output MCM emission on every Zone change.
+- Reconfiguration state reset (dropped notes, cleared group assignments, Expression Value defaults).
+- The Note Off emission choice for dropped notes.
+
+**Add:** MCMs are emitted **at start-up** as well as on reconfiguration. This is the one genuinely new fact
+in the Section 8 "Zone Configuration" bullet; everything else in that bullet restates 3.3.
+
+### 3.3.3 Pitch Bend Sensitivity
+
+This is the substantive addition. Section 8's PBS bullet is the **only** place in the paper specifying how
+the Tuner interprets incoming PBS; it must not be lost.
+
+**Fix the causality.** Section 8 currently says:
+
+> "the MPE Tuner relies on the default Pitch Bend Sensitivity values that the MCM establishes — ±48
+> semitones for Member Channels and ±2 semitones for the Master Channel [1, §2.4]."
+
+This inverts the relationship, and the paper's own background section proves it. Section 2.3 ("Pitch Bend
+Sensitivity") states:
+
+> "Upon receiving an MCM, a receiver must set: **Master Channel Pitch Bend Sensitivity**: ±2 semitones
+> (default). **Member Channel Pitch Bend Sensitivity**: ±48 semitones (default). These values may be
+> changed via RPN 0."
+
+And Section 2.1 ("Zones, Master Channels, and Member Channels"):
+
+> "When a Zone configuration changes, receivers are required to stop all ongoing notes and to reset all
+> controls to reasonable default values on each channel entering or leaving MPE control [1, §2.1.4]."
+
+The defaults are **spec-defined properties of MPE**; the MCM is the **reset trigger** that applies them.
+Write 3.3.3 in that direction: the defaults exist independently, and an MCM resets PBS to them.
+
+**Facts to carry over from Section 8's PBS bullet:**
+
+- Defaults: ±48 semitones Member Channels, ±2 semitones Master Channel `[1, §2.4]`.
+- The Tuner listens for RPN 00 00 on its input and conforms to it when interpreting incoming Pitch Bend.
+- **MPE Input Mode:** a sensitivity received on any input Member Channel applies Zone-wide, per the quote
+  Section 8 already carries — *"[a] receiver must apply the last Pitch Bend Sensitivity message received on
+  any Member Channel to all Member Channels in the Zone"* `[1, §2.4]`. On output the Tuner **mirrors the
+  input**, forwarding each received message on its corresponding output Member Channel, and does *not*
+  fan out. Keep the **`n²` flood rationale** verbatim in substance: a conforming MPE sender already
+  addresses the message to each of the `n` Member Channels `[1, §2.4]`, so re-fanning `n` messages to `n`
+  channels would produce an `n²` flood; per-channel forwarding already configures every output Member
+  Channel.
+- **Non-MPE Input Mode:** the input carries no Member Channels; a received RPN 00 00 applies to the output
+  **Master Channel**, consistent with the redirection of the input's Pitch Bend there (Section 3.4). Output
+  Member Channels retain ±48, changeable **only** through the non-MIDI configuration interface.
+
+**Add: PBS to the reconfiguration reset list.** Section 3.3's reset enumeration currently reads:
+
+> "the retained Expression Values and remembered input-channel control values (Section 6) return to their
+> defaults — Expression Pitch Bend 0, Channel Pressure 0, and CC #74 64."
+
+PBS is absent, even though the cited obligation `[1, §2.1.4]` is to reset **all** controls, and Section 2.3
+names PBS explicitly as MCM-reset. Add PBS (±48 Member / ±2 Master) to that list.
+
+### Decided: MCM/PBS emission ordering is a non-issue
+
+An earlier draft of this analysis raised a concern that the Tuner's own MCM emission would wipe a
+non-default configured Member PBS on the receiving instrument, requiring an RPN 00 00 re-emission after
+every MCM. **Decision: this is not an issue, and the paper need not specify a re-emission obligation.**
+Reasoning to preserve:
+
+- In **Non-MPE Input Mode**, the Tuner emits MCM **+** PBS only at start-up or when the non-MIDI
+  configuration changes, and it must emit both to completely configure the output. Correct configuration is
+  therefore true by construction — there is no window in which an MCM strands a configured PBS.
+- If an **MCM is received on the input** while in Non-MPE Input Mode, the Tuner will normally switch to MPE
+  Input Mode, and resetting PBS to defaults is correct. A user who sends an MCM does so intentionally, knows
+  an MCM resets PBS to defaults, and will send their own PBS values if they want others.
+
+### Known limitation to record (may warrant a sentence in the paper)
+
+**The empty-Zone MCM revert path.** When an MCM with zero Member Channels deactivates all Zones and the
+Tuner reverts to Non-MPE Input Mode, there is no way to set output **Member Channel PBS** over MIDI — in
+Non-MPE Input Mode the input has no Member Channel to receive RPN 00 00 on, and input PBS is redirected to
+the Master Channel. **Decision: accept this limitation.** Consider one sentence in 3.3.3 acknowledging it,
+so the constraint is documented rather than discovered.
+
+> **Open question for the drafting step.** Section 3.3 says the revert restores "the output Zone
+> configuration provided through the configuration interface", and Section 3.3 also requires an output MCM
+> "[w]henever the Zone configuration changes — through either mechanism". If that restore emits MCM **+**
+> PBS (the same pairing as start-up), the non-MIDI interface's Member PBS *is* re-applied and the
+> limitation reduces to the general Non-MPE one — the *performer* cannot change Member PBS over MIDI,
+> which is already stated. Decide whether the revert re-emits the PBS pair, and phrase the limitation to
+> match. This affects only the wording of the limitation, not any other work item.
+
+---
+
+## Work item 2 — Velocity-0 convention → Section 4 preamble
+
+Section 8.3 currently carries:
+
+> "A Note On with velocity 0 in the input is treated as a Note Off, following the MIDI 1.0 shorthand and
+> the specification's recommendation "that this message be interpreted as Note Off velocity 64"
+> [1, §3.3.2]. Recognizing the shorthand is essential: occupancy tracking, Expression Value averaging, and
+> channel reuse all depend on detecting note releases."
+
+**Placement.** Section 3.2 ("Input Modes") was considered and rejected: it is a taxonomy of the two modes,
+and a message-parsing rule has no business there. The rule is MIDI 1.0 baseline that any compliant device
+honors — not a Tuner design decision — so it needs to be stated once, early, and not argued.
+
+Destination: the **Section 4 ("Allocation of Notes to Member Channels") preamble**, the paragraph beginning:
+
+> "The allocation rules in this section apply to notes that are candidates for tuning via per-channel Pitch
+> Bend — that is, all notes received in Non-MPE Input Mode, and all notes received on a Member Channel in
+> MPE Input Mode."
+
+That paragraph is already a "how to read the rest of this section" scoping note; the register matches.
+
+**Phrasing constraints:**
+
+- Write it as a **global convention** — e.g. *"throughout this specification, a Note On with velocity 0 is
+  treated as a Note Off [1, §3.3.2]"* — **not** as an allocation-local rule. This matters: the fact also
+  governs Section 6's Expression Value averaging, and a global phrasing lets Section 6 inherit it without a
+  second mention.
+- **Drop the block quote**; a bracketed `[1, §3.3.2]` citation carries it.
+- **Drop** the "Recognizing the shorthand is essential: occupancy tracking, Expression Value averaging, and
+  channel reuse all depend on…" sentence. That is the section justifying its own existence — exactly the
+  padding this reorg removes. One sentence is enough.
+
+---
+
+## Work item 3 — Section 3.5 "Master Channel Note Forwarding" → "Master Channel Forwarding"
+
+### Rationale
+
+The same passthrough rule is currently stated in **three** places under different headings. The unifying
+axis is *Master Channel + passthrough*, not *notes + sender intent*:
+
+| Concern | Currently in | Text |
+|---|---|---|
+| Notes | 3.5 | "Note On and Note Off messages received on a Master Channel of an enabled Zone are forwarded on the same Master Channel without modification" |
+| Pitch Bend | 4.7.5 | "The MPE Tuner forwards Master Channel Pitch Bend as received, without modification." |
+| Zone-level controls | 8.2 | "Zone-level messages … are forwarded on the Master Channel without modification." |
+
+Retitle 3.5 to **"Master Channel Forwarding"** and let it own the mechanic for all three.
+
+### 3.5 keeps all current facts
+
+Nothing in the existing 3.5 is dropped. The note-specific material remains as the argument it already is,
+now scoped as one concern within a broader rule:
+
+- Master Channel notes bypass channel allocation; no Pitch Bend / CC #74 / Channel Pressure setup messages
+  are emitted for a Master Channel Note On.
+- Master Channel notes **do not receive a per-pitch-class tuning offset**; they sound in 12-EDO. Keep the
+  pitch-class-invariant explanation.
+- The threefold rationale: MPE Specification compliance, conservation of Member Channel resources,
+  preservation of Polyphonic Key Pressure compatibility.
+
+### 3.5 absorbs from 8.2 "Zone-Level Messages"
+
+> "Zone-level messages (Damper Pedal, Program Change, Reset All Controllers, and other messages listed in
+> Table 1 of the MPE Specification) are forwarded on the Master Channel without modification. The MPE Tuner
+> does not interpret or alter these messages."
+
+Move verbatim in substance. Section 2.6 ("Zone-Level Messages") already supplies the background, so this
+reads as the established background-then-behavior pattern.
+
+### 3.5 absorbs from 4.7.5 "Master Channel Pitch Bend" — without losing facts
+
+Section 4.7.5 currently reads:
+
+> "The MPE Tuner forwards Master Channel Pitch Bend as received, without modification. Master Pitch Bend is
+> not used by the Tuner in computing tuning offsets; it is a Zone-level expressive control, belonging
+> entirely to the performer. The Tuner's tuning offsets are applied exclusively through the Tuning Pitch
+> Bend component of Member Channel Pitch Bend."
+
+Split it:
+
+- **Moves to 3.5:** the bare mechanic — *forwards Master Channel Pitch Bend as received, without
+  modification*.
+- **Stays in 4.7.5:** the RP-053 quote (*"If an MPE synthesizer receives Pitch Bend on both a Master and a
+  Member Channel, it must combine the data meaningfully."* `[1, §2.3.2]`) **and** the argument — Master
+  Pitch Bend is a Zone-level expressive control belonging entirely to the performer, is not an input to
+  tuning, and tuning offsets are applied exclusively via the Tuning Pitch Bend component of Member Channel
+  Pitch Bend.
+
+This preserves both facts. Section 4.7 is "Comparison with Standard MPE Allocation" — the *argument* about
+why Master Pitch Bend is not a tuning input is a legitimate comparison point and belongs there; the
+*mechanic* does not. After the split, 4.7.5 keeps its quote and its point, and adds a cross-reference to
+3.5 for the mechanic.
+
+**Do not touch 4.7.4 ("Same Note Number on Multiple Channels").** It concerns the Expression Group and the
+bent-then-restruck pattern, and has no Master Channel forwarding content.
+
+### Widen the 3.5 closing line
+
+Current:
+
+> "In Non-MPE Input Mode the concept of a Master Channel does not apply to the input: every incoming note is
+> allocated to a Member Channel regardless of the input channel number."
+
+Once 3.5 covers Zone-level controls, this is too narrow — in Non-MPE Input Mode, Zone-level messages **do**
+reach the output Master Channel, via Section 3.4's redirection. The distinction to draw is
+**forwarding vs. redirection**: in Non-MPE Input Mode there is no input Master Channel to *forward from*,
+so Section 3.4 ("Non-MPE to MPE Conversion") item 4 *redirects* channel messages to the output Master
+Channel instead. Section 3.4 item 4 already makes exactly this point:
+
+> "Non-MPE input has no Master Channel of its own from which Section 8.2's forwarding could operate; this
+> redirection gives those messages their conformant Zone-level home on the output."
+
+After the reorg that sentence's reference resolves to 3.5, making 3.4 ↔ 3.5 a clean pairing. Keep the
+existing note-allocation clause; widen the surrounding statement to cover all three concerns.
+
+---
+
+## Work item 4 — Section 8.1 "Message Ordering" → new Section 6.1.1
+
+Section 6.1 ("Aggregation Model") already defers to 8.1 explicitly:
+
+> "Second, it enables an emission optimization: an implementation is not required to emit all three control
+> dimensions before a Note On — it may emit only those whose values differ from the values the channel
+> already holds (Section 8.1)."
+
+The retention rule is what **licenses** the omission optimization, so the two belong together. Create
+**6.1.1 "Message Ordering"** under Section 6.1 and move:
+
+- The emission order on the assigned Member Channel: **1. Pitch Bend, 2. CC #74, 3. Channel Pressure,
+  4. Note On**, with the `[1, §3.3.1]` citation and the rationale that the receiving instrument has correct
+  pitch and articulation state before the note sounds.
+- The omission rule: an implementation may omit any of the three control dimension messages whose value is
+  unchanged since its last emission on that output channel, relying on the state retention of 6.1. With
+  6.1.1 nested under 6.1, the cross-reference becomes local.
+
+**Delete as restatement:** the trailing "In particular, in Non-MPE Input Mode CC #74 is never emitted on a
+Member Channel…" — already stated in both Section 6.3 ("Non-MPE Input Mode") and Section 3.4 item 3.
+
+---
+
+## Work item 5 — Section 8.3 "Note Off Behavior" remainder
+
+Section 8.3 is dissolved. Its content:
+
+- **→ Section 6.1 "Aggregation Model":** the note is removed from its channel's Expression Value averages on
+  Note Off, with the `[1, §3.3.3]` quote — *"control of a note ceases once Note Off has occurred"*.
+- **→ Section 4.2 "Dual-Group Channel Partitioning":** "The channel becomes available for reuse once all its
+  notes have received Note Off messages." Place it next to the existing group-persistence rule:
+
+  > "The group assignment of a channel is determined at the moment a note is placed on it and persists for
+  > the lifetime of that channel's occupancy."
+
+  The two rules are the same occupancy lifecycle stated from opposite ends.
+- **→ Section 4 preamble:** the velocity-0 convention (Work item 2).
+- **Delete as restatement:** "While other notes remain active on the channel, the Tuner continues to update
+  the channel's Pitch Bend — for tuning changes (Section 7) as well as for Expression Value changes
+  (Section 6)." Already covered by Section 6.1's update-propagation rule and Section 7.
+
+---
+
+## Cross-references to repoint
+
+Every reference to Section 8 in the paper, with its resolution. Search for the parenthetical to locate each.
+
+| In section | Current reference | Action |
+|---|---|---|
+| 3.3 Zones | "the receiving instrument adopts the same Zone structure **(Section 8)**" | Drop the cross-reference; absorb the start-up MCM fact into 3.3.2. |
+| 3.4 item 3 (CC #74) | "never sends CC #74 on a Member Channel **(Sections 6.3 and 8.1)**" | → "(Section 6.3)" |
+| 3.4 item 4 | "where they act as Zone-level messages **(Section 8.2)**" | → Section 3.5 |
+| 3.4 item 4 | "Non-MPE input has no Master Channel of its own from which **Section 8.2's** forwarding could operate" | → Section 3.5's |
+| 3.4 item 4 | "the sensitivity of the Master Channel Pitch Bend to which the input's Pitch Bend is redirected **(Section 8)**" | → Section 3.3.3 |
+| 6.1 Aggregation Model | "it may emit only those whose values differ from the values the channel already holds **(Section 8.1)**" | → Section 6.1.1, or inline now that it is adjacent. |
+| 6.3 Non-MPE Input Mode | "the dimension is thus controllable only globally **(Section 8.1)**" | → Section 3.4 item 3 |
+
+**Renumbering:** Section 9 ("Worked Examples") → 8; Section 10 ("Summary") → 9. Check for any prose
+references to those numbers before renumbering. Appendix A is unaffected.
+
+**Sweep after editing:** grep the paper for `Section 8` and `§8` to confirm no dangling references survive.
+Also grep the repo outside the paper — `issues/00202-pbs-non-mpe-input/pbs-non-mpe-and-mcm-test-mode-plan.md`
+already cites the paper by a stale path and stale numbering (`docs/tuner/mpe-tuner-paper.md` §3.3.2), so
+other docs may cite Section 8 numbers too. Updating stale sibling docs is **out of scope** for the reorg
+unless trivially cheap; note them rather than fix them.
+
+---
+
+## Coherence risk to watch
+
+After dissolution, no single section says "here is what conformant output looks like." A reader wanting the
+output contract must assemble it from 3.3.3, 3.4, 3.5, and 6.1.1. **This is the real cost of dissolution**
+and it is accepted deliberately — the alternative (retitling Section 8 to "Output Message Contract" and
+keeping only 8.1 and 8.2) leaves a thin two-subsection section whose parts both have better homes.
+
+**Mitigation:** consider one compensating sentence in Section 1.4 ("Overview of Operation") or Section 10
+("Summary") noting where output conformance is specified. Section 1.4 already ends with the input-mode
+sentence and is the natural host. Optional — evaluate when drafting.
+
+---
+
+## Facts inventory
+
+Completeness guarantee. Every fact in Section 8 at `44b7030`, its status, and its destination. **New** =
+exists nowhere else in the paper and must not be lost. **Restatement** = verifiably duplicated elsewhere;
+safe to delete.
+
+| # | Fact | From | Status | Destination |
+|---|---|---|---|---|
+| 1 | Output MCMs establish Zone structure on the receiver; single- and dual-Zone `[1, §2.1]` | 8 intro | restatement of 3.3 | delete |
+| 2 | **MCMs emitted at start-up** | 8 intro | **new** | 3.3.2 Zones |
+| 3 | MCMs emitted on every Zone reconfiguration | 8 intro | restatement of 3.3 | delete |
+| 4 | Tuner listens for input MCMs and reconfigures its own Zones | 8 intro | restatement of 3.3 | delete |
+| 5 | Tuner forwards that configuration to the output instrument | 8 intro | restatement of 3.3 | delete |
+| 6 | **PBS defaults ±48 Member / ±2 Master relied upon** `[1, §2.4]` | 8 intro | **new** (2.3 states the spec rule; this states the Tuner's reliance) | 3.3.3 — **with causality corrected** |
+| 7 | **Listens for RPN 00 00 on input; conforms when interpreting incoming Pitch Bend** | 8 intro | **new** | 3.3.3 |
+| 8 | **MPE Input Mode: sensitivity on any Member Channel applies Zone-wide** (+ `[1, §2.4]` quote) | 8 intro | **new** | 3.3.3 |
+| 9 | **MPE Input Mode: mirrors input per-channel; no fan-out; `n²` flood rationale** | 8 intro | **new** | 3.3.3 |
+| 10 | **Non-MPE Input Mode: RPN 00 00 → output Master Channel** | 8 intro | restatement of 3.4 item 4 | delete from 8; 3.4 item 4 keeps it, repointed |
+| 11 | **Non-MPE Input Mode: output Member Channels retain ±48; changeable only via non-MIDI interface** | 8 intro | **new** | 3.3.3 (+ limitation note) |
+| 12 | **Emission order: Pitch Bend → CC #74 → Channel Pressure → Note On** `[1, §3.3.1]` | 8.1 | **new** | 6.1.1 |
+| 13 | Omission optimization for unchanged dimensions | 8.1 | half-restatement of 6.1 | merge into 6.1.1 |
+| 14 | CC #74 never emitted on a Member Channel in Non-MPE Input Mode | 8.1 | restatement of 6.3 and 3.4 item 3 | delete |
+| 15 | **Zone-level messages forwarded on Master Channel, unmodified; Tuner does not interpret or alter them** | 8.2 | **new** | 3.5 |
+| 16 | **Note removed from Expression Value averages on Note Off** (+ `[1, §3.3.3]` quote) | 8.3 | **new** (the quote) | 6.1 |
+| 17 | Channel keeps receiving Pitch Bend updates while other notes remain active | 8.3 | restatement of 6.1 and 7 | delete |
+| 18 | **Channel available for reuse once all its notes have received Note Off** | 8.3 | **new** | 4.2 |
+| 19 | **Note On velocity 0 treated as Note Off** `[1, §3.3.2]` | 8.3 | **new** | Section 4 preamble, as a global convention |
+| 20 | "Recognizing the shorthand is essential: occupancy tracking, …" | 8.3 | self-justifying prose | delete |
+
+**Totals:** 11 new facts relocated, 1 merged, 8 deleted as restatement or padding.
+
+### Additional fixes surfaced by this analysis (not from Section 8)
+
+| Fact | Location | Action |
+|---|---|---|
+| PBS missing from the reconfiguration reset list | 3.3 | **Add** PBS to the defaults enumeration — the `[1, §2.1.4]` obligation is to reset *all* controls. |
+| Master Channel Pitch Bend forwarding mechanic | 4.7.5 | Move mechanic to 3.5; keep quote and argument in place. |
+
+---
+
+## Constraints for the executing prompt
+
+- **Markdown only.** Do not modify Scala or any other committed source. The paper and the implementation
+  are both work in progress; updating `MpeTuner` is out of scope.
+- **Maintain the technical academic tone** of the paper.
+- **Do not read `MpeTuner`** to resolve questions about intended behavior — this paper is the specification,
+  not a description of the current implementation.
+- Preserve the paper's existing capitalization of MPE terms (Zone, Master Channel, Member Channel, Pitch
+  Bend, Tuning Pitch Bend, Expression Pitch Bend, Expression Values, Tuning, Tuner).
+- Verify each quoted passage still matches before editing; the paper may have moved past `44b7030`.


### PR DESCRIPTION
Part of #154.

Reorganizes the MPE Tuner design paper (`docs/architecture/tuner/mpe-tuner-paper.md`) per the design in `issues/00154-mpe-tuner-poly-expr/paper-config-reorg-design.md`, executed via the plan in `issues/00154-mpe-tuner-poly-expr/paper-config-reorg-plan.md`. Content-only change to a Markdown document — no source code, tests, or behavior affected, except one deliberate documented behavior change noted below.

## What changed

- **Extracted Configuration into a new dedicated Section 4** (Input Mode, Zones, Pitch Bend Sensitivity), pulled out of the Architecture chapter (old 3.3) and consolidated with facts formerly scattered in the dissolved Section 8.
- **One deliberate behavior change**: an MCM that deactivates all Zones no longer reverts the Tuner to Non-MPE Input Mode. The in-band MPE Input Mode switch is now one-way; only the non-MIDI configuration interface can re-enter Non-MPE Input Mode.
- **Broadened old Section 3.5** ("Master Channel Note Forwarding") into "Master Channel Forwarding," now covering Pitch Bend and Zone-level message passthrough on the Master Channel in addition to notes.
- **Moved the velocity-0 convention and channel-reuse rule** into the Allocation section, where they're used.
- **Added Section 6.1.1 "Message Ordering"** and **Section 6.4 "Channel Pressure Reset at Note Off"** under Expression Value Processing, absorbing facts that used to live in Section 8.
- **Dissolved Section 8 ("MPE Tuner Output Conformance")** entirely — every fact it stated now lives at the pipeline stage it actually describes. Added a short conformance pointer to Section 1.4 as a coherence mitigation, so a reader can still find "where is conformance discussed" without a dedicated section.
- **Renumbered** all subsequent sections and cross-references in a single final sweep, verified against a before/after reference-count snapshot (exact match) and an expected final header list (exact match).

## Verification

- Every `Remove:`/`Add:` edit in the plan matched the file text verbatim.
- Reference-count diff before vs. after renumbering: empty (`COUNTS-OK`).
- Final header list: matches the plan's expected structure exactly.
- Key quotes from the MPE Specification spot-checked for survival at expected occurrence counts (the "combine the data meaningfully" quote correctly appears twice, in 2.2 and 5.7.5; all others once).
- Full top-to-bottom read-through: no doubled blank lines or stray `---` around the deleted section, Appendix A untouched, all `Section N` references resolve to the section they now mean.

## Known follow-up (out of scope here)

Two sibling docs still cite the old `docs/tuner/mpe-tuner-paper.md` path and pre-reorg `§3.3.2` numbering; left unfixed per the design's stated scope:
- `issues/00202-pbs-non-mpe-input/pbs-non-mpe-and-mcm-test-mode-plan.md`
- `issues/00143-add-mpe-tuner/plan.md`