### PR TITLE
[#250] Reconcile the four MPE Tuner routing conformance phases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val root = (project in file("."))
     commonSettings,
     // Aggregate thresholds — enforced by `coverageAggregate` on the combined report from all modules.
     // TODO #183 Raise toward 80% statement and branch coverage once the per-module floors do.
-    coverageSettings(stmt = 71, branch = 65),
+    coverageSettings(stmt = 73, branch = 68),
   )
 
 lazy val appModule = (project in file("app"))
@@ -200,8 +200,7 @@ lazy val tunerModule = (project in file("tuner"))
     name := "microtonalist-tuner",
     commonSettings,
     libraryDependencies ++= Seq(),
-    // TODO #178 Raise branch coverage toward 80% (statement now at the 80% target).
-    coverageSettings(stmt = 80, branch = 75),
+    coverageSettings(stmt = 80, branch = 80),
   )
 
 lazy val formatModule = (project in file("format"))
@@ -251,7 +250,7 @@ lazy val scMidiModule = (project in file("sc-midi"))
       coreMidi4j,
     ),
     // TODO #177 Raise toward 80% statement and branch coverage.
-    coverageSettings(stmt = 62, branch = 44),
+    coverageSettings(stmt = 67, branch = 52),
   )
 
 lazy val experimentsModule = (project in file("experiments"))

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -388,9 +388,12 @@ output Zone to be allocated into. Passing it through would emit an untuned note 
 contradicting the guarantee of Section 3.2 that the output is always MPE-conformant, and it would sound in 12-EDO
 without the deliberate trade-off that makes Master Channel notes acceptable (Section 3.4).
 
-MPE Configuration Messages are the sole exception. An MCM's validity is governed by Section 4.2 — it must arrive on a
-Master Channel — and it is acted upon regardless of whether the Zone it addresses is currently enabled; this is what
-allows a deactivated Zone to be re-activated in band (Section 4.1).
+MPE Configuration Messages are the sole exception. An MCM's validity is governed by Section 4.2 — it must arrive on
+MIDI Channel 1 or 16, a test of channel number rather than of the channel's current role — and it is acted upon
+regardless of whether the Zone it addresses is currently enabled. That the test does not consult the role is what makes
+the exception operative here at all: with the addressed Zone disabled, the channel carrying the MCM lies outside the
+Zone structure like any other, and a role-based test would reject the very message that re-activates the Zone in band
+(Section 4.1).
 
 In Non-MPE Input Mode this subsection does not apply: notes are recognized on all sixteen channels (Section 3.2) and
 routed to the single output Zone selected by Section 4.2. If no Zone is enabled at all, however, there is no output Zone

--- a/issues/00250-mpe-tuner-conformance/2026-08-03-routing-conformance-prompt.md
+++ b/issues/00250-mpe-tuner-conformance/2026-08-03-routing-conformance-prompt.md
@@ -2,6 +2,9 @@
 
 - **Date**: 2026-08-03
 - **Revised**: 2026-08-10 — rebased onto #252's file split (see "Rebase onto #252" below)
+- **Revised**: 2026-08-16 (commit `8e636d7`) — §2.2(f)'s always-emit-the-selector requirement was superseded during
+  implementation; see the note in that bullet. The requirement text is left as written, so that what was asked for and
+  what shipped stay both visible.
 - **Issue**: [#250](https://github.com/calinburloiu/microtonalist/issues/250) — "Make MPE Tuner MIDI message routing and
   filtering conform to the paper"
 - **Base commit**: `5f55a84bf81eb95cb8619d56a918f22768b7b686`
@@ -170,6 +173,18 @@ that state now lives in `MpeChannelState.scala`, not alongside the allocator.
       Increment/Decrement (CC #96/#97), are forwarded separately through that same catch-all. See **C6**, which is the
       paper-conformance half of the same code path: it asks where these messages must *go*, this bullet asks how they
       must be *grouped*, and the two verdicts differ in Non-MPE Input Mode.
+    - **Superseded during implementation (2026-08-16, commit `8e636d7`).** The always-emit rule above — "the selector
+      is always emitted before such a message, even if it's verbose" — is *not* what shipped, and the author has
+      accepted the change. `MpeMessageRouting.rpnSequence` emits the selector only when the parameter it selects
+      differs from the one `MpeTuner.outputRpnSelectors` records as last left selected on that output channel;
+      selection latches, so a run of value messages of one parameter spends one selector while two senders alternating
+      between parameters still get a selector each, which is the separation this bullet was asking for. The record is
+      exact rather than presumed — the Tuner consumes every selector its input sends and never relays a value message
+      verbatim — and it is dropped for any channel a relayed Reset All Controllers or a System Reset deselects at the
+      receiver (`MpeMessageRouting.deselectsOnRelay`). §4's preamble in the paper was amended to state the shipped
+      rule, and the paper remains the source of truth. Note that the design
+      ([`2026-08-12-routing-conformance-design.md`](2026-08-12-routing-conformance-design.md) §5, C6), issue #261 and
+      PR #268 all still describe the always-emit shape.
 
 ## 3. Implementation gaps
 

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeMessageRouting.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeMessageRouting.scala
@@ -241,10 +241,17 @@ private[tuner] object MpeMessageRouting {
    * forget what it last left selected there.
    *
    * Reset All Controllers is the case that arises in ordinary traffic: the paper forwards it unmodified onto the
-   * very output Master Channel a relayed sequence latches its selector on, and a receiver responds to it by
-   * returning its parameter selection to Null — as [[ScMidiChannelStateTracker]] does for the channels it tracks.
-   * The Tuner therefore authors the parameter selected on its output channels without authoring every message that
-   * changes it, which is what this predicate exists to catch.
+   * very output Master Channel a relayed sequence latches its selector on, and a conformant receiver responds to it
+   * by returning its parameter selection to Null. The Tuner therefore authors the parameter selected on its output
+   * channels without authoring every message that changes it, which is what this predicate exists to catch.
+   *
+   * This is a statement about the ''receiver'', not about the Tuner's own view of its input.
+   * [[ScMidiChannelStateTracker]] can model the same response, but only when constructed with
+   * `shallRespondToResetMessages`, and [[MpeTuner]] deliberately leaves that off: the paper has the Tuner keep its
+   * tracked state across a relayed Reset All Controllers rather than clear it. So the two sides part company here by
+   * design — the output-channel record is dropped while the input channel keeps its selection — and the parting is
+   * safe in the only direction that matters, a dropped record costing a re-emitted selector rather than a value
+   * message riding a selection the receiver no longer holds.
    *
    * All Sound Off, All Notes Off and Local Control leave the selection alone and are not included. A System Reset
    * does deselect, on every channel at once; it carries no channel of its own, so its caller handles it rather than


### PR DESCRIPTION
Resolves #250

The four phases of #250 landed as separate pull requests (#264, #265, #268, #266) and departed from the plan in two
places. Each phase was internally consistent; what no single phase owned was the reconciliation between them. This is
that pass. **No behaviour changes** — coverage floors, two documentation corrections, and one ScalaDoc correction.

## What the review found already integrated

All nine gaps (P7, C3, C4, C5, C6, N4, I2, I3, I1) and the prompt's §2.2(d)/(e) hold in the merged code, and the three
cross-PR reconciliations the sub-issues flagged as merge hazards all landed: `assignmentOf` repointed at
`MpeMessageRouting.roleOf`, the selector byte order unified behind `RpnMessages.select`, and the `TODO #250` marker and
its "Subject to change" bullet removed by the last phase. `stopNotesOn` and `MpeChannelAllocator.retaining` agree
exactly on which notes a reconfiguration affects, so no hanging note and no unmatched Note Off. Nothing there needed
changing.

## What this PR changes

- **`build.sbt` coverage floors.** `tuner` has reached the 80% target on both axes, so it moves to
  `coverageSettings(stmt = 80, branch = 80)` and the `TODO #178` marker goes away (#178 closed). `sc-midi` and the
  `root` aggregate also rose well past their 3% buffer and are ratcheted to 67/52 and 73/68; #177 and #183 stay open.
- **Paper §3.7.** It glossed an MCM's validity as "it must arrive on a Master Channel", contradicting §4.2 ("determined
  by channel number rather than by the channel's current role") and §3.5's table ("whatever their current role"), and
  contradicting `MpeMessageRouting.isValidMcm`, which tests channel number and member count and never the role. The
  gloss also defeated the exception §3.7 was itself stating: §3.7 is about channels outside every Zone, where by
  definition no channel is a Master Channel of an enabled Zone, so a role-based test could never let the re-activating
  MCM through. Rewritten to state the channel-number test and say why it has to be one.
- **`MpeMessageRouting.deselectsOnRelay` ScalaDoc.** It claimed `ScMidiChannelStateTracker` returns its parameter
  selection to Null on a relayed Reset All Controllers "for the channels it tracks". `MpeTuner` constructs the tracker
  without `shallRespondToResetMessages`, exactly as the prompt's §2.2(e) requires, so it does not. The doc now says the
  claim is about the receiver, that the two sides part company by design, and why the parting is safe in the only
  direction that matters.
- **A dated note on the prompt's §2.2(f).** That bullet required the selector ahead of *every* value message, "even if
  it's verbose", and was marked binding. What shipped spends the selector only when the parameter changes, backed by
  `MpeTuner.outputRpnSelectors` and invalidated on a relayed Reset All Controllers or a System Reset. The paper's §4
  preamble states the shipped rule; the design, issue #261 and PR #268 still describe the always-emit shape. The
  requirement text is left as written and the supersession noted beside it, so what was asked for and what shipped stay
  both visible. #250's body carries the same correction alongside the document links, together with the
  LSB-before-MSB reversal #259 made against the design's MSB-before-LSB decision.

I audited the latching bookkeeping for holes before accepting it: entries in `outputRpnSelectors` are only ever written
by the Tuner's own emitters, every relayed message that deselects at a receiver is accounted for, and Master Channels
are fixed at 0 and 15 so an MCM cannot strand one. It is correct — it was simply unrecorded outside the paper.

## Verification

- Full suite: **1045 tests, 0 failures**.
- `sbtn coverageAll` passes against the new floors: `tuner` 84.34% / 82.78%, `sc-midi` 70.94% / 55.17%,
  `format` 71.46% / 64.69%, `root` aggregate 76.13% / 71.15%.
- Module-only (`coverageModules`): `tuner` 82.89% / 81.34%, `sc-midi` 70.65% / 55.17%.
- `MpeMessageRouting.scala` and `RpnMessages.scala` are both 100% statement and branch.

Resolves #250
