### PR TITLE
[#244] Ignore reset Channel Mode messages in ScMidiChannelStateTracker by default

### DIFF
--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -772,12 +772,31 @@ every output channel whose average changes receives the updated value immediatel
 
 ### 7.4 Channel Pressure Reset at Note Off
 
-At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that "Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the design of a controller" [1, §3.3.4].
+At Note Off, whether the Tuner emits a Channel Pressure reset depends on the input mode. The specification requires that
+"Channel Pressure must be set to zero immediately before a Note On or a Note Off wherever it is appropriate to the
+design of a controller" [1, §3.3.4].
 
-- In **MPE Input Mode** the output Channel Pressure passes through from the input sender, so the Tuner emits no reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the output through the update mechanism of Section 7.2, and if the sender emits none, neither does the Tuner.
-- In **Non-MPE Input Mode** the per-note Channel Pressure on an output Member Channel is the Tuner's own, synthesized from the input's Polyphonic Key Pressure (Section 3.3); here the Tuner is the controller to which the MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel Pressure to 0 as Section 7.3 requires.
+Under the allocation rules of Section 5 an output Member Channel may host several notes, whose Channel Pressure
+Expression Values are averaged (Section 7.1). At Note Off, the Tuner therefore withdraws the released note from its
+channel's aggregated value *before* emitting the Note Off: by the emission rule of Section 7.1 the recomputed Channel
+Pressure is sent at once, and the Note Off follows. No separate zeroing of the released note's Expression Value is
+required, and none is performed — removal alone withdraws its contribution, in a single update. What the channel then
+carries follows from the aggregation:
 
-Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's "wherever it is appropriate" qualifier and are documented design choices.
+- When other notes remain active on the channel, the recomputed value is their average. It is reduced by the withdrawal
+  but not zeroed.
+- When the released note is the only active note, removal empties the channel and the retention rule of Section 7.1
+  fixes the value the channel keeps. The two input modes differ only in what that retained value is:
+    * In **Non-MPE Input Mode** the per-note Channel Pressure on an output Member Channel is the Tuner's own,
+      synthesized from the input's Polyphonic Key Pressure (Section 3.3); here the Tuner is the controller to which the
+      MPE Specification requirement [1, §3.3.4] applies, so it performs the reset itself, returning the channel's Channel
+      Pressure to 0 as Section 7.3 requires.
+    * In **MPE Input Mode** the output Channel Pressure passes through from the input sender, so the Tuner emits no
+      reset of its own — it inherits the sender's behavior: a conforming sender's pre-release reset propagates to the
+      output through the update mechanism of Section 7.2, and if the sender emits none, neither does the Tuner.
+
+Deferring to the sender in MPE Input Mode and resetting in Non-MPE Input Mode both fall within the specification's
+"wherever it is appropriate" qualifier and are documented design choices.
 
 ---
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -308,15 +308,16 @@ upon receiving Mono On on its Basic Channel, which within a Zone is its lowest-n
 that switch would break the channel-sharing premise downstream while the Tuner's allocation state continued to assume
 polyphonic channels. Section 5.7.6 records this departure.
 
-The remaining Channel Mode messages — All Sound Off (120), Reset All Controllers (121), Local Control (122), and
-All Notes Off (123) — pass through the Tuner as Zone-level messages, forwarded (Section 3.4) or redirected
-(Section 3.3, item 4) on the output Master Channel. Receiving All Sound Off or All Notes Off does not clear the
-Tuner's note-tracking state: MIDI 1.0 requires that every Note On still be terminated by its own Note Off and forbids
-All Notes Off as a substitute [2, pp. 24–25], so the Tuner's state reconciles through the ordinary Note Off path while
-the downstream Zone responds to the message itself. MIDI 1.0 in fact directs receivers to ignore All Notes Off while
-Omni is on [2, p. 25]; the Tuner, although Omni-On-like on input, is a processor rather than a sound generator, so
-instead of consuming the message it delivers it to the output Zone, whose response is governed by the MPE
-Specification.
+The remaining Channel Mode messages — All Sound Off (120), Reset All Controllers (121), Local Control (122), and All
+Notes Off (123) — pass through the Tuner as Zone-level messages, forwarded (Section 3.4) or redirected (Section 3.3,
+item 4) on the output Master Channel. Receiving All Sound Off, All Notes Off or Reset All Controllers does not clear the
+Tuner's note-tracking and controller state: MIDI 1.0 requires that every Note On still be terminated by its own Note Off
+and forbids All Notes Off as a substitute [2, pp. 24–25], so the Tuner's state reconciles through the ordinary Note Off
+path while the downstream Zone responds to the message itself. MIDI 1.0 in fact directs receivers to ignore All Notes
+Off while Omni is on [2, p. 25]; the Tuner, although Omni-On-like on input, is a processor rather than a sound
+generator, so instead of consuming the message it delivers it to the output Zone, whose response is governed by the MPE
+Specification. For All Sound Off messages, the MPE Specification states that an MPE receiver is not expected to respond
+to [1, Table 1].
 
 ---
 

--- a/sc-midi/src/main/scala/org/calinburloiu/music/scmidi/ScMidiChannelStateTracker.scala
+++ b/sc-midi/src/main/scala/org/calinburloiu/music/scmidi/ScMidiChannelStateTracker.scala
@@ -33,14 +33,21 @@ import scala.collection.mutable
  * '''Not thread-safe.''' External synchronization is required when accessed from multiple threads. It should usually
  * be used from a track thread.
  *
- * @param ccDefaults   per-CC-number default values that override the companion's defaults.
- * @param rpnDefaults  per-RPN default values that override the companion's defaults.
- * @param nrpnDefaults per-NRPN default values that override the companion's defaults.
+ * @param ccDefaults                  per-CC-number default values that override the companion's defaults.
+ * @param rpnDefaults                 per-RPN default values that override the companion's defaults.
+ * @param nrpnDefaults                per-NRPN default values that override the companion's defaults.
+ * @param shallRespondToResetMessages whether the reset Channel Mode messages — All Sound Off (120), Reset All
+ *                                    Controllers (121), and All Notes Off (123) — mutate the tracked state. Defaults
+ *                                    to `false`, which records those messages as received but leaves the state
+ *                                    untouched. Set to `true` when the tracker models a receiver that is known
+ *                                    to act on these messages. Independent of this flag, [[reset]] always clears
+ *                                    everything.
  */
 @NotThreadSafe
 class ScMidiChannelStateTracker(ccDefaults: Map[Int, Int] = Map.empty,
                                 rpnDefaults: Map[(Int, Int), (Int, Int)] = Map.empty,
-                                nrpnDefaults: Map[(Int, Int), (Int, Int)] = Map.empty) extends ScMidiReceiver {
+                                nrpnDefaults: Map[(Int, Int), (Int, Int)] = Map.empty,
+                                shallRespondToResetMessages: Boolean = false) extends ScMidiReceiver {
 
   import ScMidiChannelStateTracker.*
 
@@ -293,16 +300,18 @@ class ScMidiChannelStateTracker(ccDefaults: Map[Int, Int] = Map.empty,
     case _ => // not part of the RPN/NRPN protocol
   }
 
-  private def handleChannelModeCc(state: ChannelState, ccNumber: Int): Unit = ccNumber match {
-    case ScMidiCc.AllSoundOff | ScMidiCc.AllNotesOff =>
-      state.activeNotes.clear()
-    case ScMidiCc.ResetAllControllers =>
-      ResetAllControllersCcNumbers.foreach(state.ccValues.remove)
-      state.channelPressure = None
-      state.pitchBend = None
-      state.rpnSelector = RpnSelector.None
-    case _ =>
-  }
+  private def handleChannelModeCc(state: ChannelState, ccNumber: Int): Unit =
+    if (shallRespondToResetMessages) ccNumber match {
+      case ScMidiCc.AllSoundOff | ScMidiCc.AllNotesOff =>
+        state.activeNotes.clear()
+      case ScMidiCc.ResetAllControllers =>
+        ResetAllControllersCcNumbers.foreach(state.ccValues.remove)
+        state.activeNotes.valuesIterator.foreach(_.polyPressure = 0)
+        state.channelPressure = None
+        state.pitchBend = None
+        state.rpnSelector = RpnSelector.None
+      case _ =>
+    }
 
   private def writeDataEntry(state: ChannelState, isMsb: Boolean, value: Int): Unit = state.rpnSelector match {
     case RpnSelector.Rpn(rmsb, rlsb) if rmsb != ScMidiRpn.NullMsb && rlsb != ScMidiRpn.NullLsb =>
@@ -356,7 +365,8 @@ object ScMidiChannelStateTracker {
   /**
    * CC numbers cleared from `ccValues` on Reset All Controllers (MIDI 1.0 RP-015). Bank Select, Volume, Pan, and
    * Program Change are intentionally preserved. In addition to clearing these CC values, the handler also resets
-   * Channel Pressure, Pitch Bend, and the RPN/NRPN selector to their default states.
+   * Channel Pressure, Polyphonic Key Pressure on every active note of the channel, Pitch Bend, and the RPN/NRPN
+   * selector to their default states, following the response the MMA recommends for the message.
    */
   private val ResetAllControllersCcNumbers: Set[Int] = Set(
     ScMidiCc.DataEntryMsb,

--- a/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/ScMidiChannelStateTrackerTest.scala
+++ b/sc-midi/src/test/scala/org/calinburloiu/music/scmidi/ScMidiChannelStateTrackerTest.scala
@@ -34,6 +34,11 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
     val tracker: ScMidiChannelStateTracker = ScMidiChannelStateTracker()
   }
 
+  /** A tracker that models a receiver known to act on All Sound Off, Reset All Controllers, and All Notes Off. */
+  private trait ResettableTrackerFixture {
+    val tracker: ScMidiChannelStateTracker = ScMidiChannelStateTracker(shallRespondToResetMessages = true)
+  }
+
   behavior of "ScMidiChannelStateTracker per note tracking"
 
   it should "have no active notes on any channel when empty" in new TrackerFixture {
@@ -994,7 +999,7 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
 
   behavior of "ScMidiChannelStateTracker Channel Mode messages"
 
-  it should "cancel active notes on the channel when All Sound Off is received" in new TrackerFixture {
+  it should "cancel active notes on the channel when All Sound Off is received" in new ResettableTrackerFixture {
     // Given
     tracker.send(NoteOnScMidiMessage(Channel, C4, velocity = 100))
     tracker.send(NoteOnScMidiMessage(Channel, E4, velocity = 110))
@@ -1008,7 +1013,7 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
     tracker.activeNotes(OtherChannel) should contain only G4
   }
 
-  it should "cancel active notes on the channel when All Notes Off is received" in new TrackerFixture {
+  it should "cancel active notes on the channel when All Notes Off is received" in new ResettableTrackerFixture {
     // Given
     tracker.send(NoteOnScMidiMessage(Channel, C4, velocity = 100))
     tracker.send(NoteOnScMidiMessage(OtherChannel, G4, velocity = 90))
@@ -1021,7 +1026,7 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
     tracker.activeNotes(OtherChannel) should contain only G4
   }
 
-  it should "clear resettable CCs when Reset All Controllers is received" in new TrackerFixture {
+  it should "clear resettable CCs when Reset All Controllers is received" in new ResettableTrackerFixture {
     // Given
     tracker.send(CcScMidiMessage(Channel, ScMidiCc.ModulationMsb, value = 64))
     tracker.send(CcScMidiMessage(Channel, ScMidiCc.ExpressionMsb, value = 50))
@@ -1047,7 +1052,7 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
   }
 
   it should "clear Data Entry, Data Increment, and Data Decrement CCs when Reset All Controllers is received" in
-    new TrackerFixture {
+    new ResettableTrackerFixture {
       // Given
       tracker.send(CcScMidiMessage(Channel, ScMidiCc.DataEntryMsb, value = 12))
       tracker.send(CcScMidiMessage(Channel, ScMidiCc.DataEntryLsb, value = 34))
@@ -1065,7 +1070,7 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
     }
 
   it should "clear Channel Pressure, Pitch Bend, and the RPN/NRPN selector when Reset All Controllers is received" in
-    new TrackerFixture {
+    new ResettableTrackerFixture {
       // Given
       tracker.send(ChannelPressureScMidiMessage(Channel, value = 80))
       tracker.send(PitchBendScMidiMessage(Channel, value = 1234))
@@ -1083,7 +1088,7 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
     }
 
   it should "clear the RPN/NRPN selector so subsequent Data Entry is ignored after Reset All Controllers" in
-    new TrackerFixture {
+    new ResettableTrackerFixture {
       // Given
       selectRpn(tracker, Channel, ScMidiRpn.PitchBendSensitivityMsb, ScMidiRpn.PitchBendSensitivityLsb)
       tracker.send(CcScMidiMessage(Channel, ScMidiCc.DataEntryMsb, value = 12))
@@ -1098,7 +1103,7 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
     }
 
   it should "preserve Bank Select, Volume, Pan, Program Change, and RPN/NRPN values on Reset All Controllers" in
-    new TrackerFixture {
+    new ResettableTrackerFixture {
       // Given
       tracker.send(CcScMidiMessage(Channel, ScMidiCc.BankSelectMsb, value = 3))
       tracker.send(CcScMidiMessage(Channel, ScMidiCc.VolumeMsb, value = 90))
@@ -1119,7 +1124,27 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
         equal(Some((12, 0)))
     }
 
-  it should "scope Reset All Controllers to the channel it was received on" in new TrackerFixture {
+  it should "reset Polyphonic Key Pressure on every active note when Reset All Controllers is received" in
+    new ResettableTrackerFixture {
+      // Given
+      tracker.send(NoteOnScMidiMessage(Channel, C4, velocity = 100))
+      tracker.send(NoteOnScMidiMessage(Channel, E4, velocity = 110))
+      tracker.send(NoteOnScMidiMessage(OtherChannel, G4, velocity = 90))
+      tracker.send(PolyPressureScMidiMessage(Channel, C4, value = 70))
+      tracker.send(PolyPressureScMidiMessage(Channel, E4, value = 80))
+      tracker.send(PolyPressureScMidiMessage(OtherChannel, G4, value = 90))
+
+      // When
+      tracker.send(CcScMidiMessage(Channel, ScMidiCc.ResetAllControllers, value = 0))
+
+      // Then — the notes stay active, only their pressure is reset, and only on the addressed channel
+      tracker.activeNotes(Channel) should contain theSameElementsAs Seq(C4, E4)
+      tracker.polyPressure(Channel, C4) should equal(0)
+      tracker.polyPressure(Channel, E4) should equal(0)
+      tracker.polyPressure(OtherChannel, G4) should equal(90)
+    }
+
+  it should "scope Reset All Controllers to the channel it was received on" in new ResettableTrackerFixture {
     // Given
     tracker.send(CcScMidiMessage(Channel, ScMidiCc.ModulationMsb, value = 64))
     tracker.send(CcScMidiMessage(OtherChannel, ScMidiCc.ModulationMsb, value = 90))
@@ -1132,6 +1157,47 @@ class ScMidiChannelStateTrackerTest extends AnyFlatSpec with Matchers {
     tracker.ccOption(Channel, ScMidiCc.ModulationMsb) shouldBe None
     tracker.ccOption(OtherChannel, ScMidiCc.ModulationMsb) should equal(Some(90))
     tracker.channelPressure(OtherChannel) should equal(70)
+  }
+
+  it should "not cancel active notes on All Sound Off by default" in new TrackerFixture {
+    // Given
+    tracker.send(NoteOnScMidiMessage(Channel, C4, velocity = 100))
+    tracker.send(NoteOnScMidiMessage(Channel, E4, velocity = 110))
+
+    // When
+    tracker.send(CcScMidiMessage(Channel, ScMidiCc.AllSoundOff, value = 0))
+
+    // Then — a Note Off is still owed for each note, so the record of them must survive
+    tracker.activeNotes(Channel) should contain theSameElementsAs Seq(C4, E4)
+  }
+
+  it should "not cancel active notes on All Notes Off by default" in new TrackerFixture {
+    // Given
+    tracker.send(NoteOnScMidiMessage(Channel, C4, velocity = 100))
+
+    // When
+    tracker.send(CcScMidiMessage(Channel, ScMidiCc.AllNotesOff, value = 0))
+
+    // Then
+    tracker.activeNotes(Channel) should contain only C4
+  }
+
+  it should "not clear controller state on Reset All Controllers by default" in new TrackerFixture {
+    // Given
+    tracker.send(CcScMidiMessage(Channel, ScMidiCc.ModulationMsb, value = 64))
+    tracker.send(ChannelPressureScMidiMessage(Channel, value = 80))
+    tracker.send(PitchBendScMidiMessage(Channel, value = 1234))
+    selectRpn(tracker, Channel, ScMidiRpn.PitchBendSensitivityMsb, ScMidiRpn.PitchBendSensitivityLsb)
+
+    // When
+    tracker.send(CcScMidiMessage(Channel, ScMidiCc.ResetAllControllers, value = 0))
+
+    // Then
+    tracker.ccOption(Channel, ScMidiCc.ModulationMsb) should equal(Some(64))
+    tracker.channelPressure(Channel) should equal(80)
+    tracker.pitchBend(Channel) should equal(1234)
+    tracker.rpnSelector(Channel) shouldEqual RpnSelector.Rpn(
+      ScMidiRpn.PitchBendSensitivityMsb, ScMidiRpn.PitchBendSensitivityLsb)
   }
 
   behavior of "ScMidiChannelStateTracker reset"


### PR DESCRIPTION
* Resolves #244
* Clarifies Channel Pressure reset on Note Off.