### PR TITLE
[#276] Restate the Pitch Bend Sensitivity of both Zones after an MCM

### DIFF
--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -445,20 +445,6 @@ reading a receiver took, the sequences that follow its MCM leave it holding the 
 load-bearing in both directions. The sequences must *follow* the MCM, since a receiver that does reset would
 otherwise overwrite them; and they must *precede* the re-emitted Pitch Bends below, which are encoded against them.
 
-The sequences reach further than the MCMs do. An MCM is emitted only for a Zone whose configuration actually
-changed, whereas the Pitch Bend Sensitivity sequences are emitted for **both** Zones on every MCM the Tuner honors:
-for the addressed Zone, for a Zone overlap resolution shrank, and equally for a Zone the reconfiguration left
-entirely alone, which takes no MCM of its own and whose sequences therefore have none to follow. That reach is
-chosen to match the Pitch Bend re-emission below, which likewise covers the occupied Member Channels of both Zones
-rather than only those of the Zone that changed. The two have to agree: a Pitch Bend restated on a channel whose
-sensitivity is left unstated is precisely what a receiver that wrongly took the §2.4 reset Zone-wide would misread,
-and that receiver is the one this redundancy exists for. Against a conforming receiver the additional sequences
-change nothing, the values they restate being the ones it already holds, and the cost is a handful of Control
-Changes per reconfiguration — a trade this design's ordering of intonation precision over message economy
-(Section 5) accepts as readily as it accepts the redundant Note Offs at the end of this section and the redundant
-Pitch Bends below. A disabled Zone has neither a Master Channel nor Member Channels and so contributes no
-sequences at all.
-
 A channel the reconfiguration left untouched therefore keeps its notes and state while the range its Pitch Bend is
 read against may change underneath them, with two consequences on the addressed Zone. Its Pitch Bend is re-emitted,
 encoded against the new sensitivity, so the tuned pitch of the notes it carries is correctly re-encoded. Only that
@@ -476,7 +462,7 @@ For every dropped note, the Tuner emits an explicit Note Off before the MCM — 
 
 ### 4.3 Pitch Bend Sensitivity
 
-The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The MPE Tuner relies on these defaults both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output. It does not rely on the *receiver* performing that reset, however: every MCM it emits is followed by explicit Pitch Bend Sensitivity sequences on the Master and Member Channels of both Zones — the addressed Zone's stating the defaults it has just adopted, the other Zone's the values it retains — rather than leaving either implied (Section 4.2).
+The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The MPE Tuner relies on these defaults both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output. It does not rely on the *receiver* performing that reset, however: every MCM it emits is followed by explicit Pitch Bend Sensitivity sequences on the Zone's Master and Member Channels, stating what the Tuner holds for that Zone rather than leaving it implied (Section 4.2).
 
 The Tuner also listens for Pitch Bend Sensitivity messages (RPN 00 00) on its input and conforms to them when interpreting incoming Pitch Bend. How a received message propagates to the output depends on the input mode:
 

--- a/docs/architecture/tuner/mpe-tuner-paper.md
+++ b/docs/architecture/tuner/mpe-tuner-paper.md
@@ -445,6 +445,20 @@ reading a receiver took, the sequences that follow its MCM leave it holding the 
 load-bearing in both directions. The sequences must *follow* the MCM, since a receiver that does reset would
 otherwise overwrite them; and they must *precede* the re-emitted Pitch Bends below, which are encoded against them.
 
+The sequences reach further than the MCMs do. An MCM is emitted only for a Zone whose configuration actually
+changed, whereas the Pitch Bend Sensitivity sequences are emitted for **both** Zones on every MCM the Tuner honors:
+for the addressed Zone, for a Zone overlap resolution shrank, and equally for a Zone the reconfiguration left
+entirely alone, which takes no MCM of its own and whose sequences therefore have none to follow. That reach is
+chosen to match the Pitch Bend re-emission below, which likewise covers the occupied Member Channels of both Zones
+rather than only those of the Zone that changed. The two have to agree: a Pitch Bend restated on a channel whose
+sensitivity is left unstated is precisely what a receiver that wrongly took the §2.4 reset Zone-wide would misread,
+and that receiver is the one this redundancy exists for. Against a conforming receiver the additional sequences
+change nothing, the values they restate being the ones it already holds, and the cost is a handful of Control
+Changes per reconfiguration — a trade this design's ordering of intonation precision over message economy
+(Section 5) accepts as readily as it accepts the redundant Note Offs at the end of this section and the redundant
+Pitch Bends below. A disabled Zone has neither a Master Channel nor Member Channels and so contributes no
+sequences at all.
+
 A channel the reconfiguration left untouched therefore keeps its notes and state while the range its Pitch Bend is
 read against may change underneath them, with two consequences on the addressed Zone. Its Pitch Bend is re-emitted,
 encoded against the new sensitivity, so the tuned pitch of the notes it carries is correctly re-encoded. Only that
@@ -462,7 +476,7 @@ For every dropped note, the Tuner emits an explicit Note Off before the MCM — 
 
 ### 4.3 Pitch Bend Sensitivity
 
-The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The MPE Tuner relies on these defaults both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output. It does not rely on the *receiver* performing that reset, however: every MCM it emits is followed by explicit Pitch Bend Sensitivity sequences on the Zone's Master and Member Channels, stating what the Tuner holds for that Zone rather than leaving it implied (Section 4.2).
+The MPE Specification defines default Pitch Bend Sensitivity values — ±48 semitones for Member Channels and ±2 semitones for the Master Channel — and makes the MCM the trigger that applies them: upon receiving an MCM, a receiver must reset the Pitch Bend Sensitivity of the affected channels to these defaults (Section 2.3) [1, §2.4]. The MPE Tuner relies on these defaults both when interpreting incoming Pitch Bend and when encoding Pitch Bend on its output. It does not rely on the *receiver* performing that reset, however: every MCM it emits is followed by explicit Pitch Bend Sensitivity sequences on the Master and Member Channels of both Zones — the addressed Zone's stating the defaults it has just adopted, the other Zone's the values it retains — rather than leaving either implied (Section 4.2).
 
 The Tuner also listens for Pitch Bend Sensitivity messages (RPN 00 00) on its input and conforms to them when interpreting incoming Pitch Bend. How a received message propagates to the output depends on the input mode:
 

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -413,8 +413,10 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     // Read from `zonesBefore` rather than the `_zones`-backed getters, so it survives the reassignment below.
     val otherZoneBefore = if (channel == 0) zonesBefore.upper else zonesBefore.lower
 
-    // Leaving Non-MPE Input Mode is conservatively treated as affecting every channel: Member Channel Expression
-    // Values were synthesized under different semantics and the Channel-Pressure-reset rule differs by mode.
+    // Leaving Non-MPE Input Mode is conservatively treated as affecting every channel, wider than strictly
+    // necessary: an input Member Channel becoming a Lower/Upper Member keeps resolving through the same allocator,
+    // so only input channels becoming Master Channels strand. But Member Channel Expression Values were
+    // synthesized under different semantics and the Channel-Pressure-reset rule differs by mode.
     // Within MPE Input Mode only the channels whose Zone assignment changes are affected — and no note is bound
     // outside the Zone structure for that comparison to miss, `route` discarding a Note On from an unassigned
     // channel.
@@ -459,8 +461,9 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     // Rebuild each Zone's allocator against the new Zone structure and emit what the rebuild moved: retained
     // notes reclassified against the Zone's sensitivity — reset under them on the addressed Zone, moving its
     // threshold — notes whose input channel left MPE control dropped, and the channels that kept notes retuned.
-    // It sits here so that mutating the allocators and describing that to the receiver stay adjacent, and it must
-    // in any case follow the MCMs above, whose restated sensitivities its Pitch Bends are encoded against.
+    // It sits here so that mutating the allocators and describing that to the receiver stay adjacent — nothing
+    // between the `_zones` assignment above and here touches an allocator — and it must in any case follow the
+    // MCMs above, whose restated sensitivities its Pitch Bends are encoded against.
     //
     // Lower before Upper, as `tune()` orders them; a freshly created allocator holds no notes and reports nothing.
     // The unaddressed Zone runs the pass too, its occupied channels taking a redundant, bit-identical Pitch Bend —

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -384,14 +384,16 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
   /**
    * Processes an incoming MPE Configuration Message (MCM).
    *
-   * Reconfigures zones (with overlap resolution) and outputs the new configuration messages downstream: for each
-   * Zone whose configuration changed, its MCM followed by the Pitch Bend Sensitivity sequences that restate what
-   * that Zone holds.
+   * Reconfigures zones (with overlap resolution) and outputs the new configuration messages downstream: the MCM of
+   * each Zone whose configuration changed, and the Pitch Bend Sensitivity sequences of '''both''' Zones, each
+   * Zone's following its own MCM where one is emitted. The Pitch Bend Sensitivity of a Zone the reconfiguration
+   * left alone is restated with the same reach as the Pitch Bend the retuning pass re-emits, so that a receiver
+   * that did not take the MCM's reset as the specification defines it cannot read one against the other's range.
    *
    * The addressed Zone has both its Master and its Member Pitch Bend Sensitivity '''reset to the specification's
    * defaults''' — ±2 and ±48 semitones — because that is what the MCM does at a conforming receiver (MPE Spec
-   * §2.4); the reconfigured Zone is built afresh, so it carries those defaults by construction. A Zone that
-   * overlap resolution merely shrinks in consequence was not addressed by the MCM and keeps its sensitivities.
+   * §2.4); the reconfigured Zone is built afresh, so it carries those defaults by construction. The other Zone was
+   * not addressed by the MCM and keeps its sensitivities, whether or not overlap resolution shrank it.
    *
    * Only the channels entering or leaving MPE control by the reconfiguration have their notes stopped and their
    * tracked state reset; a Zone untouched by the reconfiguration keeps its notes and state, as the paper's
@@ -462,16 +464,27 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     val otherZoneAfter = if (channel == 0) upperZone else lowerZone
     if (otherZoneAfter != otherZoneBefore) {
       val otherZoneType = if (channel == 0) MpeZoneType.Upper else MpeZoneType.Lower
-      // This Zone keeps its Pitch Bend Sensitivity: the received MCM addressed the other Zone, and the MPE
-      // Specification does not say whether the Zone that overlap resolution shrinks in response loses its
-      // sensitivity along with its channels. The Tuner resolves it as JUCE's `MPEZoneLayout` does, narrowing the
-      // yielding Zone's channel range while leaving its sensitivities untouched — see the paper's "Zones"
-      // section. Restating the kept sensitivity after this Zone's own MCM is what makes that reading safe
-      // against a receiver that took the other one and reset it.
       logger.info(s"$otherZoneType zone adjusted by overlap resolution: $otherZoneAfter")
       emitMcmSequence(buffer, otherZoneAfter)
-      emitZonePbsSequences(buffer, otherZoneAfter)
     }
+
+    // Restate the other Zone's Pitch Bend Sensitivity whether or not overlap resolution moved its boundary. It
+    // keeps the sensitivity it held: the received MCM addressed the other Zone, and the MPE Specification does not
+    // say whether the Zone that overlap resolution shrinks in response loses its sensitivity along with its
+    // channels. The Tuner resolves it as JUCE's `MPEZoneLayout` does, narrowing the yielding Zone's channel range
+    // while leaving its sensitivities untouched — see the paper's "Zones" section. Restating the kept sensitivity
+    // is what makes that reading safe against a receiver that took the other one and reset it.
+    //
+    // Restating it on a Zone the reconfiguration left entirely alone is redundant against a conforming receiver,
+    // which resets only the addressed Zone, and is emitted for the same reason the retuning pass below re-emits
+    // Pitch Bend on *both* Zones' occupied channels — the two reaches are deliberately the same. A receiver that
+    // wrongly took the MCM's reset Zone-wide would otherwise read those Pitch Bends against a range the Tuner does
+    // not share and mistune every note this Zone holds, and that receiver is the one the redundancy exists for.
+    //
+    // It must follow this Zone's own MCM above, where there is one, for the same reason the addressed Zone's
+    // sequences follow its own — a receiver that does reset would otherwise overwrite them — and precede the
+    // retuning pass below. A disabled Zone emits nothing; see [[emitZonePbsSequences]].
+    emitZonePbsSequences(buffer, otherZoneAfter)
 
     // Rebuild each Zone's allocator against the new Zone structure and emit what the rebuild moved: the retained
     // notes are reclassified against the Zone's Pitch Bend Sensitivity, the ones whose input channel left MPE

--- a/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
+++ b/tuner/src/main/scala/org/calinburloiu/music/microtonalist/tuner/MpeTuner.scala
@@ -384,26 +384,22 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
   /**
    * Processes an incoming MPE Configuration Message (MCM).
    *
-   * Reconfigures zones (with overlap resolution) and outputs the new configuration messages downstream: the MCM of
-   * each Zone whose configuration changed, and the Pitch Bend Sensitivity sequences of '''both''' Zones, each
-   * Zone's following its own MCM where one is emitted. The Pitch Bend Sensitivity of a Zone the reconfiguration
-   * left alone is restated with the same reach as the Pitch Bend the retuning pass re-emits, so that a receiver
-   * that did not take the MCM's reset as the specification defines it cannot read one against the other's range.
+   * Reconfigures the Zones (with overlap resolution) and restates the result downstream: the MCM of each Zone
+   * whose configuration changed, and the Pitch Bend Sensitivity sequences of '''both''' Zones, each following its
+   * own MCM where one is emitted.
    *
-   * The addressed Zone has both its Master and its Member Pitch Bend Sensitivity '''reset to the specification's
-   * defaults''' — ±2 and ±48 semitones — because that is what the MCM does at a conforming receiver (MPE Spec
-   * §2.4); the reconfigured Zone is built afresh, so it carries those defaults by construction. The other Zone was
-   * not addressed by the MCM and keeps its sensitivities, whether or not overlap resolution shrank it.
+   * The addressed Zone is built afresh and so carries the specification's defaults — ±2 and ±48 semitones — which
+   * is what an MCM does at a conforming receiver (MPE Spec §2.4). The other Zone keeps its sensitivities, whether
+   * or not overlap resolution shrank it.
    *
-   * Only the channels entering or leaving MPE control by the reconfiguration have their notes stopped and their
-   * tracked state reset; a Zone untouched by the reconfiguration keeps its notes and state, as the paper's
-   * Zone-configuration section requires.
+   * Only the channels entering or leaving MPE control have their notes stopped and their tracked state reset; a
+   * Zone untouched by the reconfiguration keeps its notes and state. See the paper's "Zones" section.
    */
   private def processMcm(buffer: mutable.Buffer[MidiMessage], channel: Int, memberCount: Int): Unit = {
     assert(channel == 0 || channel == 15, "MCM messages are only sent to channel 0 or 15!")
     assert(MpeZone.isValidMemberCount(memberCount),
       s"An invalid MCM member count of $memberCount reached the MpeTuner!")
-    // Per MPE spec Section 2.4, receiving MCM resets PBS to defaults
+    // A freshly built Zone carries the default sensitivities the MCM resets the addressed Zone to (MPE Spec §2.4).
     val (zoneType, newZone) = if (channel == 0)
       (MpeZoneType.Lower, MpeZone(MpeZoneType.Lower, memberCount))
     else
@@ -414,53 +410,37 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
     val zonesBefore = _zones
     val zonesAfter = zonesBefore.update(newZone)
 
-    // Remember the other zone before update to detect overlap resolution changes. Read from `zonesBefore`,
-    // not from the `_zones`-backed `lowerZone`/`upperZone` getters, so this holds the pre-update view
-    // regardless of where `_zones` is reassigned below.
+    // Read from `zonesBefore` rather than the `_zones`-backed getters, so it survives the reassignment below.
     val otherZoneBefore = if (channel == 0) zonesBefore.upper else zonesBefore.lower
 
-    // Leaving Non-MPE Input Mode is treated as affecting every channel, deliberately conservatively rather
-    // than out of strict necessity: an input Member Channel becoming a Lower/Upper Member keeps resolving
-    // through the same allocator, so strictly only input channels becoming Master Channels strand. But the
-    // Expression Values on Member Channels were synthesized under different (Non-MPE) semantics, and the
-    // Channel-Pressure-reset rule differs by mode, so a wholesale reset is still the safer call.
-    //
-    // Within MPE Input Mode only the channels whose Zone assignment actually changes are affected. No note is
-    // bound outside the Zone structure for that comparison to miss: `MpeMessageRouting.route` discards a Note On
-    // arriving on a channel under no Zone's control, and `allocatorFor` would have no allocator to offer it in
-    // any case.
+    // Leaving Non-MPE Input Mode is conservatively treated as affecting every channel: Member Channel Expression
+    // Values were synthesized under different semantics and the Channel-Pressure-reset rule differs by mode.
+    // Within MPE Input Mode only the channels whose Zone assignment changes are affected — and no note is bound
+    // outside the Zone structure for that comparison to miss, `route` discarding a Note On from an unassigned
+    // channel.
     val affected =
       if (_inputMode == MpeInputMode.NonMpe) AllChannels else channelsAffectedByMcm(zonesBefore, zonesAfter)
 
-    // Stop the affected notes while the old Zone structure and allocators are still in place. This must emit a
-    // Note Off for exactly the notes `rebuildAllocator` drops below *for the same reason* — the ones it leaves
-    // behind with the channels it does not retain, plus the ones it takes off the channels it does because their
-    // input channel departed — both passes reading the same `affected` set: if they ever disagree on which notes
-    // are affected, the result is either a hanging note (dropped without a Note Off) or an unmatched Note Off
-    // (stopped without being dropped).
-    //
-    // The rebuild's other drops are not this pass's to emit. Re-applying the divergence rule against the moved
-    // threshold drops notes `affected` does not name; those come back in the rebuild's `MpeExpressionUpdateResult`
-    // and are sounded off by `emitZoneConfigurationResult`. The two sets are disjoint by construction — the
-    // departed-input-channel drop runs first and removes its notes, so the divergence rule can only reach notes
-    // whose input and output channels are both unaffected — which is what keeps a note from taking two Note Offs.
+    // Stop the affected notes while the old Zone structure and allocators are still in place. This must cover
+    // exactly the notes `rebuildAllocator` drops below for the same reason — both passes read the same `affected`
+    // set — or a note hangs (dropped with no Note Off) or takes an unmatched one. The rebuild's divergence-rule
+    // drops are not this pass's: `emitZoneConfigurationResult` sounds those off, and the two sets are disjoint,
+    // the departed-input-channel drop running first.
     stopNotesOn(buffer, affected)
 
     _zones = zonesAfter
     affected.foreach(tracker.reset)
 
-    // Forward MCM for the updated zone, and restate the Pitch Bend Sensitivity the Zone holds afterwards on every
-    // one of its channels. A conforming receiver resets it to the defaults on the MCM itself (MPE spec Section
-    // 2.4) — which is exactly what a freshly configured Zone carries — so the restatement is idempotent there, and
-    // it repairs a receiver that does not perform that reset. It must follow the MCM: a receiver that does reset
-    // would otherwise overwrite it. And it must precede the retuning pass below, whose Pitch Bends are encoded
-    // against this sensitivity.
+    // The addressed Zone's MCM, then the sensitivity it now holds on each of its channels: idempotent against a
+    // receiver that performs the §2.4 reset itself, corrective against one that does not. It must follow the MCM,
+    // which would otherwise overwrite it, and precede the retuning pass below, whose Pitch Bends are encoded
+    // against it.
     val updatedZone = if (channel == 0) lowerZone else upperZone
     logger.info(s"$zoneType zone updated: $updatedZone")
     emitMcmSequence(buffer, updatedZone)
     emitZonePbsSequences(buffer, updatedZone)
 
-    // Forward MCM for the other zone only if it was changed by overlap resolution
+    // The other Zone takes an MCM only if overlap resolution moved its boundary.
     val otherZoneAfter = if (channel == 0) upperZone else lowerZone
     if (otherZoneAfter != otherZoneBefore) {
       val otherZoneType = if (channel == 0) MpeZoneType.Upper else MpeZoneType.Lower
@@ -468,42 +448,23 @@ class MpeTuner(private val initialZones: MpeZones = MpeZones.DefaultZones,
       emitMcmSequence(buffer, otherZoneAfter)
     }
 
-    // Restate the other Zone's Pitch Bend Sensitivity whether or not overlap resolution moved its boundary. It
-    // keeps the sensitivity it held: the received MCM addressed the other Zone, and the MPE Specification does not
-    // say whether the Zone that overlap resolution shrinks in response loses its sensitivity along with its
-    // channels. The Tuner resolves it as JUCE's `MPEZoneLayout` does, narrowing the yielding Zone's channel range
-    // while leaving its sensitivities untouched — see the paper's "Zones" section. Restating the kept sensitivity
-    // is what makes that reading safe against a receiver that took the other one and reset it.
-    //
-    // Restating it on a Zone the reconfiguration left entirely alone is redundant against a conforming receiver,
-    // which resets only the addressed Zone, and is emitted for the same reason the retuning pass below re-emits
-    // Pitch Bend on *both* Zones' occupied channels — the two reaches are deliberately the same. A receiver that
-    // wrongly took the MCM's reset Zone-wide would otherwise read those Pitch Bends against a range the Tuner does
-    // not share and mistune every note this Zone holds, and that receiver is the one the redundancy exists for.
-    //
-    // It must follow this Zone's own MCM above, where there is one, for the same reason the addressed Zone's
-    // sequences follow its own — a receiver that does reset would otherwise overwrite them — and precede the
-    // retuning pass below. A disabled Zone emits nothing; see [[emitZonePbsSequences]].
+    // Its Pitch Bend Sensitivity is restated either way, with the values it keeps — the MCM addressed the other
+    // Zone, and the Tuner resolves the specification's silence as JUCE's `MPEZoneLayout` does, leaving a shrunk
+    // Zone's sensitivities untouched (the paper's "Zones" section). The reach matches the retuning pass below,
+    // which re-emits Pitch Bend on *both* Zones' occupied channels: a receiver that wrongly took the reset
+    // Zone-wide would otherwise read those bends against a range the Tuner does not share. A disabled Zone emits
+    // nothing.
     emitZonePbsSequences(buffer, otherZoneAfter)
 
-    // Rebuild each Zone's allocator against the new Zone structure and emit what the rebuild moved: the retained
-    // notes are reclassified against the Zone's Pitch Bend Sensitivity, the ones whose input channel left MPE
-    // control are dropped, and the channels that kept notes are retuned. The addressed Zone's sensitivity has just
-    // been reset to the defaults, so a retained channel's Pitch Bend would otherwise be read against the wrong
-    // range, and the threshold has moved under its notes.
+    // Rebuild each Zone's allocator against the new Zone structure and emit what the rebuild moved: retained
+    // notes reclassified against the Zone's sensitivity — reset under them on the addressed Zone, moving its
+    // threshold — notes whose input channel left MPE control dropped, and the channels that kept notes retuned.
+    // It sits here so that mutating the allocators and describing that to the receiver stay adjacent, and it must
+    // in any case follow the MCMs above, whose restated sensitivities its Pitch Bends are encoded against.
     //
-    // The rebuild sits here, rather than beside the `_zones` assignment above, so that mutating the allocators and
-    // telling the receiver about it stay adjacent: nothing between the two can then read a Zone's notes in a state
-    // the buffer does not yet describe. Its emissions must in any case follow the MCMs above, whose Pitch Bends
-    // are encoded against the sensitivity they restate, and nothing between the assignment and here touches an
-    // allocator.
-    //
-    // Lower before Upper, as `tune()` already orders them. An allocator built fresh by `createAllocator` already
-    // holds the right threshold and holds no notes, so it reports nothing and needs no condition. The other Zone
-    // runs the pass just the same, although its sensitivity — and so its threshold — did not move, whether or not
-    // overlap resolution shrank it: its occupied channels take a redundant, bit-identical Pitch Bend on every MCM.
-    // That is deliberate, in keeping with the paper's commitment to redundant messages for robustness against
-    // receivers that do not fully conform, and not an unguarded case.
+    // Lower before Upper, as `tune()` orders them; a freshly created allocator holds no notes and reports nothing.
+    // The unaddressed Zone runs the pass too, its occupied channels taking a redundant, bit-identical Pitch Bend —
+    // deliberate, per the paper's commitment to redundancy against receivers that do not fully conform.
     val lowerRebuild = rebuildAllocator(lowerAllocator, lowerZone, affected)
     val upperRebuild = rebuildAllocator(upperAllocator, upperZone, affected)
     lowerAllocator = lowerRebuild.map(_.allocator)

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
@@ -3185,7 +3185,7 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       sendPbsMsb(tuner, channel = 8, semitones = 24)
       // When
       // Shrinking the Lower Zone to 4 Members leaves the Upper Zone's 7 untouched, so no MCM is emitted for it
-      // and the receiver's sensitivity for it stands.
+      // and the sensitivity the Tuner holds for it stands.
       sendMcm(tuner, channel = 0, memberCount = 4)
       // Then
       tuner.zones.upper.memberCount shouldEqual 7
@@ -3385,18 +3385,91 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       }
     }
 
-  it should "output no Pitch Bend Sensitivity for a Zone the reconfiguration leaves alone" in
+  it should "output the kept Pitch Bend Sensitivity of a Zone the reconfiguration leaves alone on its channels" in
     new Fixture(dualZoneTunerMpeInput) {
       // Given
+      // Lower Zone master 0, members 1..7; Upper Zone master 15, members 8..14, given a custom member
+      // sensitivity that the MCM below neither addresses nor changes.
       sendPbsMsb(tuner, channel = 8, semitones = 24)
+
       // When
-      // Shrinking the Lower Zone to 4 Members leaves the Upper Zone's 7 untouched, so no MCM is emitted for it
-      // and nothing at the receiver has disturbed its sensitivity.
+      // Shrinking the Lower Zone to 4 Members leaves the Upper Zone's 7 untouched.
       private val output = sendMcm(tuner, channel = 0, memberCount = 4)
+
       // Then
+      // The Upper Zone still restates what the Tuner holds for it on every one of its channels, matching the
+      // reach of the Pitch Bend the retuning pass re-emits on both Zones: a receiver that wrongly took the MCM's
+      // reset Zone-wide would otherwise read those Pitch Bends against a range the Tuner does not share.
       private val ccs = extractCc(output)
-      (8 to 15).foreach { ch => ccs.filter(_.channel == ch) shouldBe empty }
+      ccs should contain inOrder(
+        CcScMidiMessage(15, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
+        CcScMidiMessage(15, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
+        CcScMidiMessage(15, ScMidiCc.DataEntryMsb, masterPbs.semitones),
+        CcScMidiMessage(15, ScMidiCc.DataEntryLsb, masterPbs.cents)
+      )
+      (8 to 14).foreach { ch =>
+        ccs should contain inOrder(
+          CcScMidiMessage(ch, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
+          CcScMidiMessage(ch, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
+          CcScMidiMessage(ch, ScMidiCc.DataEntryMsb, 24),
+          CcScMidiMessage(ch, ScMidiCc.DataEntryLsb, defaultPbs.cents)
+        )
+      }
     }
+
+  it should "output no MCM for a Zone the reconfiguration leaves alone" in new Fixture(dualZoneTunerMpeInput) {
+    // When
+    // Shrinking the Lower Zone to 4 Members leaves the Upper Zone's 7 untouched, so its Zone structure needs no
+    // restating — only its Pitch Bend Sensitivity does.
+    private val output = sendMcm(tuner, channel = 0, memberCount = 4)
+    // Then
+    // The Master Channel's Control Changes are pinned exactly rather than the MCM selector merely asserted
+    // absent: the MCM and the Pitch Bend Sensitivity selectors share their RPN MSB, so only the whole sequence
+    // tells the two apart.
+    extractCc(output).filter(_.channel == 15) shouldEqual Seq(
+      CcScMidiMessage(15, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
+      CcScMidiMessage(15, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
+      CcScMidiMessage(15, ScMidiCc.DataEntryMsb, masterPbs.semitones),
+      CcScMidiMessage(15, ScMidiCc.DataEntryLsb, masterPbs.cents),
+      CcScMidiMessage(15, ScMidiCc.RpnLsb, ScMidiRpn.NullLsb),
+      CcScMidiMessage(15, ScMidiCc.RpnMsb, ScMidiRpn.NullMsb)
+    )
+  }
+
+  it should "output the Pitch Bend Sensitivity of a Zone the reconfiguration leaves alone before its Pitch Bend" in
+    new Fixture(dualZoneTunerMpeInput, Some(quarterCommaMeantone)) {
+      // Given
+      // Lower Zone master 0, members 1..7; Upper Zone master 15, members 8..14, with a custom member sensitivity
+      // of ±24 semitones. E4 sounds on Upper Member Channel 13 at its -14-cent offset encoded against it:
+      // -14 / 2400 * 8192 rounds to -48.
+      sendPbsMsb(tuner, channel = 8, semitones = 24)
+      rawPitchBend(-14.0, PitchBendSensitivity(24)) shouldEqual -48
+      private val keptPitchBend = PitchBendScMidiMessage(13, rawPitchBend(-14.0, PitchBendSensitivity(24)))
+      extractPitchBends(noteOn(13, E4)) shouldEqual Seq(keptPitchBend)
+
+      // When
+      // Shrinking the Lower Zone to 4 Members leaves the Upper Zone untouched, yet the retuning pass still
+      // re-emits the Pitch Bend of its occupied channels.
+      private val output = sendMcm(tuner, channel = 0, memberCount = 4)
+
+      // Then
+      // The restated sensitivity precedes the Pitch Bend encoded against it, so a receiver that wrongly reset it
+      // on the MCM is back in step with the Tuner before the value that depends on it arrives.
+      extractScMidiMessages(output) should contain inOrder(
+        CcScMidiMessage(13, ScMidiCc.DataEntryMsb, 24),
+        keptPitchBend
+      )
+    }
+
+  it should "output no Pitch Bend Sensitivity for a disabled Zone on an MCM" in new Fixture(tuner7MpeInput) {
+    // When
+    // The Upper Zone is disabled, so the reconfiguration of the Lower Zone leaves it nothing to state: it has
+    // neither a Master Channel nor Member Channels of its own.
+    private val output = sendMcm(tuner, channel = 0, memberCount = 4)
+    // Then
+    private val ccs = extractCc(output)
+    (5 to 15).foreach { ch => ccs.filter(_.channel == ch) shouldBe empty }
+  }
 
   it should "keep the active Tuning when an MCM reconfigures the Zones" in
     new Fixture(mpeTunerMpeInput, Some(quarterCommaMeantone)) {

--- a/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
+++ b/tuner/src/test/scala/org/calinburloiu/music/microtonalist/tuner/MpeTunerTest.scala
@@ -3388,8 +3388,9 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
   it should "output the kept Pitch Bend Sensitivity of a Zone the reconfiguration leaves alone on its channels" in
     new Fixture(dualZoneTunerMpeInput) {
       // Given
-      // Lower Zone master 0, members 1..7; Upper Zone master 15, members 8..14, given a custom member
-      // sensitivity that the MCM below neither addresses nor changes.
+      // Lower Zone master 0, members 1..7; Upper Zone master 15, members 8..14, given custom Master and
+      // Member sensitivities that the MCM below neither addresses nor changes.
+      sendPbsMsb(tuner, channel = 15, semitones = 12)
       sendPbsMsb(tuner, channel = 8, semitones = 24)
 
       // When
@@ -3404,7 +3405,7 @@ class MpeTunerTest extends AnyFlatSpec with Matchers with Inside with OptionValu
       ccs should contain inOrder(
         CcScMidiMessage(15, ScMidiCc.RpnLsb, ScMidiRpn.PitchBendSensitivityLsb),
         CcScMidiMessage(15, ScMidiCc.RpnMsb, ScMidiRpn.PitchBendSensitivityMsb),
-        CcScMidiMessage(15, ScMidiCc.DataEntryMsb, masterPbs.semitones),
+        CcScMidiMessage(15, ScMidiCc.DataEntryMsb, 12),
         CcScMidiMessage(15, ScMidiCc.DataEntryLsb, masterPbs.cents)
       )
       (8 to 14).foreach { ch =>


### PR DESCRIPTION
Resolves #276

## Problem

An MCM makes `MpeTuner` re-emit Pitch Bend on the occupied Member Channels of **both** Zones — the retuning pass runs for the Lower and the Upper allocator alike — deliberately including the Zone the reconfiguration left alone, as redundancy against a receiver that does not fully conform.

The Pitch Bend Sensitivity (PBS) restatement did not have the same reach: it was emitted only for a Zone whose configuration actually changed (the addressed one, plus the other one when overlap resolution shrank it). A receiver that wrongly applied the MCM's §2.4 PBS reset Zone-wide — exactly the class of receiver the redundant Pitch Bend exists for — was therefore left reading those Pitch Bends against a range the Tuner does not share, and mistuning every note the untouched Zone holds.

## Change

`MpeTuner#processMcm` now emits the other Zone's PBS sequences unconditionally, whether or not overlap resolution moved its boundary:

- The addressed Zone is unchanged: its MCM, then its PBS sequences (the specification's defaults it carries by construction).
- The other Zone keeps the sensitivities the Tuner holds for it and has them restated on its Master and Member Channels. Its **MCM** stays conditional on an actual configuration change — only PBS became unconditional.
- Ordering is preserved and still load-bearing: a Zone's PBS sequences follow its own MCM where one is emitted (a receiver that does reset would otherwise overwrite them) and precede the retuning pass, whose Pitch Bends are encoded against them.
- A disabled Zone still emits nothing.

## Tests

Developed test-first; the new ordering test was confirmed red against the old production code, failing with a Pitch Bend re-emitted on the untouched Zone's channel and no sensitivity restated for it. In `MpeTunerTest`:

- "output the kept Pitch Bend Sensitivity of a Zone the reconfiguration leaves alone on its channels" — replaces the inverted "output no Pitch Bend Sensitivity …" expectation; asserts the Master and every Member Channel of the untouched Zone take its retained values.
- "output the Pitch Bend Sensitivity of a Zone the reconfiguration leaves alone before its Pitch Bend" — pins the ordering that makes the restatement useful, with a note sounding on the untouched Zone at a custom ±24-semitone sensitivity.
- "output no MCM for a Zone the reconfiguration leaves alone" — pins the untouched Zone's Master Channel traffic exactly, so an MCM cannot creep in (the MCM and PBS selectors share their RPN MSB, so only the whole sequence tells them apart).
- "output no Pitch Bend Sensitivity for a disabled Zone on an MCM" — guards the disabled-Zone case.

`tuner` module: 468 tests pass. Full suite passes. `sbt coverageCheck` passes: `tuner` at 83.09% stmt / 81.75% branch against its 80/80 floor, aggregate 76.17% / 71.08% against 73/68.

## Documentation

`MpeTuner#processMcm`'s ScalaDoc and in-method rationale are updated. A second commit condenses the comments of the whole method — they had grown to roughly 85 lines around 25 lines of code, restating at length what the paper already carries — keeping the reasoning that is not in the paper (the ordering constraints, why both passes must read the same affected-channel set, why the pre-update Zone is read from `zonesBefore`) and citing the paper for the rest.

**The paper is deliberately left untouched.** It never documented that an MCM re-emits Pitch Bend on both Zones' occupied channels — §4.2 scopes the post-MCM retuning to the addressed Zone, and its only cross-Zone statement is that the §2.4 PBS reset does *not* extend to the Zone overlap resolution shrinks. Documenting the PBS half alone would argue from a behavior the paper does not state; both halves of this redundancy should be written up together, in a change that covers them both. Nothing in the paper is falsified by this change: §4.2's "Each MCM the Tuner emits is followed by the Pitch Bend Sensitivity sequences of the Zone it describes" and §4.3's "every MCM it emits is followed by explicit Pitch Bend Sensitivity sequences" both quantify over emitted MCMs and remain true.

**`docs/architecture/tuner/README.md` needs no change**, although #276's Scope names it. It never states the reach of the PBS restatement; its only related sentence covers selector bookkeeping — `outputRpnSelectors` is "[the] record of what it last left selected on each output channel, which its own MCM and Pitch Bend Sensitivity sequences update as well, both closing with a deselecting RPN Null" — which stays accurate under the new behavior.

## Code review follow-up

A fourth commit applies review feedback, without changing behavior:

- The untouched Zone's Master Channel assertion now customizes the Master sensitivity to ±12 (as its sibling overlap-resolution test does) instead of leaving it at the ±2 default, so it distinguishes the sensitivity the Tuner kept from the value a freshly built Zone would carry.
- Two pieces of reasoning the comment condensation dropped, and which the paper does not carry, are restored: how much wider than strictly necessary the Non-MPE exit's affected-channel set is, and the invariant behind the rebuild's placement — that nothing between the `_zones` assignment and it touches an allocator.

## Note

#274 may revisit the redundant Pitch Bend emission this change aligns PBS with; the two reaches should stay in step whichever way that is settled.
