### PR TITLE
[#256] Address the post-merge review of the MPE Tuner tests

### DIFF
--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -1142,17 +1142,18 @@ pitch class E, so the pitch-class invariant permits any of them to share a chann
    The Note On for E2 follows. Channels 4 and 5 are untouched, and output Channel 3 remains unoccupied: the pitch-class
    invariant, not channel scarcity, forced the sharing (Section 5.8.1).
 
-4. **The performer bends E2 to +30 cents.** Channel 2's Expression Pitch Bend becomes `(+10 + 30) / 2 = +20`, emitted as
-   `T(E) + 20 = +6.3` cents (Section 7.2). E2's 50-cent excursion yields 25 cents on the output — the half-amplitude
-   attenuation of Section 5.7. No note is dropped: the threshold applies to a note's own bend, and +30 is below `t`.
+4. **The performer bends E2 to +31 cents.** Channel 2's Expression Pitch Bend becomes `(+10 + 31) / 2 = +20.5`, emitted
+   as `T(E) + 20.5 = +6.8` cents (Section 7.2). E2's 51-cent excursion yields 25.5 cents on the output — the
+   half-amplitude attenuation of Section 5.7. No note is dropped: the threshold is compared against the absolute value
+   of a note's own bend, not against its excursion, and +31 is below `t` although the excursion exceeds it.
 
 5. **Note Off for E1.** The Note Off is emitted first, and the values recomputed without E1 follow (Section 7.5):
-   Channel 2 takes E2's values alone — Pitch Bend `T(E) + 30 = +16.3` cents, CC #74 96, Channel Pressure 96. The Channel
+   Channel 2 takes E2's values alone — Pitch Bend `T(E) + 31 = +17.3` cents, CC #74 96, Channel Pressure 96. The Channel
    Pressure becomes the surviving note's own value rather than 0; in MPE Input Mode the dimension passes through from
    the sender, so the Tuner emits no reset of its own (Section 7.4).
 
 6. **Note Off for E2**, the channel's last active note. Removal empties output Channel 2, so averaging no longer applies
-   and the retention rule of Section 7.1 fixes what the channel keeps: Expression Pitch Bend +30 (Pitch Bend `+16.3`
+   and the retention rule of Section 7.1 fixes what the channel keeps: Expression Pitch Bend +31 (Pitch Bend `+17.3`
    cents), CC #74 96, and Channel Pressure 96. None of the three values changes, so the Tuner emits the Note Off alone.
    The Channel Pressure in particular is *not* zeroed: in MPE Input Mode the Tuner defers to the sender (Section 7.4).
    Had the sender preceded its Note Off with Channel Pressure 0 on input Channel 3, that update would have propagated
@@ -1178,14 +1179,14 @@ Consider a Zone with 3 Member Channels (`n = 3`, Pitch Class Group = 1, Expressi
 Where the previous example drops notes because channels ran out, this one drops a note that a channel can no longer
 represent. It continues from step 4 of Section 9.3, at which output Channel 2 shares two notes that reached it from
 different input channels: E1, from input Channel 2, with an Expression Pitch Bend of +10 cents, and E2, from input
-Channel 3, with +30 cents — averaging to +20. The performer now sends Pitch Bend +101 cents on input Channel 2.
+Channel 3, with +31 cents — averaging to +20.5. The performer now sends Pitch Bend +101 cents on input Channel 2.
 
 1. Pitch Bend is a channel message, so the value belongs to every note active on input Channel 2 — here only E1, which
    carries it as its Expression Pitch Bend under the update propagation rule of Section 7.2. At +101 cents it exceeds
    the threshold `t = 50`, so E1 acquires a High Expression Pitch Bend (Section 5.5). The test applies to the note's
    own Expression Value, not to the channel's average.
 2. E1 shares its output channel, so the divergence rule of Section 6.2.1 applies: **all other notes on that channel are
-   dropped**. E2's own Expression Pitch Bend, +30 cents from input Channel 3, is left untouched by this message and is
+   dropped**. E2's own Expression Pitch Bend, +31 cents from input Channel 3, is left untouched by this message and is
    well below `t` — yet E2 is dropped all the same.
 3. E1 is now the channel's only note, so each average collapses to its own value: Pitch Bend `T(E) + 101 = +87.3`
    cents. The Note Off for E2 is emitted first on output Channel 2, carrying the neutral release velocity 64 that any
@@ -1194,7 +1195,7 @@ Channel 3, with +30 cents — averaging to +20. The performer now sends Pitch Be
    updates first would sweep E2 to `+87.3` cents on its way out — a bend it never asked for, audible for as long as its
    Note Off is delayed.
 
-Had both notes been kept, the averaged Expression Pitch Bend would have been `(+101 + 30) / 2 = +65.5` cents: E2 would
+Had both notes been kept, the averaged Expression Pitch Bend would have been `(+101 + 31) / 2 = +66` cents: E2 would
 have been pulled more than half a semitone away from its tuned pitch, while E1 would have received under two thirds of
 the bend the performer asked for. Dropping E2 is what delivers the gesture intact, and it restores invariant 2 of
 Section 6.3 — a note with a High Expression Pitch Bend is always the sole active note on its channel. Channels 4 and 5

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeChannelAllocatorTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeChannelAllocatorTest.scala
@@ -1062,16 +1062,23 @@ class MpeChannelAllocatorTest extends AnyFlatSpec with Matchers with OptionValue
 
   it should "update a single identity's Channel Pressure contribution" in {
     // Given
+    // C4 and C5 both arrive on input channel 1 but land on different channels, and C3, from another input
+    // channel, shares C4's.
     val alloc = allocator2 // PCG=1, EG=1
     val first = MpeNoteIdentity(1, C4)
+    val sibling = MpeNoteIdentity(1, C5)
     val channel = alloc.allocate(first).channel
-    alloc.allocate(MpeNoteIdentity(2, C5))
+    val siblingChannel = alloc.allocate(sibling).channel
+    siblingChannel should not equal channel
     alloc.allocate(MpeNoteIdentity(3, C3)).channel shouldBe channel
     // When
     val result = alloc.updatePressure(first, 80)
     // Then
+    // Only C4's own contribution changes: its channel averages 80 with C3's 0, and — unlike an input-channel
+    // update — nothing fans out to C5, which shares C4's input channel.
     result.channelUpdates shouldEqual Seq(
       MpeChannelExpressionUpdate(channel, MpeExpressionUpdate(pressure = Some(40))))
+    alloc.channelExpression(siblingChannel).pressure shouldBe MpeExpression.DefaultPressure
   }
 
   it should "keep the most recently sounded note when several notes on a channel acquire a high bend at once" in {

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
@@ -133,6 +133,10 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
     initialZones = MpeZones(MpeZone(MpeZoneType.Lower, 7), MpeZone(MpeZoneType.Upper, 7))
   )
 
+  private def upperZoneOnlyTuner: MpeTuner = MpeTuner(
+    initialZones = MpeZones(MpeZone(MpeZoneType.Lower, 0), MpeZone(MpeZoneType.Upper, 7))
+  )
+
   private def tuner7MpeInput: MpeTuner = MpeTuner(
     initialZones = MpeZones(MpeZone(MpeZoneType.Lower, 7), MpeZone(MpeZoneType.Upper, 0)),
     initialInputMode = MpeInputMode.Mpe
@@ -796,14 +800,28 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       pb2.cents shouldEqual -14.0
     }
 
-  it should "route notes to the Lower Zone only when both Zones are enabled" in new Fixture(dualZoneTuner) {
-    // Non-MPE input is routed exclusively to the Lower Zone, so the Upper Zone's Member Channels (8..14)
-    // are unreachable and wasted — the configuration the Tuner warns about at construction and on reset().
+  it should "route notes to the Lower Zone when both Zones are enabled" in new Fixture(dualZoneTuner) {
+    // When
     private val out1 = noteOn(nonMpeInputChannel, C4)
     private val out2 = noteOn(nonMpeInputChannel, E4)
     // Then
+    // Non-MPE input is routed to a single Zone and the Lower Zone takes precedence when both are enabled,
+    // so the Upper Zone's Member Channels (8..14) are ignored and wasted — the configuration the Tuner
+    // warns about at construction and on reset().
     Seq(out1, out2).flatMap(extractNoteOns).map(_.channel).foreach { channel =>
       channel should (be >= 1 and be <= 7)
+    }
+  }
+
+  it should "route notes to the Upper Zone when it is the only Zone enabled" in new Fixture(upperZoneOnlyTuner) {
+    // When
+    private val out1 = noteOn(nonMpeInputChannel, C4)
+    private val out2 = noteOn(nonMpeInputChannel, E4)
+    // Then
+    // With no Lower Zone to take precedence, the single Zone non-MPE input is routed to is the Upper one,
+    // so its Member Channels (8..14) carry the notes.
+    Seq(out1, out2).flatMap(extractNoteOns).map(_.channel).foreach { channel =>
+      channel should (be >= 8 and be <= 14)
     }
   }
 
@@ -1791,6 +1809,8 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       extractSlides(out2) shouldBe empty
       extractChannelPressures(out2) shouldBe empty
       extractPitchBends(out3).head.cents shouldEqual quarterCommaMeantone.e
+      extractSlides(out3) shouldBe empty
+      extractChannelPressures(out3) shouldBe empty
 
       // 3. E2 arrives on input Channel 2 carrying Pitch Bend −20 cents, Channel Pressure 96 and CC #74 96.
       //    Both groups are unavailable for it, so Step 3 shares the oldest E channel and all three
@@ -1801,13 +1821,16 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       extractSlides(out4) shouldEqual Seq(CcScMidiMessage(ch, ScMidiCc.MpeSlide, (48 + 96) / 2))
       extractChannelPressures(out4) shouldEqual Seq(ChannelPressureScMidiMessage(ch, (32 + 96) / 2))
 
-      // 4. The performer bends E2 to +30 cents: the channel's Expression Pitch Bend becomes +20 — the
-      //    half-amplitude attenuation of a shared channel — and no note is dropped, the threshold applying
-      //    to a note's own bend.
-      private val out5 = pitchBend(2, 30.0)
+      // 4. The performer bends E2 to +31 cents: the channel's Expression Pitch Bend becomes +20.5 — the
+      //    half-amplitude attenuation of a shared channel — and no note is dropped. The threshold is
+      //    compared against a note's own bend in absolute value, and +31 stays below it even though the
+      //    51-cent excursion from E2's initial −20 exceeds it. Only the Pitch Bend dimension moves.
+      private val out5 = pitchBend(2, 31.0)
       extractPitchBends(out5) should have size 1
-      extractPitchBends(out5).head.cents shouldEqual (quarterCommaMeantone.e + (10.0 + 30.0) / 2)
+      extractPitchBends(out5).head.cents shouldEqual (quarterCommaMeantone.e + (10.0 + 31.0) / 2)
       extractNoteOffs(out5) shouldBe empty
+      extractSlides(out5) shouldBe empty
+      extractChannelPressures(out5) shouldBe empty
 
       // 5. Note Off for E1: the Note Off is emitted first and the values recomputed without it follow.
       //    The Channel Pressure becomes the surviving note's own value rather than 0: in MPE Input Mode
@@ -1819,7 +1842,7 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
         case cc: CcScMidiMessage if cc.number == ScMidiCc.MpeSlide => "slide"
         case _: ChannelPressureScMidiMessage => "pressure"
       } shouldEqual Seq("noteOff", "pitchBend", "slide", "pressure")
-      extractPitchBends(out6).head.cents shouldEqual (quarterCommaMeantone.e + 30.0)
+      extractPitchBends(out6).head.cents shouldEqual (quarterCommaMeantone.e + 31.0)
       extractSlides(out6) shouldEqual Seq(CcScMidiMessage(ch, ScMidiCc.MpeSlide, 96))
       extractChannelPressures(out6) shouldEqual Seq(ChannelPressureScMidiMessage(ch, 96))
 
@@ -2179,12 +2202,12 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
     new Fixture(tuner4MpeInput, Some(quarterCommaMeantone)) {
       // Given
       // The state reached at step 4 of "Averaging Expression Values": E1 (input Channel 1, +10 cents) and
-      // E2 (input Channel 2, +30 cents) share an output channel, averaging to +20.
+      // E2 (input Channel 2, +31 cents) share an output channel, averaging to +20.5.
       private val out1 = noteOn(1, E1, pbCents = Some(10.0))
       private val ch = extractNoteOns(out1).head.channel
       noteOn(3, E3)
       noteOn(4, E4)
-      extractNoteOns(noteOn(2, E2, pbCents = Some(30.0))).head.channel shouldBe ch
+      extractNoteOns(noteOn(2, E2, pbCents = Some(31.0))).head.channel shouldBe ch
 
       // When
       // The performer sends Pitch Bend +101 cents on input Channel 1: the value belongs to E1, which


### PR DESCRIPTION
Resolves #256

Addresses the four unresolved comments of the review submitted on PR #251 after it was merged. All of them are on test files; no production code changes.

## `MpeChannelAllocatorTest`

- **"update a single identity's Channel Pressure contribution"** — the fixture now allocates a second note that also arrives on input channel 1 and lands on the *other* output channel, and asserts that channel still holds the default Channel Pressure. A `updatePressure(noteIdentity, …)` must update one note's contribution only, never fanning out the way `updatePressure(inputChannel, …)` does; with the previous fixture (all other notes on foreign input channels) the two behaviours were indistinguishable.

## `MpeTunerTest`

- **Non-MPE Zone routing** — the test name and comment asserted that non-MPE input is routed *exclusively* to the Lower Zone. It is routed to a *single* Zone: the Lower when enabled, otherwise the Upper. The test is renamed to "route notes to the Lower Zone when both Zones are enabled", its comment now says the Lower Zone takes precedence and the Upper is ignored, and a companion test — "route notes to the Upper Zone when it is the only Zone enabled", with a new `upperZoneOnlyTuner` fixture — covers the Upper-only configuration that was previously untested in Non-MPE Input Mode.
- **`"Averaging Expression Values"` step 2** — E4 (`out3`) now asserts the absent Slide and Channel Pressure, as E3 (`out2`) already did.
- **`"Averaging Expression Values"` step 4** — E2 is bent to +31 cents rather than +30. Its excursion from the initial −20 is then 51 cents, above the 50-cent High Expression Pitch Bend threshold, while its absolute bend of +31 stays below it, so the test now discriminates the rule it is meant to prove: the threshold is compared against the absolute value of a note's own bend, not against how far it moved. At +30 the excursion was exactly 50 and proved nothing. The step also asserts that Slide and Channel Pressure do not move.

## Paper

The two worked examples above are reproductions of the design paper, which is the source of truth, so the paper is kept in step: Section 9.3 step 4 (and the values steps 5–6 derive from it) uses the +31 bend and states the absolute-value comparison explicitly, and Section 9.5 — which continues from Section 9.3 step 4 — follows, along with the setup of its own test. Wording, tone and structure are otherwise untouched.

## Verification

- `tuner` module: 368 tests pass.
- Full suite: 935 tests pass across all modules.
- `tuner` coverage: 82.16% statement / 80.00% branch, above the module's 80% / 75% floor. No production statement changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVvzsdxPiBS12qTNEkc3qc)_